### PR TITLE
chore(types): mypy strict を有効化（残り 5 件を解消・issue #25 完了）

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,9 +72,6 @@ exclude_dirs = ["tests"]
 [tool.mypy]
 python_version = "3.11"
 ignore_missing_imports = true
-# 段階的に有効化できるチェック
-warn_unused_ignores = true
-warn_return_any = true
+strict = true
+# strict に含まれない追加チェック
 warn_unreachable = true
-disallow_untyped_defs = true
-disallow_any_generics = true

--- a/src/gfo/adapter/azure_devops.py
+++ b/src/gfo/adapter/azure_devops.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import base64
 import json as _json
-from collections.abc import Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from typing import TYPE_CHECKING, Any
 from urllib.parse import quote, urlparse
 
@@ -877,7 +877,7 @@ class AzureDevOpsAdapter(GitServiceAdapter):
     @_wrap_conversion_error
     def _to_pipeline(data: dict[str, Any]) -> Pipeline:
 
-        status_map = {
+        status_map: dict[str, Callable[[dict[str, Any]], str]] = {
             "completed": lambda d: {
                 "succeeded": "success",
                 "failed": "failure",

--- a/src/gfo/adapter/github.py
+++ b/src/gfo/adapter/github.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import base64
-from collections.abc import Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from typing import Any, ClassVar
 from urllib.parse import quote
 
@@ -1506,7 +1506,7 @@ class GitHubAdapter(GitHubLikeAdapter, GitServiceAdapter):
     @_wrap_conversion_error
     def _to_pipeline(data: dict[str, Any]) -> Pipeline:
 
-        status_map = {
+        status_map: dict[str, Callable[[dict[str, Any]], str]] = {
             "completed": lambda d: {
                 "success": "success",
                 "failure": "failure",

--- a/src/gfo/cli.py
+++ b/src/gfo/cli.py
@@ -49,7 +49,7 @@ from gfo import __version__
 from gfo._context import cli_account, cli_remote, cli_repo
 from gfo.config import get_configured_output_format
 from gfo.exceptions import ConfigError, GfoError, NotSupportedError
-from gfo.i18n import _
+from gfo.i18n import _ as _
 from gfo.output import format_error_json
 
 


### PR DESCRIPTION
## 概要

issue #25。`mypy --strict` の残差 **5 件 / 3 ファイル**を解消し、`pyproject.toml [tool.mypy]` を `strict = true` に切り替えて CI で恒久強制する。

## 変更

### `disallow_untyped_calls`（2 件）
- `adapter/github.py` / `adapter/azure_devops.py` の `_to_pipeline` 内 `status_map` を `dict[str, Callable[[dict[str, Any]], str]]` で明示型付け。`mapper(data)` の「untyped function 呼び出し」を解消。`Callable` を `collections.abc` から import 追加。

### `no_implicit_reexport`（3 件）
- `cli.py` の `from gfo.i18n import _` を `from gfo.i18n import _ as _`（明示 re-export の慣用形）に変更。`schema.py` が schema 出力を英語化するため `gfo.cli._` を monkeypatch している箇所の `attr-defined` エラーを解消。ランタイム挙動は不変。

### `pyproject.toml`
- 個別フラグ（`warn_unused_ignores` / `warn_return_any` / `disallow_untyped_defs` / `disallow_any_generics`）を `strict = true` に集約。`strict` に含まれない `warn_unreachable` のみ明示維持。`ignore_missing_imports` も維持。

## 計測

- `mypy --strict src/gfo`: **5→0 errors**
- 既定 `mypy src/gfo`（strict 有効化後）: Success（CI で恒久強制）
- `ruff` `ruff format --check`: pass / `pytest`: 3854 passed
- `uv.lock`: 無変更（依存変更なし）

## 補足

これで `src/gfo` は `mypy --strict` 完全準拠。`#12`（`disallow_any_generics`）に続く strict 化の最終段。

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)