### PR TITLE
test: 実ロジックの穴を埋める（GitBucket/Gogs/base.py）

### DIFF
--- a/tests/test_adapter_base.py
+++ b/tests/test_adapter_base.py
@@ -374,3 +374,68 @@ class TestGetCurrentUsername:
         """login が最優先で、他のキーより先にチェックされることを確認。"""
         adapter = self._make_adapter({"login": "first", "username": "second"})
         assert adapter.get_current_username() == "first"
+
+
+class TestDefaultTopicMethods:
+    """add_topic / remove_topic のデフォルト実装（list_topics + set_topics）の分岐。
+
+    override 版（github/gitea/gitlab）はテスト済みだが、base.py のデフォルト実装の
+    early-return 分岐（既存 topic を add / 不在 topic を remove）が未到達のため埋める。
+    """
+
+    def _make_adapter(self, current_topics: list[str]):
+        adapter = TestGitServiceAdapterDeleteDefaults()._make_adapter()
+        adapter.list_topics = lambda: list(current_topics)
+        adapter.set_topics = MagicMock(side_effect=lambda topics: topics)
+        return adapter
+
+    def test_add_topic_appends_when_absent(self):
+        adapter = self._make_adapter(["a", "b"])
+        result = adapter.add_topic("c")
+        assert result == ["a", "b", "c"]
+        adapter.set_topics.assert_called_once_with(["a", "b", "c"])
+
+    def test_add_topic_noop_when_present(self):
+        """既存 topic を add すると set_topics を呼ばず現状を返す（early-return）。"""
+        adapter = self._make_adapter(["a", "b"])
+        result = adapter.add_topic("a")
+        assert result == ["a", "b"]
+        adapter.set_topics.assert_not_called()
+
+    def test_remove_topic_removes_when_present(self):
+        adapter = self._make_adapter(["a", "b"])
+        result = adapter.remove_topic("a")
+        assert result == ["b"]
+        adapter.set_topics.assert_called_once_with(["b"])
+
+    def test_remove_topic_noop_when_absent(self):
+        """不在 topic を remove すると set_topics を呼ばず現状を返す（early-return）。"""
+        adapter = self._make_adapter(["a", "b"])
+        result = adapter.remove_topic("c")
+        assert result == ["a", "b"]
+        adapter.set_topics.assert_not_called()
+
+
+class TestResolveMilestoneIdByTitle:
+    """_resolve_milestone_id_by_title のデフォルト実装（list_milestones ループ）。"""
+
+    def _make_adapter(self, milestones: list[Milestone]):
+        adapter = TestGitServiceAdapterDeleteDefaults()._make_adapter()
+        adapter.list_milestones = lambda *, limit=0: milestones
+        return adapter
+
+    def test_found_returns_number(self):
+        adapter = self._make_adapter(
+            [
+                Milestone(number=3, title="v1.0", description=None, state="open", due_date=None),
+                Milestone(number=7, title="v2.0", description=None, state="open", due_date=None),
+            ]
+        )
+        assert adapter._resolve_milestone_id_by_title("v2.0") == 7
+
+    def test_not_found_raises(self):
+        from gfo.exceptions import GfoError
+
+        adapter = self._make_adapter([])
+        with pytest.raises(GfoError, match="Milestone not found"):
+            adapter._resolve_milestone_id_by_title("nope")

--- a/tests/test_adapters/test_gitbucket.py
+++ b/tests/test_adapters/test_gitbucket.py
@@ -684,6 +684,101 @@ class TestCreateRelease:
         assert rel.tag == "v1.0.0"
 
 
