### PR TITLE
test: Forgejo の親クラス再テストを wiring 検証に集約（#28）

### DIFF
--- a/tests/test_adapters/test_forgejo.py
+++ b/tests/test_adapters/test_forgejo.py
@@ -1,17 +1,21 @@
-"""ForgejoAdapter のテスト。"""
+"""ForgejoAdapter のテスト。
+
+ForgejoAdapter は ``service_name`` 以外を一切オーバーライドしないため、CRUD / ``_to_*``
+の挙動は GiteaAdapter（``tests/test_adapters/test_gitea.py``）のテストが網羅している。
+本ファイルは Forgejo 固有の wiring（registry 登録・継承・Gitea API 互換パス）だけを検証し、
+GiteaAdapter のテストと重複する挙動テストは持たない。
+
+新たに override を追加した場合は :class:`TestNoBehavioralOverrides` が失敗するので、
+その時点で当該挙動のテストを本ファイルへ個別に追加すること。
+"""
 
 from __future__ import annotations
 
-import json as json_mod
-
-import pytest
 import responses
 
-from gfo.adapter.base import Issue, PullRequest, Repository
 from gfo.adapter.forgejo import ForgejoAdapter
 from gfo.adapter.gitea import GiteaAdapter
 from gfo.adapter.registry import get_adapter_class
-from gfo.exceptions import AuthenticationError, NotFoundError, ServerError
 
 BASE = "https://forgejo.example.com/api/v1"
 REPOS = f"{BASE}/repos/test-owner/test-repo"
@@ -48,18 +52,6 @@ def _issue_data(*, number=1, state="open"):
     }
 
 
-def _repo_data(*, private=False):
-    return {
-        "name": "test-repo",
-        "full_name": "test-owner/test-repo",
-        "description": "A test repo",
-        "private": private,
-        "default_branch": "main",
-        "clone_url": "https://forgejo.example.com/test-owner/test-repo.git",
-        "html_url": "https://forgejo.example.com/test-owner/test-repo",
-    }
-
-
 class TestRegistry:
     def test_registered(self):
         assert get_adapter_class("forgejo") is ForgejoAdapter
@@ -76,26 +68,24 @@ class TestInheritance:
         assert forgejo_adapter.service_name != "Gitea"
 
 
-class TestToPullRequest:
-    def test_open(self):
-        pr = ForgejoAdapter._to_pull_request(_pr_data())
-        assert pr.state == "open"
-        assert pr.number == 1
-        assert pr.author == "author1"
+class TestNoBehavioralOverrides:
+    """Forgejo が GiteaAdapter から挙動を変えていないことを保証する。
 
-    def test_closed(self):
-        pr = ForgejoAdapter._to_pull_request(_pr_data(state="closed", merged_at=None))
-        assert pr.state == "closed"
+    これが green である限り、CRUD/_to_* の挙動は GiteaAdapter のテストで担保される。
+    override を足したらここが落ちるので、その挙動を本ファイルに個別テストする合図になる。
+    """
 
