### PR TITLE
chore(types): output/config/小 adapter の型引数欠落を補完 (disallow_any_generics 第2弾)

### DIFF
--- a/src/gfo/adapter/base.py
+++ b/src/gfo/adapter/base.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Iterator
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from gfo.adapter._helpers import _mask_token_in_exception, _wrap_conversion_error
 from gfo.adapter.models import (
@@ -718,7 +718,7 @@ class GitServiceAdapter(ABC):
         raise NotSupportedError(self.service_name, "ci cancel")
 
     def trigger_pipeline(
-        self, ref: str, *, workflow: str | None = None, inputs: dict | None = None
+        self, ref: str, *, workflow: str | None = None, inputs: dict[str, Any] | None = None
     ) -> Pipeline:
         raise NotSupportedError(self.service_name, "ci trigger")
 
@@ -756,7 +756,7 @@ class GitServiceAdapter(ABC):
         raise NotSupportedError(self.service_name, "ci download")
 
     # --- User ---
-    def get_current_user(self) -> dict:
+    def get_current_user(self) -> dict[str, Any]:
         raise NotSupportedError(self.service_name, "user whoami")
 
     def get_current_username(self) -> str:

--- a/src/gfo/adapter/gitbucket.py
+++ b/src/gfo/adapter/gitbucket.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import json
 import urllib.parse
 from collections.abc import Iterator
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from gfo.exceptions import GfoError, NotFoundError, NotSupportedError
 
@@ -51,7 +51,7 @@ class GitBucketAdapter(GitHubAdapter):
 
     # --- ヘルパー ---
 
-    def _parse_response(self, resp: requests.Response) -> dict:
+    def _parse_response(self, resp: requests.Response) -> dict[str, Any]:
         """GitBucket の create 系 API が返す二重エンコード JSON を解析する。"""
         data = resp.json()
         if isinstance(data, str):
@@ -161,7 +161,7 @@ class GitBucketAdapter(GitHubAdapter):
     # --- Release ---
 
     @staticmethod
-    def _to_release(data: dict) -> Release:
+    def _to_release(data: dict[str, Any]) -> Release:
         """GitBucket リリースの変換。created_at / html_url が省略される場合に対応する。"""
         try:
             return Release(

--- a/src/gfo/adapter/gogs.py
+++ b/src/gfo/adapter/gogs.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import urllib.parse
 from collections.abc import Iterator
+from typing import Any
 from urllib.parse import quote
 
 from gfo.exceptions import NotSupportedError
@@ -388,10 +389,10 @@ class GogsAdapter(GiteaAdapter):
         events: list[str] | None = None,
         secret: str | None = None,
     ) -> Webhook:
-        config: dict = {"url": url, "content_type": "json"}
+        config: dict[str, str] = {"url": url, "content_type": "json"}
         if secret is not None:
             config["secret"] = secret
-        payload: dict = {
+        payload: dict[str, Any] = {
             "config": config,
             "events": events or ["push"],
             "active": True,

--- a/src/gfo/config.py
+++ b/src/gfo/config.py
@@ -94,7 +94,7 @@ def get_credentials_path() -> Path:
 # ── TOML 読み込み ──
 
 
-def load_user_config() -> dict:
+def load_user_config() -> dict[str, Any]:
     """config.toml を読み込み dict で返す。存在しなければ空 dict。"""
     path = get_config_path()
     if not path.exists():
@@ -263,7 +263,7 @@ def unset_config_value(key: str) -> bool:
     cfg = load_user_config()
 
     # parts を辿り、末端キーを削除する
-    ancestors: list[tuple[dict, str]] = []
+    ancestors: list[tuple[dict[str, Any], str]] = []
     current = cfg
     for part in parts[:-1]:
         if not isinstance(current, dict) or part not in current:
@@ -287,7 +287,7 @@ def unset_config_value(key: str) -> bool:
     return True
 
 
-def _save_config(cfg: dict) -> None:
+def _save_config(cfg: dict[str, Any]) -> None:
     """dict を config.toml に TOML 形式で書き出す。"""
     path = get_config_path()
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -295,7 +295,7 @@ def _save_config(cfg: dict) -> None:
         _write_toml(f, cfg)
 
 
-def _write_toml(f: Any, data: dict, prefix: str = "") -> None:
+def _write_toml(f: Any, data: dict[str, Any], prefix: str = "") -> None:
     """dict を TOML 形式で書き出す（シンプルな値 → テーブルの順）。"""
     # まずスカラー値を書き出す
     for key, value in data.items():

--- a/src/gfo/output.py
+++ b/src/gfo/output.py
@@ -131,7 +131,7 @@ def output(
         print(format_table(items, fields))
 
 
-def format_table(items: list, fields: list[str]) -> str:
+def format_table(items: list[Any], fields: list[str]) -> str:
     """テーブル形式にフォーマットする。"""
     headers = [f.upper() for f in fields]
 
@@ -157,13 +157,13 @@ def format_table(items: list, fields: list[str]) -> str:
     return "\n".join(lines)
 
 
-def format_json(items: list) -> str:
+def format_json(items: list[Any]) -> str:
     """JSON 形式にフォーマットする。"""
     dicts = [dataclasses.asdict(item) for item in items]
     return json.dumps(dicts, indent=2, ensure_ascii=False, default=str)
 
 
-def format_plain(items: list, fields: list[str]) -> str:
+def format_plain(items: list[Any], fields: list[str]) -> str:
     """プレーン形式にフォーマットする。タブ区切り、ヘッダーなし。"""
     lines: list[str] = []
     for item in items:
@@ -173,7 +173,7 @@ def format_plain(items: list, fields: list[str]) -> str:
 
 
 def output_grouped(
-    groups: dict[str, list],
+    groups: dict[str, list[Any]],
     *,
     fields: list[str],
     fmt: str,


### PR DESCRIPTION
## 概要

issue #12（`disallow_any_generics` 段階導入）第2弾の小 PR。小物ファイル（output / config / base / gitbucket / gogs）の bare generic に型引数を補完する。

## 変更

- `output`: `format_table/json/plain` の `list` → `list[Any]`、`output_grouped` の `dict[str, list]` → `dict[str, list[Any]]`
- `config`: `load_user_config` / `_save_config` / `_write_toml` / `ancestors` の `dict` → `dict[str, Any]`
- `adapter/base`: `dispatch_workflow` の `inputs` と `get_current_user` の `dict` → `dict[str, Any]`
- `adapter/gitbucket`: `_parse_response` / `_to_release` の `dict` → `dict[str, Any]`
- `adapter/gogs`: webhook `config` を `dict[str, str]`、`payload` を `dict[str, Any]`

## 計測

- `mypy --disallow-any-generics src/gfo`: **311→297 errors / 13→8 files**（対象ファイルは全クリア）
- 既定 `mypy`: Success / `ruff` `ruff format --check`: pass / `pytest`: 3854 passed

## 補足

残りは adapter 大物（github/gitlab/gitea/bitbucket/backlog/azure_devops）+ http + github_like。`disallow_any_generics = true` の追加は全エラー 0 達成後に別 PR。

Refs #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)