+class TestListTags:
+    """list_tags は二重エンコード回避のため GET /git/refs/tags を使い prefix を剥がす。"""
+
+    def test_strips_prefix_and_extracts_sha(self, mock_responses, gitbucket_adapter):
+        mock_responses.add(
+            responses.GET,
+            f"{REPOS}/git/refs/tags",
+            json=[
+                {"ref": "refs/tags/v1.0.0", "object": {"sha": "abc123"}},
+                {"ref": "refs/tags/v2.0.0", "object": {"sha": "def456"}},
+            ],
+            status=200,
+        )
+        tags = gitbucket_adapter.list_tags()
+        assert [t.name for t in tags] == ["v1.0.0", "v2.0.0"]
+        assert tags[0].sha == "abc123"
+        assert tags[1].sha == "def456"
+        # GitHub の /tags ではなく /git/refs/tags を使う。
+        assert mock_responses.calls[0].request.url.startswith(f"{REPOS}/git/refs/tags")
+
+    def test_missing_object_falls_back_to_empty_sha(self, mock_responses, gitbucket_adapter):
+        mock_responses.add(
+            responses.GET,
+            f"{REPOS}/git/refs/tags",
+            json=[{"ref": "refs/tags/v1.0.0"}],
+            status=200,
+        )
+        tags = gitbucket_adapter.list_tags()
+        assert tags[0].name == "v1.0.0"
+        assert tags[0].sha == ""
+
+    def test_ref_without_prefix_kept_as_is(self, mock_responses, gitbucket_adapter):
+        mock_responses.add(
+            responses.GET,
+            f"{REPOS}/git/refs/tags",
+            json=[{"ref": "v9.9.9", "object": {"sha": "x"}}],
+            status=200,
+        )
+        tags = gitbucket_adapter.list_tags()
+        assert tags[0].name == "v9.9.9"
+
+    def test_empty(self, mock_responses, gitbucket_adapter):
+        mock_responses.add(responses.GET, f"{REPOS}/git/refs/tags", json=[], status=200)
+        assert gitbucket_adapter.list_tags() == []
+
+
+class TestGetLatestRelease:
+    """get_latest_release は releases?limit=1 の先頭を返し、空なら NotFoundError。"""
+
+    def test_returns_first(self, mock_responses, gitbucket_adapter):
+        mock_responses.add(
+            responses.GET,
+            f"{REPOS}/releases",
+            json=[
+                {
+                    "tag_name": "v2.0.0",
+                    "name": "Release 2.0.0",
+                    "body": "notes",
+                    "html_url": "https://gitbucket.example.com/test-owner/test-repo/releases/v2.0.0",
+                    "created_at": "2025-02-01T00:00:00Z",
+                }
+            ],
+            status=200,
+        )
+        rel = gitbucket_adapter.get_latest_release()
+        assert isinstance(rel, Release)
+        assert rel.tag == "v2.0.0"
+
+    def test_empty_raises_not_found(self, mock_responses, gitbucket_adapter):
+        mock_responses.add(responses.GET, f"{REPOS}/releases", json=[], status=200)
+        with pytest.raises(NotFoundError):
+            gitbucket_adapter.get_latest_release()
+
+
+class TestUpdateRepository:
+    """update_repository は未対応パラメータを警告し、対応分だけ super に委譲する。"""
+
+    def test_supported_params_delegated(self, mock_responses, gitbucket_adapter):
+        mock_responses.add(responses.PATCH, REPOS, json=_repo_data(), status=200)
+        repo = gitbucket_adapter.update_repository(description="new desc", private=True)
+        assert isinstance(repo, Repository)
+        req_body = json_mod.loads(mock_responses.calls[0].request.body)
+        assert req_body["description"] == "new desc"
+        assert req_body["private"] is True
+
+    def test_unsupported_param_warns_and_dropped(self, mock_responses, gitbucket_adapter):
+        mock_responses.add(responses.PATCH, REPOS, json=_repo_data(), status=200)
+        with pytest.warns(UserWarning, match="archived"):
+            gitbucket_adapter.update_repository(description="d", archived=True)
+        req_body = json_mod.loads(mock_responses.calls[0].request.body)
+        # 警告したパラメータは super に渡らない（payload に含まれない）。
+        assert "archived" not in req_body
+        assert req_body["description"] == "d"
+
+
 class TestMigrateRepository:
     def test_not_supported(self, gitbucket_adapter):
         with pytest.raises(NotSupportedError):

