### PR TITLE
test: Forgejo の機能別重複テストを削除（#28 カテゴリ1続き）

### DIFF
--- a/tests/test_adapters/test_browse.py
+++ b/tests/test_adapters/test_browse.py
@@ -277,65 +277,6 @@ class TestGiteaBrowse:
         )
 
 
-class TestForgejoBrowse:
-    def test_repo(self, forgejo_adapter):
-        assert forgejo_adapter.get_web_url() == "https://forgejo.example.com/test-owner/test-repo"
-
-    def test_pr(self, forgejo_adapter):
-        assert (
-            forgejo_adapter.get_web_url("pr", 42)
-            == "https://forgejo.example.com/test-owner/test-repo/pulls/42"
-        )
-
-    def test_pr_list(self, forgejo_adapter):
-        assert (
-            forgejo_adapter.get_web_url("pr")
-            == "https://forgejo.example.com/test-owner/test-repo/pulls"
-        )
-
-    def test_issue(self, forgejo_adapter):
-        assert (
-            forgejo_adapter.get_web_url("issue", 7)
-            == "https://forgejo.example.com/test-owner/test-repo/issues/7"
-        )
-
-    def test_issue_list(self, forgejo_adapter):
-        assert (
-            forgejo_adapter.get_web_url("issue")
-            == "https://forgejo.example.com/test-owner/test-repo/issues"
-        )
-
-    def test_release(self, forgejo_adapter):
-        assert (
-            forgejo_adapter.get_web_url("release", "v1.0.0")
-            == "https://forgejo.example.com/test-owner/test-repo/releases/tag/v1.0.0"
-        )
-
-    def test_release_list(self, forgejo_adapter):
-        assert (
-            forgejo_adapter.get_web_url("release")
-            == "https://forgejo.example.com/test-owner/test-repo/releases"
-        )
-
-    def test_milestone(self, forgejo_adapter):
-        assert (
-            forgejo_adapter.get_web_url("milestone", 3)
-            == "https://forgejo.example.com/test-owner/test-repo/milestones/3"
-        )
-
-    def test_milestone_list(self, forgejo_adapter):
-        assert (
-            forgejo_adapter.get_web_url("milestone")
-            == "https://forgejo.example.com/test-owner/test-repo/milestones"
-        )
-
-    def test_settings(self, forgejo_adapter):
-        assert (
-            forgejo_adapter.get_web_url("settings")
-            == "https://forgejo.example.com/test-owner/test-repo/settings"
-        )
-
-
 class TestGogsBrowse:
     def test_repo(self, gogs_adapter):
         assert gogs_adapter.get_web_url() == "https://gogs.example.com/test-owner/test-repo"

--- a/tests/test_adapters/test_gpg_key.py
+++ b/tests/test_adapters/test_gpg_key.py
@@ -336,41 +336,6 @@ class TestGiteaGpgKey:
             gitea_adapter.delete_gpg_key(key_id=999)
 
 
-# --- Forgejo (inherits Gitea) ---
-
-
-class TestForgejoGpgKey:
-    @responses.activate
-    def test_list(self, forgejo_adapter):
-        responses.add(
-            responses.GET,
-            "https://forgejo.example.com/api/v1/user/gpg_keys",
-            json=[_common_gpg_key_data()],
-        )
-        keys = forgejo_adapter.list_gpg_keys()
-        assert len(keys) == 1
-
-    @responses.activate
-    def test_create(self, forgejo_adapter):
-        responses.add(
-            responses.POST,
-            "https://forgejo.example.com/api/v1/user/gpg_keys",
-            json=_common_gpg_key_data(id=2),
-            status=201,
-        )
-        key = forgejo_adapter.create_gpg_key(armored_key="-----BEGIN PGP...")
-        assert key.id == 2
-
-    @responses.activate
-    def test_delete(self, forgejo_adapter):
-        responses.add(
-            responses.DELETE,
-            "https://forgejo.example.com/api/v1/user/gpg_keys/1",
-            status=204,
-        )
-        forgejo_adapter.delete_gpg_key(key_id=1)
-
-
 # --- NotSupported ---
 
 

--- a/tests/test_adapters/test_notification.py
+++ b/tests/test_adapters/test_notification.py
@@ -261,48 +261,6 @@ class TestGiteaNotification:
             gitea_adapter.list_notifications()
 
 
-# --- Forgejo ---
-
-
-class TestForgejoNotification:
-    @responses.activate
-    def test_list(self, forgejo_adapter):
-        responses.add(
-            responses.GET,
-            "https://forgejo.example.com/api/v1/notifications",
-            json=[_gitea_notification_data()],
-        )
-        notifs = forgejo_adapter.list_notifications()
-        assert len(notifs) == 1
-
-    @responses.activate
-    def test_mark_read(self, forgejo_adapter):
-        responses.add(
-            responses.PATCH,
-            "https://forgejo.example.com/api/v1/notifications/threads/1",
-            status=205,
-        )
-        forgejo_adapter.mark_notification_read("1")
-
-    @responses.activate
-    def test_mark_all_read(self, forgejo_adapter):
-        responses.add(
-            responses.PUT,
-            "https://forgejo.example.com/api/v1/notifications",
-            status=205,
-        )
-        forgejo_adapter.mark_all_notifications_read()
-
-    @responses.activate
-    def test_list_empty(self, forgejo_adapter):
-        responses.add(
-            responses.GET,
-            "https://forgejo.example.com/api/v1/notifications",
-            json=[],
-        )
-        assert forgejo_adapter.list_notifications() == []
-
-
 # --- Backlog ---
 
 

