### PR TITLE
test: テスト実行を高速化（cov 分離 + pytest-xdist 並列化）

### DIFF
--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -23,18 +23,22 @@ allowed-tools: Bash, Read, Glob, Grep
 
 単体テスト（`tests/` 配下、`tests/integration/` を除く）を実行する。
 
+> カバレッジは `addopts` に焼き込んでいない（計測オーバーヘッドが支配的なため）。
+> このスキルはローカルのカバレッジ計測経路として `--cov` を明示付与し、`-n auto`（pytest-xdist）で並列実行する。
+
 ### 実行手順
 
 1. **引数の解析**: `$ARGUMENTS` を確認する
-   - 引数なし → `python -m pytest --ignore=tests/integration -v`
-   - ファイルやキーワード指定あり → そのまま pytest に渡す
+   - 引数なし → `python -m pytest --ignore=tests/integration --cov=gfo --cov-report=term-missing -n auto`
+   - ファイルやキーワード指定あり → そのまま pytest に渡す（`--cov=gfo --cov-report=term-missing -n auto` は維持）
 
 2. **テスト実行**: 以下のコマンドで実行する
    ```
-   python -m pytest {target} -v
+   python -m pytest {target} --cov=gfo --cov-report=term-missing -n auto
    ```
    - `{target}` は引数から構築する
    - `tests/integration/` は常に除外する（引数で明示的に指定された場合を除く）
+   - カバレッジ不要で素早く回したい場合は `--no-cov` を付ける
 
 3. **結果報告**: テスト結果をユーザーに簡潔に報告する
    - 全テスト通過: 通過数を報告

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,13 @@ jobs:
       - name: Security scan (bandit)
         run: uv run bandit -r src/gfo -c pyproject.toml -q
 
+      # runner は 4 vCPU 固定なので xdist は -n 4 を明示 (auto でも同等だが意図を固定)。
+      # CI ではカバレッジを維持する (addopts から外したぶん明示的に付与)。
+      # 3.13 (max) のみ coverage の sysmon コアを使い計測オーバーヘッドを抑える (3.11 は非対応)。
       - name: Unit tests (pytest)
-        run: uv run pytest -q
+        env:
+          COVERAGE_CORE: ${{ matrix.label == 'max' && 'sysmon' || '' }}
+        run: uv run pytest -n 4 --cov=gfo --cov-report=term-missing -q
 
   # matrix を束ねる安定名の必須チェック。Ruleset は "ci" だけを Require すればよく、
   # テスト対象バージョンを増減しても再設定不要。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ gfo = "gfo.cli:main"
 # 開発依存は PEP 735 dependency-groups で管理する。`uv sync` が既定でインストールし、
 # Dependabot も development 依存として正しく分類・グルーピングできる。
 [dependency-groups]
-dev = ["pytest", "responses", "pytest-cov", "ruff", "bandit", "mypy", "types-requests", "pre-commit"]
+dev = ["pytest", "responses", "pytest-cov", "pytest-xdist", "ruff", "bandit", "mypy", "types-requests", "pre-commit"]
 
 [build-system]
 requires = ["hatchling"]
@@ -48,7 +48,13 @@ path = "hatch_build.py"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--cov=gfo --cov-report=term-missing --ignore=tests/integration"
+# カバレッジは addopts に焼き込まない (計測オーバーヘッドが支配的で開発ループを毎回重くするため)。
+# 開発時の `uv run pytest` は cov 無し = 高速。カバレッジ計測は明示的に付与する:
+#   ローカル / test スキル: `uv run pytest --cov=gfo --cov-report=term-missing -n auto`
+#   CI: `uv run pytest -n 4 --cov=gfo --cov-report=term-missing`
+addopts = "--ignore=tests/integration --durations=10"
+# 走査対象外 (collection 高速化・誤検出回避)。
+norecursedirs = ["tmp", ".venv", ".git", "*.egg", "build", "dist"]
 markers = [
     "integration: integration tests requiring live services",
     "saas: integration tests requiring SaaS accounts (GitHub, GitLab, etc.)",
@@ -56,6 +62,15 @@ markers = [
     "cli: CLI integration tests (argparse -> handler -> adapter -> output)",
     "slow: slow tests (CI pipelines, network-heavy operations)",
 ]
+
+# xdist (並列ワーカー) × coverage 併用のための設定。
+# parallel = true で各ワーカーの計測を別ファイルに記録し combine 可能にする。
+# relative_files = true で worker の作業パス差を吸収する (未設定だと CI で 0% 化する)。
+# `coverage run -m pytest` は使わず `pytest --cov ... -n ...` 形式で計測する。
+[tool.coverage.run]
+source = ["gfo"]
+parallel = true
+relative_files = true
 
 [tool.ruff]
 line-length = 100

--- a/uv.lock
+++ b/uv.lock
@@ -291,6 +291,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.29.4"
 source = { registry = "https://pypi.org/simple" }
@@ -313,6 +322,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "responses" },
     { name = "ruff" },
     { name = "types-requests" },
@@ -328,6 +338,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "responses" },
     { name = "ruff" },
     { name = "types-requests" },
@@ -612,6 +623,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #27

## 概要

単体テスト（3854 件）の実行を高速化する。カバレッジ計測オーバーヘッドが支配的だったため `addopts` から `--cov` を外し、`pytest-xdist` で並列化する。

## 変更

- **pyproject**: `addopts` から `--cov=gfo --cov-report=term-missing` を除去（`--ignore=tests/integration` は維持）。`--durations=10` と `norecursedirs`（`tmp`/`.venv` 等）を追加。
- **deps**: `pytest-xdist` を dev に追加（`uv.lock` 同梱）。
- **coverage**: `[tool.coverage.run]` に `parallel = true` / `relative_files = true` / `source = ["gfo"]` を追加（xdist × cov 併用時の 0% 化を防止）。
- **CI**: pytest を `-n 4 --cov=gfo --cov-report=term-missing` で実行。3.13(max) のみ `COVERAGE_CORE=sysmon`。
- **test スキル**: ローカル計測経路として `--cov ... -n auto` を明示。

## 検証（ローカル / WSL）

- CI 相当 `pytest -n 4 --cov ...`: **3854 passed**・カバレッジ **92%**（並列計測が正しく集計され 0% 化なし）。
- `ruff check` / `ruff format --check` green、`ci.yml` は valid YAML。
- 重複テストファイル名は各テストディレクトリの `__init__.py` で完全修飾名が一意になり、xdist・デフォルト import モードで安全。

## 非スコープ

- 冗長テスト整理（#28）、実ロジックの穴埋め（#29）、uv キャッシュ（#30）は別 PR。