### PR TITLE
chore(types): CLI/commands 層の型引数欠落を補完 (disallow_any_generics 段階導入)

### DIFF
--- a/src/gfo/cli.py
+++ b/src/gfo/cli.py
@@ -1547,7 +1547,7 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     return parser, subparser_map
 
 
-_DISPATCH: dict[tuple[str, str | None], Callable] = {
+_DISPATCH: dict[tuple[str, str | None], Callable[..., None]] = {
     ("init", None): gfo.commands.init.handle,
     ("auth", "login"): gfo.commands.auth_cmd.handle_login,
     ("auth", "status"): gfo.commands.auth_cmd.handle_status,

--- a/src/gfo/commands/__init__.py
+++ b/src/gfo/commands/__init__.py
@@ -174,7 +174,7 @@ def create_adapter_from_spec(spec: ServiceSpec) -> GitServiceAdapter:
     token = gfo.auth.resolve_token(spec.host, spec.service_type)
     client = gfo.adapter.registry.create_http_client(spec.service_type, api_url, token)
     adapter_cls = gfo.adapter.registry.get_adapter_class(spec.service_type)
-    kwargs: dict = {}
+    kwargs: dict[str, str] = {}
     if spec.service_type == "backlog" and spec.project_key:
         kwargs["project_key"] = spec.project_key
     elif spec.service_type == "azure-devops":

--- a/src/gfo/commands/config_cmd.py
+++ b/src/gfo/commands/config_cmd.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+from typing import Any
 
 from gfo.config import (
     get_config_path,
@@ -76,7 +77,7 @@ def handle_path(args: argparse.Namespace, *, fmt: str, jq: str | None = None) ->
         print(path)
 
 
-def _flatten(data: dict, prefix: str = "") -> list[tuple[str, str]]:
+def _flatten(data: dict[str, Any], prefix: str = "") -> list[tuple[str, str]]:
     """ネストされた dict をフラットな (キー, 値) リストに変換する。
 
     ドットを含むキーは引用符で囲み、出力をそのまま get/set/unset に渡せるようにする。

--- a/src/gfo/commands/issue.py
+++ b/src/gfo/commands/issue.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 import sys
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from gfo.commands import (
     create_adapter_from_spec,
@@ -75,7 +75,7 @@ def handle_create(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
     if not title:
         raise ConfigError(_("--title must not be empty."))
 
-    kwargs: dict = {}
+    kwargs: dict[str, Any] = {}
     if args.type:
         if config.service_type == "azure-devops":
             kwargs["work_item_type"] = args.type

--- a/src/gfo/commands/label.py
+++ b/src/gfo/commands/label.py
@@ -96,7 +96,7 @@ def handle_clone(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -
     )
     client = gfo.adapter.registry.create_http_client(config.service_type, api_url, token)
     adapter_cls = gfo.adapter.registry.get_adapter_class(config.service_type)
-    extra_kwargs: dict = {}
+    extra_kwargs: dict[str, str] = {}
     if config.service_type == "backlog" and config.project_key:
         extra_kwargs["project_key"] = config.project_key
     elif config.service_type == "azure-devops":

--- a/src/gfo/commands/repo.py
+++ b/src/gfo/commands/repo.py
@@ -127,7 +127,7 @@ def handle_create(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
     adapter_cls = get_adapter_class(service_type)
 
     # サービスによってはコンストラクタに追加引数が必要
-    extra_kwargs: dict = {}
+    extra_kwargs: dict[str, str] = {}
     if service_type == "backlog":
         if not project_key:
             raise ConfigError(

--- a/src/gfo/commands/schema.py
+++ b/src/gfo/commands/schema.py
@@ -240,7 +240,7 @@ _OUTPUT_MAP: dict[tuple[str, str | None], type | None] = {
 }
 
 # file get / user whoami の特殊出力スキーマ
-_SPECIAL_OUTPUT: dict[tuple[str, str | None], dict] = {
+_SPECIAL_OUTPUT: dict[tuple[str, str | None], dict[str, Any]] = {
     ("file", "get"): {
         "type": "object",
         "properties": {
@@ -269,7 +269,7 @@ _SPECIAL_OUTPUT: dict[tuple[str, str | None], dict] = {
 }
 
 
-def _python_type_to_json_schema(tp: Any) -> dict:
+def _python_type_to_json_schema(tp: Any) -> dict[str, Any]:
     """Python 型アノテーションを JSON Schema に変換する。"""
     origin = typing.get_origin(tp)
 
@@ -307,7 +307,7 @@ def _python_type_to_json_schema(tp: Any) -> dict:
     return {"type": "string"}
 
 
-def _union_to_schema(args: tuple) -> dict:
+def _union_to_schema(args: tuple[Any, ...]) -> dict[str, Any]:
     """Union 型引数を JSON Schema に変換する。"""
     non_none = [a for a in args if a is not type(None)]
     has_none = len(non_none) < len(args)
@@ -327,11 +327,11 @@ def _union_to_schema(args: tuple) -> dict:
     return {"oneOf": schemas}
 
 
-def _dataclass_to_json_schema(cls: type) -> dict:
+def _dataclass_to_json_schema(cls: type) -> dict[str, Any]:
     """データクラスを JSON Schema に変換する。"""
     hints = get_type_hints(cls)
     fields = dataclasses.fields(cls)
-    properties: dict[str, dict] = {}
+    properties: dict[str, dict[str, Any]] = {}
     required: list[str] = []
 
     for f in fields:
@@ -345,7 +345,7 @@ def _dataclass_to_json_schema(cls: type) -> dict:
     return schema
 
 
-def _parser_to_input_schema(parser: argparse.ArgumentParser) -> dict:
+def _parser_to_input_schema(parser: argparse.ArgumentParser) -> dict[str, Any]:
     """argparse パーサーから入力スキーマを生成する。
 
     NOTE: argparse の非公開 API を使用している:
@@ -354,7 +354,7 @@ def _parser_to_input_schema(parser: argparse.ArgumentParser) -> dict:
         アクション種別の判定に使用
     argparse の内部実装変更により動作しなくなる可能性がある。
     """
-    properties: dict[str, dict] = {}
+    properties: dict[str, dict[str, Any]] = {}
     required: list[str] = []
     seen_dests: set[str] = set()
 
@@ -463,7 +463,7 @@ def _build_output_schema(key: tuple[str, str | None]) -> Any:
 def _build_command_schema(
     key: tuple[str, str | None],
     subparser_map: dict[str, argparse.ArgumentParser],
-) -> dict:
+) -> dict[str, Any]:
     """単一コマンドのスキーマを構築する。"""
     command, subcommand = key
 
@@ -507,7 +507,7 @@ def handle_schema(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
 
     if list_commands or not target:
         # コマンド一覧
-        result: list[dict] = []
+        result: list[dict[str, Any]] = []
         for key in _DISPATCH:
             command, subcommand = key
             cmd_label = f"{command} {subcommand}" if subcommand else command


### PR DESCRIPTION
## 概要

issue #12（`disallow_any_generics` 段階導入）の最初の小 PR。adapter 層は件数が多いため別 PR とし、本 PR では **CLI/commands レイヤー**の bare generic（`dict` / `Callable` / `tuple`）に型引数を補完する。

## 変更

- `commands/__init__,repo,label`: adapter constructor 用 kwargs を `dict[str, str]`
- `commands/issue`: `dict[str, Any]`（`work_item_type`=str / `issue_type`=int 混在のため）
- `commands/config_cmd`: `_flatten` の引数を `dict[str, Any]`
- `commands/schema`: JSON Schema を構築する dict 群を `dict[str, Any]` / `dict[str, dict[str, Any]]`、`_union_to_schema` の `tuple` を `tuple[Any, ...]`
- `cli`: `_DISPATCH` の値型 `Callable` を `Callable[..., None]`（handler は `handler(args, fmt=, jq=)` で呼ばれ None 返し）

## 計測

- `mypy --disallow-any-generics src/gfo`: **327→311 errors / 20→13 files**（commands・cli は全クリア）
- 既定 `mypy src/gfo`: Success / `ruff check` `ruff format --check`: pass / `pytest`: 3854 passed

## 補足

`disallow_any_generics = true` の `pyproject.toml` 追加は全エラー 0 達成後に別 PR で行う。

Refs #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)