### PR TITLE
test: StubAdapter の三重定義を共通フィクスチャに集約（#28）

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,8 @@ from unittest.mock import patch
 
 import pytest
 
+from gfo.adapter.base import GitServiceAdapter
+
 
 @pytest.fixture
 def config_dir(tmp_path: Path) -> Path:
@@ -21,3 +23,96 @@ def config_dir(tmp_path: Path) -> Path:
     d.mkdir()
     with patch("gfo.config.get_config_dir", return_value=d):
         yield d
+
+
+class StubAdapter(GitServiceAdapter):
+    """全抽象メソッドを最小スタブ実装した具象サブクラス（テスト共通）。
+
+    base.py のデフォルト実装（delete_*, get_pr_checkout_refspec, add_topic 等）や
+    ABC 規約の検証に使う。`base.py` のシグネチャ変更時はここ 1 箇所だけ直せばよい。
+    `tests/test_adapter_base.py` と `tests/test_adapters/test_base.py` の両方が import する。
+    """
+
+    service_name = "stub"
+
+    def list_pull_requests(self, *, state="open", limit=30):
+        return []
+
+    def create_pull_request(self, *, title, body="", base, head, draft=False):
+        return None  # type: ignore[return-value]
+
+    def get_pull_request(self, number):
+        return None  # type: ignore[return-value]
+
+    def merge_pull_request(self, number, *, method="merge", title=None, message=None):
+        return None
+
+    def close_pull_request(self, number):
+        return None
+
+    def list_issues(self, *, state="open", assignee=None, label=None, limit=30):
+        return []
+
+    def create_issue(self, *, title, body="", assignee=None, label=None, **kwargs):
+        return None  # type: ignore[return-value]
+
+    def get_issue(self, number):
+        return None  # type: ignore[return-value]
+
+    def close_issue(self, number):
+        return None
+
+    def list_repositories(self, *, owner=None, limit=30):
+        return []
+
+    def create_repository(self, *, name, visibility="public", description=""):
+        return None  # type: ignore[return-value]
+
+    def get_repository(self, owner=None, name=None):
+        return None  # type: ignore[return-value]
+
+    def list_releases(self, *, limit=30):
+        return []
+
+    def create_release(self, *, tag, title="", notes="", draft=False, prerelease=False):
+        return None  # type: ignore[return-value]
+
+    def list_labels(self, *, limit=0):
+        return []
+
+    def create_label(self, *, name, color=None, description=None):
+        return None  # type: ignore[return-value]
+
+    def list_milestones(self, *, limit=0):
+        return []
+
+    def create_milestone(self, *, title, description=None, due_date=None):
+        return None  # type: ignore[return-value]
+
+    def list_comments(self, resource, number, *, limit=30):
+        return []
+
+    def create_comment(self, resource, number, *, body):
+        return None  # type: ignore[return-value]
+
+    def update_pull_request(self, number, *, title=None, body=None, base=None):
+        return None  # type: ignore[return-value]
+
+    def update_issue(self, number, *, title=None, body=None, assignee=None, label=None):
+        return None  # type: ignore[return-value]
+
+    def list_branches(self, *, limit=30):
+        return []
+
+    def create_branch(self, *, name, ref):
+        return None  # type: ignore[return-value]
+
+
+@pytest.fixture
+def make_stub_adapter():
+    """StubAdapter のインスタンスを生成するファクトリ。"""
+
+    def _make(*, client=None, owner="o", repo="r"):
+        return StubAdapter(client=client, owner=owner, repo=repo)
+
+    return _make