--- a/tests/test_adapters/test_gogs.py
+++ b/tests/test_adapters/test_gogs.py
@@ -215,6 +215,48 @@ class TestWebUrl:
         assert "my%20repo" in exc_info.value.web_url
 
 
+class TestCreateWebhook:
+    """Gogs は type:"gogs" 固有ペイロードで webhook を作成する。"""
+
+    def _hook_response(self, *, hook_id=5, url="https://example.com/hook"):
+        return {
+            "id": hook_id,
+            "type": "gogs",
+            "config": {"url": url, "content_type": "json"},
+            "events": ["push"],
+            "active": True,
+        }
+
+    def test_payload_shape(self, mock_responses, gogs_adapter):
+        import json as json_mod
+
+        mock_responses.add(responses.POST, f"{REPOS}/hooks", json=self._hook_response(), status=201)
+        hook = gogs_adapter.create_webhook(url="https://example.com/hook")
+        assert hook.id == 5
+        req_body = json_mod.loads(mock_responses.calls[0].request.body)
+        # Gogs 固有: type="gogs"、config.content_type="json"、events デフォルト ["push"]。
+        assert req_body["type"] == "gogs"
+        assert req_body["config"]["url"] == "https://example.com/hook"
+        assert req_body["config"]["content_type"] == "json"
+        assert req_body["events"] == ["push"]
+        assert req_body["active"] is True
+        # secret 未指定なら config に含めない。
+        assert "secret" not in req_body["config"]
+
+    def test_with_secret_and_custom_events(self, mock_responses, gogs_adapter):
+        import json as json_mod
+
+        mock_responses.add(responses.POST, f"{REPOS}/hooks", json=self._hook_response(), status=201)
+        gogs_adapter.create_webhook(
+            url="https://example.com/hook",
+            events=["push", "pull_request"],
+            secret="s3cr3t",
+        )
+        req_body = json_mod.loads(mock_responses.calls[0].request.body)
+        assert req_body["config"]["secret"] == "s3cr3t"
+        assert req_body["events"] == ["push", "pull_request"]
+
+
 class TestInheritedOperations:
     def test_create_issue(self, mock_responses, gogs_adapter):
         mock_responses.add(


### PR DESCRIPTION
Closes #29

## 概要

低カバレッジ 3 ファイルのうち、`NotSupportedError` スタブではない**実ロジック分岐**を埋め、リグレッション検出力を上げる（+16 tests）。

## 追加テスト

- **GitBucket**（`test_gitbucket.py`）
  - `list_tags`: `refs/tags/` プレフィックス剥がし + `object.sha` 抽出 + object 欠落フォールバック + 空。
  - `get_latest_release`: 空リスト → `NotFoundError`、先頭返却。
  - `update_repository`: 未対応パラメータの `pytest.warns(UserWarning)` 検証 + super 委譲（警告分は payload から除外）。
- **Gogs**（`test_gogs.py`）
  - `create_webhook`: `type:"gogs"` 固有ペイロード形状（`config`/`content_type`/`events` デフォルト/`secret` 有無）を `responses` で検証。
- **base.py デフォルト実装**（`test_adapter_base.py`）
  - `add_topic`/`remove_topic`: 既存追加・不在削除の early-return 分岐。
  - `_resolve_milestone_id_by_title`: found / not-found（`GfoError`）。

## カバレッジ

| ファイル | before | after |
|---|---|---|
| `gitbucket.py` | 77% | 84% |
| `gogs.py` | 71% | 73% |
| `adapter/base.py` | 67% | 68% |

残りの未到達行は `raise NotSupportedError` 1 行スタブ（#29 非スコープ・代表テストで担保済み）。

## 補足

- `_parse_response`(GitBucket) / `get_current_username` / Gogs `_web_url` のポート分岐は既存テストで網羅済みのため対象外。
- 挙動変更なし・テスト追加のみ。全 3870 passed。