### PR TITLE
chore(lint): ruff B (flake8-bugbear) を有効化し違反を修正

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,8 @@ line-length = 100
 target-version = "py311"
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "UP"]
+# B = flake8-bugbear (実バグ検出。特に B904 = except 内 raise の例外連鎖を強制)
+select = ["E", "F", "I", "UP", "B"]
 ignore = ["E501"]  # 日本語コメント・docstring は行長制限を除外
 
 [tool.bandit]

--- a/src/gfo/adapter/gitea.py
+++ b/src/gfo/adapter/gitea.py
@@ -451,8 +451,8 @@ class GiteaAdapter(GitHubLikeAdapter, GitServiceAdapter):
                 limit=limit,
                 per_page_key="limit",
             )
-        except NotFoundError:
-            raise NotSupportedError(self.service_name, "repo contributors")
+        except NotFoundError as e:
+            raise NotSupportedError(self.service_name, "repo contributors") from e
         return [
             Contributor(
                 username=r.get("login"),

--- a/src/gfo/adapter/github.py
+++ b/src/gfo/adapter/github.py
@@ -1583,8 +1583,10 @@ class GitHubAdapter(GitHubLikeAdapter, GitServiceAdapter):
     def _encrypt_secret(public_key: str, secret_value: str) -> str:
         try:
             from nacl import encoding, public
-        except ImportError:
-            raise GfoError("PyNaCl is required for GitHub Secret encryption: pip install PyNaCl")
+        except ImportError as e:
+            raise GfoError(
+                "PyNaCl is required for GitHub Secret encryption: pip install PyNaCl"
+            ) from e
         key = public.PublicKey(public_key.encode(), encoding.Base64Encoder)
         sealed_box = public.SealedBox(key)
         encrypted = sealed_box.encrypt(secret_value.encode())

--- a/src/gfo/adapter/github_like.py
+++ b/src/gfo/adapter/github_like.py
@@ -31,7 +31,7 @@ from gfo.adapter.models import (
 )
 
 
-class GitHubLikeAdapter(ABC):
+class GitHubLikeAdapter(ABC):  # noqa: B024 - 抽象メソッドを持たない変換ヘルパー Mixin (ABC は直接インスタンス化防止のため)
     """GitHub API 互換サービス（GitHub/Gitea 系）向け共通変換ヘルパー。
 
     GitHubAdapter・GiteaAdapter・GitBucketAdapter・ForgejoAdapter が共有する

--- a/src/gfo/cli.py
+++ b/src/gfo/cli.py
@@ -57,8 +57,10 @@ def _positive_int(value: str) -> int:
     """argparse type: 正の整数のみ受け付ける。"""
     try:
         ivalue = int(value)
-    except ValueError:
-        raise argparse.ArgumentTypeError(_("{value} is not a positive integer").format(value=value))
+    except ValueError as e:
+        raise argparse.ArgumentTypeError(
+            _("{value} is not a positive integer").format(value=value)
+        ) from e
     if ivalue <= 0:
         raise argparse.ArgumentTypeError(_("{value} is not a positive integer").format(value=value))
     return ivalue

--- a/src/gfo/commands/__init__.py
+++ b/src/gfo/commands/__init__.py
@@ -215,7 +215,7 @@ def read_file_arg(path: str) -> str:
     try:
         with open(path) as f:
             return f.read()
-    except FileNotFoundError:
-        raise GfoError(_("File not found: {file}").format(file=path))
-    except PermissionError:
-        raise GfoError(_("Permission denied: {file}").format(file=path))
+    except FileNotFoundError as e:
+        raise GfoError(_("File not found: {file}").format(file=path)) from e
+    except PermissionError as e:
+        raise GfoError(_("Permission denied: {file}").format(file=path)) from e

--- a/src/gfo/commands/auth_cmd.py
+++ b/src/gfo/commands/auth_cmd.py
@@ -21,10 +21,10 @@ def handle_login(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -
         try:
             result = gfo.detect.detect_service()
             host = result.host
-        except (DetectionError, GitCommandError):
+        except (DetectionError, GitCommandError) as e:
             raise ConfigError(
                 _("Could not detect host. Use --host option: gfo auth login --host <host>")
-            )
+            ) from e
 
     # トークンの取得元優先順位:
     #   1. --token-stdin (stdin から読み込み)
@@ -140,10 +140,10 @@ def handle_switch(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
         try:
             result = gfo.detect.detect_service()
             host = result.host
-        except (DetectionError, GitCommandError):
+        except (DetectionError, GitCommandError) as e:
             raise ConfigError(
                 _("Could not detect host. Use --host option: gfo auth switch --host <host> ACCOUNT")
-            )
+            ) from e
 
     gfo.auth.switch_account(host, args.account)
     print(_("Switched to account '{account}' for {host}").format(account=args.account, host=host))
@@ -172,10 +172,10 @@ def handle_token(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -
             result = gfo.detect.detect_service()
             host = result.host
             service_type = result.service_type or ""
-        except (DetectionError, GitCommandError):
+        except (DetectionError, GitCommandError) as e:
             raise ConfigError(
                 _("Could not detect host. Use --host option: gfo auth token --host <host>")
-            )
+            ) from e
 
     token = gfo.auth.resolve_token(host, service_type)
     print(token)
@@ -189,10 +189,10 @@ def handle_logout(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
         try:
             result = gfo.detect.detect_service()
             host = result.host
-        except (DetectionError, GitCommandError):
+        except (DetectionError, GitCommandError) as e:
             raise ConfigError(
                 _("Could not detect host. Use --host option: gfo auth logout --host <host>")
-            )
+            ) from e
 
     account = getattr(args, "account", None)
     gfo.auth.remove_token(host, account=account)

--- a/src/gfo/commands/issue.py
+++ b/src/gfo/commands/issue.py
@@ -82,12 +82,12 @@ def handle_create(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
         elif config.service_type == "backlog":
             try:
                 kwargs["issue_type"] = int(args.type)
-            except (ValueError, TypeError):
+            except (ValueError, TypeError) as e:
                 raise ConfigError(
                     _("--type must be a numeric issue type ID for Backlog, got {type}.").format(
                         type=repr(args.type)
                     )
-                )
+                ) from e
     if args.priority is not None and config.service_type == "backlog":
         kwargs["priority"] = args.priority
     milestone = getattr(args, "milestone", None)
@@ -272,12 +272,12 @@ def _parse_duration(s: str) -> int:
         # Try plain integer as seconds
         try:
             total = int(s)
-        except ValueError:
+        except ValueError as e:
             raise ConfigError(
                 _(
                     "Invalid duration format: '{s}'. Use format like '1h30m', '45m', or '3600'."
                 ).format(s=s)
-            )
+            ) from e
     return total
 
 

--- a/src/gfo/detect.py
+++ b/src/gfo/detect.py
@@ -341,12 +341,12 @@ def _parse_repo_option(value: str) -> DetectResult:
         )
     try:
         return detect_from_url(f"https://{value}")
-    except DetectionError:
+    except DetectionError as e:
         raise ConfigError(
             _("Cannot parse --repo value: {value}. Use URL or HOST/OWNER/REPO format.").format(
                 value=value
             )
-        )
+        ) from e
 
 
 # ── 統合検出フロー ──

--- a/src/gfo/output.py
+++ b/src/gfo/output.py
@@ -67,12 +67,14 @@ def apply_jq_filter(json_str: str, expression: str) -> str:
             timeout=60,
         )
         return result.stdout.rstrip("\n")
-    except FileNotFoundError:
-        raise GfoError(_("jq command not found. Install it from https://jqlang.github.io/jq/"))
-    except subprocess.TimeoutExpired:
-        raise GfoError(_("jq filter timed out after 60 seconds."))
+    except FileNotFoundError as e:
+        raise GfoError(
+            _("jq command not found. Install it from https://jqlang.github.io/jq/")
+        ) from e
+    except subprocess.TimeoutExpired as e:
+        raise GfoError(_("jq filter timed out after 60 seconds.")) from e
     except subprocess.CalledProcessError as e:
-        raise GfoError(_("jq filter error: {error}").format(error=e.stderr.strip()))
+        raise GfoError(_("jq filter error: {error}").format(error=e.stderr.strip())) from e
 
 
 def format_error_json(err: GfoError) -> str:

--- a/tests/integration/test_azure_devops.py
+++ b/tests/integration/test_azure_devops.py
@@ -150,7 +150,7 @@ class TestAzureDevOpsIntegration:
         self.adapter.merge_pull_request(self._pr_number, method="merge")
         # Azure DevOps のマージは非同期の場合があるためポーリングして確認
         pr = None
-        for i in range(30):
+        for _ in range(30):
             pr = self.adapter.get_pull_request(self._pr_number)
             if pr.state == "merged":
                 break

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -405,7 +405,7 @@ def test_parser_browse_defaults():
     assert args.pr is None
     assert args.issue is None
     assert args.settings is False
-    assert getattr(args, "print") is False
+    assert args.print is False
 
 
 def test_parser_browse_pr():
@@ -431,7 +431,7 @@ def test_parser_browse_settings():
 def test_parser_browse_print():
     parser, _ = create_parser()
     args = parser.parse_args(["browse", "--print"])
-    assert getattr(args, "print") is True
+    assert args.print is True
 
 
 def test_parser_browse_mutually_exclusive():


### PR DESCRIPTION
改善レポートのステップ4のうち、価値が高く安全に実施できる **ruff `B` (flake8-bugbear)** を有効化する。`disallow_any_generics` は規模が大きい(327件)ため別 issue #12 で段階対応。

## 変更
- `pyproject.toml` の ruff `select` に **`B`** を追加。
- **B904（例外連鎖）15箇所**を `raise ... from e` に統一。
  - `cli.main()` はトップレベルで `str(err)` のみ表示し traceback をユーザに出さないため、`from e` は**ユーザ出力を変えず** cause を保持（デバッグ向上）。既存 `_wrap_conversion_error` の `from e` と house style 一致。
- **B024**: `GitHubLikeAdapter`（抽象メソッドを持たない変換ヘルパー Mixin）に `# noqa` 注記。
- **B009 / B007**（テストの軽微指摘）を修正。

## 検証
ruff（B 含む）/ format / mypy / bandit 全 green、**pytest 3854 passed**、92% cov。B 違反 0。

Closes の対象ではない（#12 は別途）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)