### PR TITLE
chore: 正確性修正と CI ハードニング

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@
 # Runner: gfo は public リポジトリで GitHub Actions が無料のため、全ジョブを GitHub-hosted の
 # ubuntu-latest で回す (self-hosted は使わない)。
 #
+# Python バージョン: 対応下限 (min) と最新 (max) の 2 つを matrix で並列検証する。
+# job 名にバージョン番号を入れず min/max ラベルにするのは、版を上げても check 名 (= Ruleset の
+# 必須ステータスチェック名) が変わらないようにするため。さらに matrix を束ねる安定名 "ci" の
+# aggregate gate job を置き、Ruleset の必須チェックは "ci" 一本で固定する (版更新で再設定不要)。
+#
 # 統合テストは実サービス (GitHub/GitLab 等) へアクセスするため CI では実行しない。
 # pytest 設定 (pyproject.toml の addopts) で tests/integration を除外済み。
 #
@@ -23,11 +28,28 @@ on:
 permissions:
   contents: read
 
+# 同一 ref への連続 push では古い run をキャンセルし、無駄な実行を避ける。
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  ci:
+  test:
+    name: test (${{ matrix.label }})
     runs-on: ubuntu-latest
+    # ハング時の保険。通常 1 分前後で終わる。
+    timeout-minutes: 15
     permissions:
       contents: read
+    strategy:
+      # 一方が落ちても他方の結果を見たいので fail-fast しない。
+      fail-fast: false
+      matrix:
+        include:
+          # min = 対応下限 / max = 最新。版を上げる時は python-version だけ差し替える
+          # (label は変えない → check 名が安定し Ruleset 再設定が不要)。
+          - { label: min, python-version: "3.11" }
+          - { label: max, python-version: "3.13" }
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -50,8 +72,9 @@ jobs:
 
       # uv.lock どおりに frozen install する。lock が古ければ fail (lockfile 整合性ゲート)。
       # dev は dependency-groups で定義されており uv sync が既定でインストールする。
-      - name: Install dependencies (frozen)
-        run: uv sync --locked
+      # --python で matrix のバージョンに .venv を作る (mise の既定 python を上書き)。
+      - name: Install dependencies (frozen, python ${{ matrix.python-version }})
+        run: uv sync --locked --python ${{ matrix.python-version }}
 
       # 違反を GitHub Actions の annotation 形式で PR diff に inline 表示し、違反で fail。
       - name: Lint (ruff)
@@ -68,3 +91,21 @@ jobs:
 
       - name: Unit tests (pytest)
         run: uv run pytest -q
+
+  # matrix を束ねる安定名の必須チェック。Ruleset は "ci" だけを Require すればよく、
+  # テスト対象バージョンを増減しても再設定不要。
+  ci:
+    name: ci
+    needs: [test]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Gate on test matrix result
+        run: |
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "::error::test matrix did not succeed (result=${{ needs.test.result }})"
+            exit 1
+          fi

--- a/src/gfo/adapter/azure_devops.py
+++ b/src/gfo/adapter/azure_devops.py
@@ -466,7 +466,7 @@ class AzureDevOpsAdapter(GitServiceAdapter):
         if label:
             conditions.append(f"[System.Tags] CONTAINS '{_wiql_escape(label)}'")
 