--- a/tests/test_adapter_base.py
+++ b/tests/test_adapter_base.py
@@ -7,7 +7,6 @@ import pytest
 
 from gfo.adapter.base import (
     GitHubLikeAdapter,
-    GitServiceAdapter,
     Issue,
     Label,
     Milestone,
@@ -16,6 +15,7 @@ from gfo.adapter.base import (
     Repository,
 )
 from gfo.exceptions import NotSupportedError
+from tests.conftest import StubAdapter
 
 
 class TestPullRequest:
@@ -230,58 +230,8 @@ class TestGitServiceAdapterDeleteDefaults:
     """delete デフォルト実装が NotSupportedError を送出することを確認する。"""
 
     def _make_adapter(self):
-        """抽象メソッドを最小限に実装したコンクリートサブクラスのインスタンスを返す。"""
-
-        class MinimalAdapter(GitServiceAdapter):
-            service_name = "TestService"
-
-            def list_pull_requests(self, *, state="open", limit=30):
-                return []
-
-            def create_pull_request(self, *, title, body="", base, head, draft=False): ...
-            def get_pull_request(self, number): ...
-            def merge_pull_request(self, number, *, method="merge", title=None, message=None): ...
-            def close_pull_request(self, number): ...
-            def list_issues(self, *, state="open", assignee=None, label=None, limit=30):
-                return []
-
-            def create_issue(self, *, title, body="", assignee=None, label=None, **kwargs): ...
-            def get_issue(self, number): ...
-            def close_issue(self, number): ...
-            def list_repositories(self, *, owner=None, limit=30):
-                return []
-
-            def create_repository(self, *, name, visibility="public", description=""): ...
-            def get_repository(self, owner=None, name=None): ...
-            def list_releases(self, *, limit=30):
-                return []
-
-            def create_release(self, *, tag, title="", notes="", draft=False, prerelease=False): ...
-            def list_labels(self, *, limit=0):
-                return []
-
-            def create_label(self, *, name, color=None, description=None): ...
-            def list_milestones(self, *, limit=0):
-                return []
-
-            def create_milestone(self, *, title, description=None, due_date=None): ...
-
-            # Phase 1+ 追加抽象メソッドのスタブ
-            def list_comments(self, resource, number, *, limit=30):
-                return []
-
-            def create_comment(self, resource, number, *, body): ...
-
-            def update_pull_request(self, number, *, title=None, body=None, base=None): ...
-
-            def update_issue(self, number, *, title=None, body=None, assignee=None, label=None): ...
-
-            def list_branches(self, *, limit=30):
-                return []
-
-            def create_branch(self, *, name, ref): ...
-
-        return MinimalAdapter(MagicMock(), "owner", "repo")
+        """全抽象メソッドをスタブ実装した共通 StubAdapter のインスタンスを返す。"""
+        return StubAdapter(MagicMock(), "owner", "repo")
 
     def test_delete_issue_raises_not_supported(self):
         adapter = self._make_adapter()

--- a/tests/test_adapters/test_base.py
+++ b/tests/test_adapters/test_base.py
@@ -6,6 +6,7 @@ import pytest
 
 from gfo.adapter.base import GitServiceAdapter
 from gfo.exceptions import NotSupportedError
+from tests.conftest import StubAdapter
 
 EXPECTED_ABSTRACT_METHODS = frozenset(
     {
@@ -35,84 +36,6 @@ EXPECTED_ABSTRACT_METHODS = frozenset(
         "create_branch",
     }
 )
-
-
-class StubAdapter(GitServiceAdapter):
-    """全抽象メソッドをスタブ実装した具象サブクラス。"""
-
-    service_name = "stub"
-
-    def list_pull_requests(self, *, state="open", limit=30):
-        return []
-
-    def create_pull_request(self, *, title, body="", base, head, draft=False):
-        return None  # type: ignore[return-value]
-
-    def get_pull_request(self, number):
-        return None  # type: ignore[return-value]
-
-    def merge_pull_request(self, number, *, method="merge", title=None, message=None):
-        return None
-
-    def close_pull_request(self, number):
-        return None
-
-    def list_issues(self, *, state="open", assignee=None, label=None, limit=30):
-        return []
-
-    def create_issue(self, *, title, body="", assignee=None, label=None, **kwargs):
-        return None  # type: ignore[return-value]
-
-    def get_issue(self, number):
-        return None  # type: ignore[return-value]
-
-    def close_issue(self, number):
-        return None
-
-    def list_repositories(self, *, owner=None, limit=30):
-        return []
-
-    def create_repository(self, *, name, visibility="public", description=""):
-        return None  # type: ignore[return-value]
-
-    def get_repository(self, owner=None, name=None):
-        return None  # type: ignore[return-value]
-
-    def list_releases(self, *, limit=30):
-        return []
-
-    def create_release(self, *, tag, title="", notes="", draft=False, prerelease=False):
-        return None  # type: ignore[return-value]
-
-    def list_labels(self):
-        return []
-
-    def create_label(self, *, name, color=None, description=None):
-        return None  # type: ignore[return-value]
-
-    def list_milestones(self):
-        return []
-
-    def create_milestone(self, *, title, description=None, due_date=None):
-        return None  # type: ignore[return-value]
-
-    def list_comments(self, resource, number, *, limit=30):
-        return []
-
-    def create_comment(self, resource, number, *, body):
-        return None  # type: ignore[return-value]
-
-    def update_pull_request(self, number, *, title=None, body=None, base=None):
-        return None  # type: ignore[return-value]
-
-    def update_issue(self, number, *, title=None, body=None, assignee=None, label=None):
-        return None  # type: ignore[return-value]
-
-    def list_branches(self, *, limit=30):
-        return []
-
-    def create_branch(self, *, name, ref):
-        return None  # type: ignore[return-value]
 
 
 class TestAbstractMethods:


### PR DESCRIPTION
Refs #28（カテゴリ3: StubAdapter / MinimalAdapter の三重定義の共通化）

## 概要

全抽象メソッドをスタブ実装した具象サブクラスが 2 箇所に重複定義され、`base.py` の抽象シグネチャ変更時に複数箇所の修正を要していた。共通フィクスチャに集約する。

## 変更

- `tests/conftest.py` に共通 `StubAdapter`（+ `make_stub_adapter` ファクトリ）を 1 箇所定義。
- `tests/test_adapter_base.py`: 内部 `MinimalAdapter`（約 50 行）を削除し共通 `StubAdapter` を使用。
- `tests/test_adapters/test_base.py`: ローカル `StubAdapter`（約 75 行）を削除し `from tests.conftest import StubAdapter`。
- import 方式は既存の `from tests.test_commands.conftest import make_args, patch_adapter` 慣習に倣う。

## 検証

- 挙動・アサーションは不変。全 **3870 passed**（テスト数維持）。
- `ruff check` / `ruff format --check` green。
- 差分: +99 / −131（重複削減）。

## スコープ

- 本 PR は #28 のカテゴリ3 のみ。カテゴリ1（Gitea ファミリー parametrize 集約）・2（`_to_*` コピペ）・4〜6 は後続 PR で対応予定。