-    def test_merged(self):
-        pr = ForgejoAdapter._to_pull_request(
-            _pr_data(state="closed", merged_at="2025-01-01T00:00:00Z")
+    def test_only_overrides_service_name(self):
+        # __dunder__ と ABCMeta の _abc_impl（具象 ABC サブクラスに必ず付く）は除外する。
+        own = {k for k in vars(ForgejoAdapter) if not k.startswith("__") and k != "_abc_impl"}
+        assert own == {"service_name"}, (
+            f"ForgejoAdapter が service_name 以外を override している: {own - {'service_name'}}。"
+            " override した挙動は本ファイルで個別にテストすること。"
         )
-        assert pr.state == "merged"
 
 
 class TestGiteaApiCompatibility:
-    """ForgejoAdapter が Gitea API v1 互換パスを使用することを確認する。"""
+    """ForgejoAdapter が継承により Gitea API v1 互換パス/方式を使うことを確認する。"""
 
     def test_pr_endpoint_uses_gitea_path(self, mock_responses, forgejo_adapter):
         mock_responses.add(
@@ -145,378 +135,3 @@ class TestGiteaApiCompatibility:
     def test_checkout_refspec_uses_gitea_format(self, forgejo_adapter):
         """Gitea 互換: チェックアウト refspec は refs/pull/{n}/head 形式。"""
         assert forgejo_adapter.get_pr_checkout_refspec(7) == "refs/pull/7/head"
-
-
-class TestListPullRequests:
-    def test_open(self, mock_responses, forgejo_adapter):
-        mock_responses.add(
-            responses.GET,
-            f"{REPOS}/pulls",
-            json=[_pr_data()],
-            status=200,
-        )
-        prs = forgejo_adapter.list_pull_requests()
-        assert len(prs) == 1
-        assert prs[0].state == "open"
-        assert prs[0].number == 1
-
-    def test_filter_params(self, mock_responses, forgejo_adapter):
-        """Gitea 継承: author/label/base パラメータがクエリパラメータに送信されることを確認する。"""
-        mock_responses.add(
-            responses.GET,
-            f"{REPOS}/pulls",
-            json=[_pr_data()],
-            status=200,
-        )
-        forgejo_adapter.list_pull_requests(author="alice", label="bug", base="main")
-        req_url = mock_responses.calls[0].request.url
-        assert "poster=alice" in req_url
-        assert "labels=bug" in req_url
-        assert "base=main" in req_url
-
-    def test_merged_filter(self, mock_responses, forgejo_adapter):
-        mock_responses.add(
-            responses.GET,
-            f"{REPOS}/pulls",
-            json=[
-                _pr_data(number=1, state="closed", merged_at="2025-01-03T00:00:00Z"),
-                _pr_data(number=2, state="closed"),
-            ],
-            status=200,
-        )
-        prs = forgejo_adapter.list_pull_requests(state="merged")
-        assert len(prs) == 1
-        assert prs[0].number == 1
-
-    def test_pagination(self, mock_responses, forgejo_adapter):
-        next_url = f"{REPOS}/pulls?page=2&limit=30"
-        call_count = {"n": 0}
-
-        def callback(request):
-            call_count["n"] += 1
-            if call_count["n"] == 1:
-                headers = {"Link": f'<{next_url}>; rel="next"'}
-                return (200, headers, json_mod.dumps([_pr_data(number=1), _pr_data(number=2)]))
-            return (200, {}, json_mod.dumps([_pr_data(number=3)]))
-
-        mock_responses.add_callback(responses.GET, f"{REPOS}/pulls", callback=callback)
-        prs = forgejo_adapter.list_pull_requests(limit=0)
-        assert len(prs) == 3
-        assert call_count["n"] == 2
-
-
-class TestCreatePullRequest:
-    def test_create(self, mock_responses, forgejo_adapter):
-        mock_responses.add(
-            responses.POST,
-            f"{REPOS}/pulls",
-            json=_pr_data(),
-            status=201,
-        )
-        pr = forgejo_adapter.create_pull_request(
-            title="PR #1",
-            body="desc",
-            base="main",
-            head="feature",
-        )
-        assert isinstance(pr, PullRequest)
-        req_body = json_mod.loads(mock_responses.calls[0].request.body)
-        assert req_body["draft"] is False
-
-    def test_create_draft(self, mock_responses, forgejo_adapter):
-        mock_responses.add(
-            responses.POST,
-            f"{REPOS}/pulls",
-            json=_pr_data(draft=True),
-            status=201,
-        )
-        forgejo_adapter.create_pull_request(
-            title="Draft",
-            body="",
-            base="main",
-            head="feature",
-            draft=True,
-        )
-        req_body = json_mod.loads(mock_responses.calls[0].request.body)
-        assert req_body["draft"] is True
-
-
-class TestGetPullRequest:
-    def test_get(self, mock_responses, forgejo_adapter):
-        mock_responses.add(
-            responses.GET,
-            f"{REPOS}/pulls/42",
-            json=_pr_data(number=42),
-            status=200,
-        )
-        pr = forgejo_adapter.get_pull_request(42)
-        assert pr.number == 42
-
-
-class TestMergePullRequest:
-    def test_merge(self, mock_responses, forgejo_adapter):
-        """merge_pull_request は POST .../merge エンドポイントを使用する（R35修正確認）。"""
-        mock_responses.add(
-            responses.POST,
-            f"{REPOS}/pulls/1/merge",
-            json={"merged": True},
-            status=200,
-        )
-        forgejo_adapter.merge_pull_request(1)
-        req_body = json_mod.loads(mock_responses.calls[0].request.body)
-        assert req_body["Do"] == "merge"
-        assert mock_responses.calls[0].request.method == "POST"
-
-    def test_merge_with_commit_message(self, mock_responses, forgejo_adapter):
-        mock_responses.add(
-            responses.POST,
-            f"{REPOS}/pulls/1/merge",
-            json={"merged": True},
-            status=200,
-        )
-        forgejo_adapter.merge_pull_request(1, title="Custom title", message="Custom body")
-        req_body = json_mod.loads(mock_responses.calls[0].request.body)
-        assert req_body["MergeTitleField"] == "Custom title"
-        assert req_body["MergeMessageField"] == "Custom body"
-
-
-class TestClosePullRequest:
-    def test_close(self, mock_responses, forgejo_adapter):
-        mock_responses.add(
-            responses.PATCH,
-            f"{REPOS}/pulls/1",
-            json=_pr_data(state="closed"),
-            status=200,
-        )
-        forgejo_adapter.close_pull_request(1)
-        req_body = json_mod.loads(mock_responses.calls[0].request.body)
-        assert req_body["state"] == "closed"
-
-
-class TestReopenPullRequest:
-    def test_reopen(self, mock_responses, forgejo_adapter):
-        mock_responses.add(
-            responses.PATCH,
-            f"{REPOS}/pulls/1",
-            json=_pr_data(state="open"),
-            status=200,
-        )
-        forgejo_adapter.reopen_pull_request(1)
-        req_body = json_mod.loads(mock_responses.calls[0].request.body)
-        assert req_body["state"] == "open"
-
-
-class TestListIssues:
-    def test_list(self, mock_responses, forgejo_adapter):
-        mock_responses.add(
-            responses.GET,
-            f"{REPOS}/issues",
-            json=[_issue_data()],
-            status=200,
-        )
-        issues = forgejo_adapter.list_issues()
-        assert len(issues) == 1
-        assert isinstance(issues[0], Issue)
-
-    def test_with_filters(self, mock_responses, forgejo_adapter):
-        mock_responses.add(
-            responses.GET,
-            f"{REPOS}/issues",
-            json=[_issue_data()],
-            status=200,
-        )
-        forgejo_adapter.list_issues(assignee="dev1", label="bug")
-        req_url = mock_responses.calls[0].request.url
-        assert "assignee=dev1" in req_url
-        assert "labels=bug" in req_url
-
-
-class TestListRepositories:
-    def test_no_owner(self, mock_responses, forgejo_adapter):
-        mock_responses.add(
-            responses.GET,
-            f"{BASE}/user/repos",
-            json=[_repo_data()],
-            status=200,
-        )
-        repos = forgejo_adapter.list_repositories()
-        assert len(repos) == 1
-        assert isinstance(repos[0], Repository)
-
-    def test_with_owner(self, mock_responses, forgejo_adapter):
-        mock_responses.add(
-            responses.GET,
-            f"{BASE}/users/someone/repos",
-            json=[_repo_data()],
-            status=200,
-        )
-        repos = forgejo_adapter.list_repositories(owner="someone")
-        assert len(repos) == 1
-
-
-class TestErrorHandling:
-    """HTTP エラーが適切な例外に変換されることを確認する。"""
-
-    def test_not_found_raises_error(self, mock_responses, forgejo_adapter):
-        mock_responses.add(
-            responses.GET,
-            f"{REPOS}/pulls/999",
-            json={"message": "Not Found"},
-            status=404,
-        )
-        with pytest.raises(NotFoundError):
-            forgejo_adapter.get_pull_request(999)
-
-    def test_auth_error_raises_error(self, mock_responses, forgejo_adapter):
-        mock_responses.add(
-            responses.GET,
-            f"{REPOS}/pulls",
-            json={"message": "Unauthorized"},
-            status=401,
-        )
-        with pytest.raises(AuthenticationError):
-            forgejo_adapter.list_pull_requests()
-
-    def test_server_error_raises_error(self, mock_responses, forgejo_adapter):
-        mock_responses.add(
-            responses.GET,
-            f"{REPOS}/issues",
-            json={"message": "Internal Server Error"},
-            status=500,
-        )
-        with pytest.raises(ServerError):
-            forgejo_adapter.list_issues()
-
-
-class TestDeleteInheritance:
-    """GiteaAdapter から継承した delete メソッドが動作することを確認する。"""
-
-    def test_delete_release(self, mock_responses, forgejo_adapter):
-        mock_responses.add(
-            responses.GET,
-            f"{REPOS}/releases/tags/v1.0.0",
-            json={"id": 42, "tag_name": "v1.0.0"},
-            status=200,
-        )
-        mock_responses.add(
-            responses.DELETE,
-            f"{REPOS}/releases/42",
-            status=204,
-        )
-        forgejo_adapter.delete_release(tag="v1.0.0")
-
-    def test_delete_label(self, mock_responses, forgejo_adapter):
-        mock_responses.add(
-            responses.GET,
-            f"{REPOS}/labels",
-            json=[{"id": 10, "name": "bug", "color": "d73a4a", "description": ""}],
-            status=200,
-        )
-        mock_responses.add(
-            responses.DELETE,
-            f"{REPOS}/labels/10",
-            status=204,
-        )
-        forgejo_adapter.delete_label(name="bug")
-
-    def test_delete_milestone(self, mock_responses, forgejo_adapter):
-        mock_responses.add(
-            responses.DELETE,
-            f"{REPOS}/milestones/3",
-            status=204,
-        )
-        forgejo_adapter.delete_milestone(number=3)
-
-    def test_get_milestone(self, mock_responses, forgejo_adapter):
-        mock_responses.add(
-            responses.GET,
-            f"{REPOS}/milestones/1",
-            json={
-                "number": 1,
-                "title": "v1.0",
-                "description": "desc",
-                "state": "open",
-                "due_on": "2026-01-01",
-            },
-            status=200,
-        )
-        ms = forgejo_adapter.get_milestone(1)
-        assert ms.title == "v1.0"
-
-    def test_update_milestone(self, mock_responses, forgejo_adapter):
-        mock_responses.add(
-            responses.PATCH,
-            f"{REPOS}/milestones/1",
-            json={
-                "number": 1,
-                "title": "v2.0",
-                "description": "desc",
-                "state": "closed",
-                "due_on": "2026-01-01",
-            },
-            status=200,
-        )
-        ms = forgejo_adapter.update_milestone(1, title="v2.0", state="closed")
-        assert ms.title == "v2.0"
-
-    def test_delete_issue(self, mock_responses, forgejo_adapter):
-        mock_responses.add(
-            responses.DELETE,
-            f"{REPOS}/issues/5",
-            status=204,
-        )
-        forgejo_adapter.delete_issue(5)
-        assert mock_responses.calls[0].request.method == "DELETE"
-
-    def test_delete_repository(self, mock_responses, forgejo_adapter):
-        mock_responses.add(
-            responses.DELETE,
-            REPOS,
-            status=204,
-        )
-        forgejo_adapter.delete_repository()
-        assert mock_responses.calls[0].request.method == "DELETE"
-
-
-class TestListIssueTemplates:
-    """list_issue_templates のテスト。"""
-
-    def test_list_issue_templates(self, mock_responses, forgejo_adapter):
-        mock_responses.add(
-            responses.GET,
-            f"{REPOS}/issue_templates",
-            json=[
-                {
-                    "name": "Bug Report",
-                    "title": "[Bug]: ",
-                    "content": "## Description\n...",
-                    "about": "Report a bug",
-                    "labels": ["bug"],
-                },
-            ],
-            status=200,
-        )
-        templates = forgejo_adapter.list_issue_templates()
-        assert len(templates) == 1
-        assert templates[0].name == "Bug Report"
-        assert templates[0].labels == ("bug",)
-
-    def test_list_issue_templates_empty(self, mock_responses, forgejo_adapter):
-        mock_responses.add(
-            responses.GET,
-            f"{REPOS}/issue_templates",
-            json=[],
-            status=200,
-        )
-        templates = forgejo_adapter.list_issue_templates()
-        assert templates == []
-
-    def test_list_issue_templates_not_found(self, mock_responses, forgejo_adapter):
-        mock_responses.add(
-            responses.GET,
-            f"{REPOS}/issue_templates",
-            json={"message": "Not Found"},
-            status=404,
-        )
-        templates = forgejo_adapter.list_issue_templates()
-        assert templates == []


### PR DESCRIPTION
Refs #28（カテゴリ1: Gitea ファミリーの親クラス再テスト）

## 概要

`ForgejoAdapter` は `service_name` 以外を一切オーバーライドしないため、`test_forgejo.py` の CRUD / `_to_*` 挙動テストは `test_gitea.py` の完全な重複だった。Forgejo 固有の wiring だけを残す。

## 変更（`test_forgejo.py` のみ）

- **追加** `TestNoBehavioralOverrides`: `vars(ForgejoAdapter)` が `service_name` 以外を持たないことを保証。将来 override を足すとこのテストが落ち、当該挙動テストを追加する合図になる（**回帰検出力の安全網**）。
- **保持**: `TestRegistry` / `TestInheritance` / `TestGiteaApiCompatibility`（Gitea API 互換パス・limit ページネーション・refspec 形式）。
- **削除**（GiteaAdapter のテストが網羅する重複）: `_to_pull_request`、list/create/get/merge/close/reopen PR、list issues/repos、error handling、delete inheritance、issue templates。
- **522 → 137 行（−385）**。

## 検証

- `forgejo.py` カバレッジ **100% 維持**（クラス定義のみ・import で全行到達）。
- 全 **3840 passed**（削除した 30 件は gitea が同型で担保）。
- `ruff check` / `ruff format --check` green。

## スコープ

- 本 PR は #28 カテゴリ1 の Forgejo 分。Gogs は PR/Label 等を override するため別途精査が必要（後続 PR）。カテゴリ2/4/5/6 も後続。