-        wiql = "SELECT [System.Id] FROM WorkItems WHERE " + " AND ".join(conditions)  # nosec B608 - conditions built from internal values only, no user input
+        wiql = "SELECT [System.Id] FROM WorkItems WHERE " + " AND ".join(conditions)  # nosec B608 - 各値 (project/assignee/label, ユーザ入力含む) は _wiql_escape() で WIQL 文字列リテラルのシングルクォートをエスケープ済み
         wiql_params = {"$top": limit} if limit > 0 else {"$top": 20000}
         wiql_resp = self._client.post(
             f"{self._wit_path()}/wiql",
@@ -1571,7 +1571,7 @@ class AzureDevOpsAdapter(GitServiceAdapter):
 
     def search_issues(self, query: str, *, limit: int = 30) -> list[Issue]:
         # WIQL を使って検索
-        wiql = f"SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = '{_wiql_escape(self._project)}' AND [System.Title] CONTAINS '{_wiql_escape(query)}'"  # nosec B608
+        wiql = f"SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = '{_wiql_escape(self._project)}' AND [System.Title] CONTAINS '{_wiql_escape(query)}'"  # nosec B608 - project/query (ユーザ入力) は _wiql_escape() でエスケープ済み
         wiql_params = {"$top": limit} if limit > 0 else {"$top": 200}
         wiql_resp = self._client.post(
             f"{self._wit_path()}/wiql",

--- a/src/gfo/adapter/base.py
+++ b/src/gfo/adapter/base.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Iterator
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from gfo.adapter._helpers import _mask_token_in_exception, _wrap_conversion_error
 from gfo.adapter.models import (
@@ -124,7 +124,7 @@ class GitServiceAdapter(ABC):
     # キー: "pr" | "issue" | "release" | "milestone" | "settings" 等。
     # 値: (list_path, detail_path)。detail_path が空文字列の場合は number 指定時も
     # list_path を返す (例: settings はリスト/詳細の区別なし)。
-    _WEB_URL_PATHS: dict[str, tuple[str, str]] = {}
+    _WEB_URL_PATHS: ClassVar[dict[str, tuple[str, str]]] = {}
 
     def __init__(self, client: HttpClient, owner: str, repo: str, **kwargs: object) -> None:
         # **kwargs はサービス固有パラメータ（BacklogAdapter の project_key、

--- a/src/gfo/adapter/bitbucket.py
+++ b/src/gfo/adapter/bitbucket.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Iterator
+from typing import ClassVar
 from urllib.parse import quote
 
 import requests
@@ -1466,7 +1467,7 @@ class BitbucketAdapter(GitServiceAdapter):
 
     # --- Browse ---
 
-    _WEB_URL_PATHS = {
+    _WEB_URL_PATHS: ClassVar[dict[str, tuple[str, str]]] = {
         "pr": ("pull-requests", "pull-requests"),
         "issue": ("issues", "issues"),
         "settings": ("admin", ""),

--- a/src/gfo/adapter/gitbucket.py
+++ b/src/gfo/adapter/gitbucket.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import json
 import urllib.parse
 from collections.abc import Iterator
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from gfo.exceptions import GfoError, NotFoundError, NotSupportedError
 
@@ -249,7 +249,7 @@ class GitBucketAdapter(GitHubAdapter):
 
     # GitBucket は GitHub 形式 (/pulls, /issues, /releases/tag/{n}) を踏襲するが
     # milestone は未対応。`_web_base_url()` は API URL から動的に導出する。
-    _WEB_URL_PATHS = {
+    _WEB_URL_PATHS: ClassVar[dict[str, tuple[str, str]]] = {
         "pr": ("pulls", "pulls"),
         "issue": ("issues", "issues"),
         "release": ("releases", "releases/tag"),

--- a/src/gfo/adapter/gitea.py
+++ b/src/gfo/adapter/gitea.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import base64
 from collections.abc import Iterator
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 from urllib.parse import quote
 
 import requests
@@ -988,7 +988,7 @@ class GiteaAdapter(GitHubLikeAdapter, GitServiceAdapter):
         return [self._to_review(r) for r in results]
 
     # Gitea/Forgejo API は "APPROVED" を要求（GitHub は "APPROVE"）
-    _REVIEW_EVENT_MAP: dict[str, str] = {"APPROVE": "APPROVED"}
+    _REVIEW_EVENT_MAP: ClassVar[dict[str, str]] = {"APPROVE": "APPROVED"}
 
     def create_review(self, number: int, *, state: str, body: str = "") -> Review:
         event = self._REVIEW_EVENT_MAP.get(state.upper(), state.upper())
@@ -1790,7 +1790,7 @@ class GiteaAdapter(GitHubLikeAdapter, GitServiceAdapter):
 
     # --- Browse ---
 
-    _WEB_URL_PATHS = {
+    _WEB_URL_PATHS: ClassVar[dict[str, tuple[str, str]]] = {
         "pr": ("pulls", "pulls"),
         "issue": ("issues", "issues"),
         "release": ("releases", "releases/tag"),

--- a/src/gfo/adapter/github.py
+++ b/src/gfo/adapter/github.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 from collections.abc import Iterable, Iterator
+from typing import ClassVar
 from urllib.parse import quote
 
 import requests
@@ -1945,7 +1946,7 @@ class GitHubAdapter(GitHubLikeAdapter, GitServiceAdapter):
 
     # --- Browse ---
 
-    _WEB_URL_PATHS = {
+    _WEB_URL_PATHS: ClassVar[dict[str, tuple[str, str]]] = {
         "pr": ("pulls", "pull"),
         "issue": ("issues", "issues"),
         "release": ("releases", "releases/tag"),

--- a/src/gfo/adapter/gitlab.py
+++ b/src/gfo/adapter/gitlab.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import base64
 from collections.abc import Iterable, Iterator
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 from urllib.parse import quote
 
 import requests
@@ -2040,7 +2040,7 @@ class GitLabAdapter(GitServiceAdapter):
 
     # --- Browse ---
 
-    _WEB_URL_PATHS = {
+    _WEB_URL_PATHS: ClassVar[dict[str, tuple[str, str]]] = {
         "pr": ("-/merge_requests", "-/merge_requests"),
         "issue": ("-/issues", "-/issues"),
         "release": ("-/releases", "-/releases"),
@@ -2148,7 +2148,7 @@ class GitLabAdapter(GitServiceAdapter):
 
     # --- Issue Reactions (Award Emoji API) ---
 
-    _REACTION_TO_EMOJI = {
+    _REACTION_TO_EMOJI: ClassVar[dict[str, str]] = {
         "+1": "thumbsup",
         "-1": "thumbsdown",
         "laugh": "laughing",
@@ -2158,7 +2158,7 @@ class GitLabAdapter(GitServiceAdapter):
         "rocket": "rocket",
         "eyes": "eyes",
     }
-    _EMOJI_TO_REACTION = {v: k for k, v in _REACTION_TO_EMOJI.items()}
+    _EMOJI_TO_REACTION: ClassVar[dict[str, str]] = {v: k for k, v in _REACTION_TO_EMOJI.items()}
 
     def list_issue_reactions(self, number: int) -> list[Reaction]:
         results = paginate_page_param(

--- a/src/gfo/output.py
+++ b/src/gfo/output.py
@@ -144,12 +144,12 @@ def format_table(items: list, fields: list[str]) -> str:
             widths[i] = max(widths[i], _display_width(val))
 
     lines: list[str] = []
-    header_line = "  ".join(_pad_right(h, w) for h, w in zip(headers, widths))
+    header_line = "  ".join(_pad_right(h, w) for h, w in zip(headers, widths, strict=True))
     lines.append(header_line.rstrip())
     sep_line = "  ".join("-" * w for w in widths)
     lines.append(sep_line.rstrip())
     for row in rows:
-        data_line = "  ".join(_pad_right(val, w) for val, w in zip(row, widths))
+        data_line = "  ".join(_pad_right(val, w) for val, w in zip(row, widths, strict=True))
         lines.append(data_line.rstrip())
 
     return "\n".join(lines)

--- a/tests/test_adapters/test_azure_devops.py
+++ b/tests/test_adapters/test_azure_devops.py
@@ -12,6 +12,7 @@ from gfo.adapter.azure_devops import (
     AzureDevOpsAdapter,
     _add_refs_prefix,
     _strip_refs_prefix,
+    _wiql_escape,
 )
 from gfo.adapter.base import (
     Branch,
@@ -1055,6 +1056,25 @@ class TestRefsPrefix:
 
     def test_roundtrip(self):
         assert _strip_refs_prefix(_add_refs_prefix("feature/xyz")) == "feature/xyz"
+
+
+# --- WIQL エスケープ (インジェクション対策) ---
+
+
+class TestWiqlEscape:
+    def test_no_quote_unchanged(self):
+        assert _wiql_escape("bug") == "bug"
+
+    def test_empty(self):
+        assert _wiql_escape("") == ""
+
+    def test_single_quote_doubled(self):
+        # WIQL 文字列リテラルはシングルクォートを '' で表現する
+        assert _wiql_escape("O'Brien") == "O''Brien"
+
+    def test_injection_attempt_neutralized(self):
+        # クォートで文字列を抜け出そうとする入力は全クォートが倍化され閉じ込められる
+        assert _wiql_escape("x' OR '1'='1") == "x'' OR ''1''=''1"
 
 
 # --- Registry ---


### PR DESCRIPTION
改善レポートのステップ1+2（WIQL 調査 + 正確性 + CI ハードニング）。

## CI ハードニング（`ci.yml`）
- **concurrency** + `cancel-in-progress`: 同一 ref への連続 push で旧 run を自動キャンセル。
- **`timeout-minutes: 15`**: ハング job の保険。
- **Python matrix `[3.11, 3.13]`**: 対応下限と最新を検証。`uv sync --locked --python ${{ matrix.python-version }}` で matrix 版に .venv を作成（ローカルで 3.11 全 3850 件 pass を確認済）。

## 正確性
- `output.py` の `zip(...)` に **`strict=True`**（表整形で長さ不一致を黙って切り詰めるのを防止、ruff B905）。
- 可変クラス定数 **9 箇所を `ClassVar` 注釈**に（`_WEB_URL_PATHS` 等の不変ルックアップテーブル、ruff RUF012）。

## WIQL 調査結果（脆弱性ではない）
- `azure_devops.py` の WIQL 構築は `_wiql_escape()`（`'`→`''`、WIQL 文字列リテラルの正しいエスケープ）を **全ユーザ入力（project/assignee/label/query）に適用済み**。ruff S608 はエスケープ有無を見ないパターン検知の誤検知。
- 誤解を招く `# nosec` コメント（「no user input」）を実態に合わせて正確化。
- `_wiql_escape` の単体テスト（エスケープ / インジェクション無害化）を追加。

## ローカル検証
ruff / format / mypy / bandit 全 green、**pytest 3854 passed**（+4 WIQL）、92% cov。RUF012/B905 残存 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)