### PR TITLE
ci: uv パッケージキャッシュを actions/cache で追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,21 @@ jobs:
           fi
 
       # mise.toml の python / uv を供給する (ローカル開発と同一の toolchain)。
+      # mise-action は python/uv の toolchain バイナリはキャッシュするが、uv の
+      # パッケージキャッシュ (~/.cache/uv) はキャッシュしないため、下の cache step で補う。
       - name: Setup mise (python + uv)
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+
+      # uv のパッケージキャッシュ (~/.cache/uv = 展開済み wheel) を復元/保存し、毎ジョブの
+      # wheel ダウンロードを省く。キーは uv.lock のハッシュ + OS + python 版で構成し、
+      # lock 変更時のみ更新する (restore-keys で前回キャッシュにフォールバック)。
+      - name: Cache uv packages
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-py${{ matrix.python-version }}-
 
       # uv.lock どおりに frozen install する。lock が古ければ fail (lockfile 整合性ゲート)。
       # dev は dependency-groups で定義されており uv sync が既定でインストールする。


### PR DESCRIPTION
Closes #30

## 概要

各 test ジョブ（3.11 / 3.13）が毎回 PyPI から wheel を取得していたため、`~/.cache/uv`（展開済み wheel）を `actions/cache` で復元/保存して依存 install を短縮する。

## 変更（`ci.yml` のみ）

- `actions/cache@v5.0.5` を **40 桁 commit SHA で pin**（`27d5ce7...`・既存の「SHA pin 自己検証 step」に準拠）。
- キャッシュキー = `uv-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('uv.lock') }}`。lock 変更時のみ更新し、`restore-keys` で前回キャッシュにフォールバック。
- mise-action の toolchain キャッシュ（既存）はそのまま維持。

## 効果

- 初回 run はキャッシュ未ヒット（cold）、2 回目以降の run で `Install dependencies` が短縮される（DL → 復元+link）。本 PR の CI run（cold）と後続 run（warm）で比較可能。
- #27 でテストが縮んだぶん `uv sync` の相対比重が上がるため、本キャッシュの削減比率も育つ。

## 非スコープ

- テスト実行自体の高速化（#27・merged）、依存/pyproject の変更。本 PR は CI yaml のみ。