--- a/tests/test_adapters/test_org.py
+++ b/tests/test_adapters/test_org.py
@@ -376,41 +376,6 @@ class TestGiteaOrg:
             gitea_adapter.get_organization("missing")
 
 
-# --- Forgejo ---
-
-
-class TestForgejoOrg:
-    @responses.activate
-    def test_list(self, forgejo_adapter):
-        responses.add(
-            responses.GET,
-            "https://forgejo.example.com/api/v1/user/orgs",
-            json=[_gitea_org_data()],
-        )
-        orgs = forgejo_adapter.list_organizations()
-        assert len(orgs) == 1
-
-    @responses.activate
-    def test_view(self, forgejo_adapter):
-        responses.add(
-            responses.GET,
-            "https://forgejo.example.com/api/v1/orgs/my-org",
-            json=_gitea_org_data(),
-        )
-        org = forgejo_adapter.get_organization("my-org")
-        assert org.name == "my-org"
-        assert org.display_name == "My Organization"
-
-    @responses.activate
-    def test_list_empty(self, forgejo_adapter):
-        responses.add(
-            responses.GET,
-            "https://forgejo.example.com/api/v1/user/orgs",
-            json=[],
-        )
-        assert forgejo_adapter.list_organizations() == []
-
-
 # --- Gogs ---
 
 
@@ -662,29 +627,6 @@ class TestGiteaOrgCreateDelete:
         responses.add(responses.DELETE, "https://gitea.example.com/api/v1/orgs/missing", status=404)
         with pytest.raises(NotFoundError):
             gitea_adapter.delete_organization("missing")
-
-
-# --- Forgejo create/delete (inherited from Gitea) ---
-
-
-class TestForgejoOrgCreateDelete:
-    @responses.activate
-    def test_create(self, forgejo_adapter):
-        responses.add(
-            responses.POST,
-            "https://forgejo.example.com/api/v1/orgs",
-            json=_gitea_org_data(),
-            status=201,
-        )
-        org = forgejo_adapter.create_organization("my-org")
-        assert org.name == "my-org"
-
-    @responses.activate
-    def test_delete(self, forgejo_adapter):
-        responses.add(
-            responses.DELETE, "https://forgejo.example.com/api/v1/orgs/my-org", status=204
-        )
-        forgejo_adapter.delete_organization("my-org")
 
 
 # --- Gogs create/delete (inherited from Gitea) ---

--- a/tests/test_adapters/test_ssh_key.py
+++ b/tests/test_adapters/test_ssh_key.py
@@ -326,41 +326,6 @@ class TestGiteaSshKey:
             gitea_adapter.delete_ssh_key(key_id=999)
 
 
-# --- Forgejo (inherits Gitea) ---
-
-
-class TestForgejoSshKey:
-    @responses.activate
-    def test_list(self, forgejo_adapter):
-        responses.add(
-            responses.GET,
-            "https://forgejo.example.com/api/v1/user/keys",
-            json=[_common_ssh_key_data()],
-        )
-        keys = forgejo_adapter.list_ssh_keys()
-        assert len(keys) == 1
-
-    @responses.activate
-    def test_create(self, forgejo_adapter):
-        responses.add(
-            responses.POST,
-            "https://forgejo.example.com/api/v1/user/keys",
-            json=_common_ssh_key_data(id=2),
-            status=201,
-        )
-        key = forgejo_adapter.create_ssh_key(title="k", key="ssh-rsa X")
-        assert key.id == 2
-
-    @responses.activate
-    def test_delete(self, forgejo_adapter):
-        responses.add(
-            responses.DELETE,
-            "https://forgejo.example.com/api/v1/user/keys/1",
-            status=204,
-        )
-        forgejo_adapter.delete_ssh_key(key_id=1)
-
-
 # --- Gogs (inherits Gitea) ---
 
 


### PR DESCRIPTION
Refs #28（カテゴリ1: Gitea ファミリーの親クラス再テスト・残りファイル）

## 概要

PR #35（test_forgejo.py 本体）に続き、機能別テストファイルに散在する Forgejo 重複クラスを削除する。`ForgejoAdapter` は `service_name` 以外を override しないため、これらは `test_gitea.py` の URL 違い複製にすぎない。

## 変更（5 ファイル・計 −229 行）

- `test_browse.py`: `TestForgejoBrowse`
- `test_ssh_key.py`: `TestForgejoSshKey`
- `test_gpg_key.py`: `TestForgejoGpgKey`
- `test_notification.py`: `TestForgejoNotification`
- `test_org.py`: `TestForgejoOrg` / `TestForgejoOrgCreateDelete`

## 安全性

- 回帰検出は **#35 で追加した `TestNoBehavioralOverrides`**（Forgejo が service_name 以外を override したら落ちるガード）+ `GiteaAdapter` のテストで担保。
- **Gogs は残す**: PR/Label/Release 等を実際に NotSupported override しており、挙動が Gitea と異なるため。

## 検証

- 全 **3815 passed**（削除した 25 件は gitea が同型で担保）。
- `ruff check` / `ruff format --check` green。