### PR TITLE
test: dataclass frozen 集約と冗長 filter テスト削除（#28 カテゴリ5/6）

### DIFF
--- a/tests/test_adapter_base.py
+++ b/tests/test_adapter_base.py
@@ -18,6 +18,82 @@ from gfo.exceptions import NotSupportedError
 from tests.conftest import StubAdapter
 
 
+class TestDataclassesFrozen:
+    """主要データクラスは frozen=True（.claude/rules/02-adapter-common.md の規約）。
+
+    各データクラスで個別に書いていた test_frozen を 1 表に集約。
+    """
+
+    @pytest.mark.parametrize(
+        ("instance", "attr"),
+        [
+            (
+                PullRequest(
+                    number=1,
+                    title="t",
+                    body=None,
+                    state="open",
+                    author="a",
+                    source_branch="b",
+                    target_branch="main",
+                    draft=False,
+                    url="u",
+                    created_at="c",
+                    updated_at=None,
+                ),
+                "title",
+            ),
+            (
+                Issue(
+                    number=1,
+                    title="t",
+                    body=None,
+                    state="open",
+                    author="a",
+                    assignees=[],
+                    labels=[],
+                    url="u",
+                    created_at="c",
+                ),
+                "state",
+            ),
+            (
+                Repository(
+                    name="n",
+                    full_name="o/n",
+                    description=None,
+                    visibility="public",
+                    default_branch="main",
+                    clone_url="c",
+                    url="u",
+                ),
+                "name",
+            ),
+            (
+                Release(
+                    tag="v1",
+                    title="t",
+                    body=None,
+                    draft=False,
+                    prerelease=False,
+                    url="u",
+                    created_at="c",
+                ),
+                "tag",
+            ),
+            (Label(name="bug", color=None, description=None), "name"),
+            (
+                Milestone(number=1, title="v1", description=None, state="open", due_date=None),
+                "state",
+            ),
+        ],
+        ids=["pull_request", "issue", "repository", "release", "label", "milestone"],
+    )
+    def test_frozen(self, instance, attr):
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            setattr(instance, attr, "changed")
+
+
 class TestPullRequest:
     def test_create(self):
         pr = PullRequest(
@@ -53,23 +129,6 @@ class TestPullRequest:
         )
         assert pr.updated_at is None
 
-    def test_frozen(self):
-        pr = PullRequest(
-            number=1,
-            title="t",
-            body=None,
-            state="open",
-            author="a",
-            source_branch="b",
-            target_branch="main",
-            draft=False,
-            url="u",
-            created_at="c",
-            updated_at=None,
-        )
-        with pytest.raises(dataclasses.FrozenInstanceError):
-            pr.title = "changed"  # type: ignore[misc]
-
 
 class TestIssue:
     def test_create(self):
@@ -87,21 +146,6 @@ class TestIssue:
         assert issue.number == 42
         assert issue.labels == ["bug", "high"]
         assert issue.body is None
-
-    def test_frozen(self):
-        issue = Issue(
-            number=1,
-            title="t",
-            body=None,
-            state="open",
-            author="a",
-            assignees=[],
-            labels=[],
-            url="u",
-            created_at="c",
-        )
-        with pytest.raises(dataclasses.FrozenInstanceError):
-            issue.state = "closed"  # type: ignore[misc]
 
 
 class TestGitHubLikeAdapterToIssue:
@@ -167,19 +211,6 @@ class TestRepository:
         assert repo.description is None
         assert repo.default_branch is None
 
-    def test_frozen(self):
-        repo = Repository(
-            name="gfo",
-            full_name="owner/gfo",
-            description=None,
-            visibility="public",
-            default_branch="main",
-            clone_url="c",
-            url="u",
-        )
-        with pytest.raises(dataclasses.FrozenInstanceError):
-            repo.name = "other"  # type: ignore[misc]
-
 
 class TestRelease:
     def test_create(self):
@@ -195,19 +226,6 @@ class TestRelease:
         assert release.tag == "v1.0.0"
         assert release.draft is False
 
-    def test_frozen(self):
-        release = Release(
-            tag="v1.0.0",
-            title="t",
-            body=None,
-            draft=False,
-            prerelease=False,
-            url="u",
-            created_at="c",
-        )
-        with pytest.raises(dataclasses.FrozenInstanceError):
-            release.tag = "v2.0.0"  # type: ignore[misc]
-
 
 class TestLabel:
     def test_create(self):
@@ -219,11 +237,6 @@ class TestLabel:
         label = Label(name="bug", color=None, description=None)
         assert label.color is None
         assert label.description is None
-
-    def test_frozen(self):
-        label = Label(name="bug", color=None, description=None)
-        with pytest.raises(dataclasses.FrozenInstanceError):
-            label.name = "feature"  # type: ignore[misc]
 
 
 class TestGitServiceAdapterDeleteDefaults:
@@ -281,11 +294,6 @@ class TestMilestone:
         )
         assert ms.description is None
         assert ms.due_date is None
-
-    def test_frozen(self):
-        ms = Milestone(number=1, title="v1.0", description=None, state="open", due_date=None)
-        with pytest.raises(dataclasses.FrozenInstanceError):
-            ms.state = "closed"  # type: ignore[misc]
 
 
 class TestGetCurrentUsername:

--- a/tests/test_commands/test_pr.py
+++ b/tests/test_commands/test_pr.py
@@ -81,20 +81,9 @@ class TestHandleList:
             milestone=None,
         )
 
-    def test_default_filter_params_are_none(self, sample_config, mock_adapter, capsys):
-        args = make_args(state="open", limit=30)
-        with _patch_all(sample_config, mock_adapter):
-            pr_cmd.handle_list(args, fmt="table")
-
-        call_kwargs = mock_adapter.list_pull_requests.call_args.kwargs
-        assert call_kwargs["author"] is None
-        assert call_kwargs["label"] is None
-        assert call_kwargs["assignee"] is None
-        assert call_kwargs["search"] is None
-        assert call_kwargs["base"] is None
-        assert call_kwargs["head"] is None
-        assert call_kwargs["draft"] is None
-        assert call_kwargs["milestone"] is None
+    # NOTE: フィルタ未指定時に全 filter kwargs が None になることは
+    # test_calls_list_pull_requests の assert_called_once_with(...) が完全に検証済み。
+    # 同内容を個別 assert で重複させていた test_default_filter_params_are_none は削除。
 
     def test_outputs_results(self, sample_config, mock_adapter, capsys):
         args = make_args(state="open", limit=30)


### PR DESCRIPTION
Refs #28（カテゴリ5: 冗長・脆いテスト / カテゴリ6: 自明な形状テスト）

## 変更

### カテゴリ6
- `test_adapter_base.py`: 6 データクラスに個別定義されていた `test_frozen` を `TestDataclassesFrozen` の `@pytest.mark.parametrize` 1 表に集約（`PullRequest` / `Issue` / `Repository` / `Release` / `Label` / `Milestone`）。検証（`frozen=True`）は不変。

### カテゴリ5
- `test_pr.py`: `test_default_filter_params_are_none` を削除。filter 未指定時に全 kwargs が `None` になることは `test_calls_list_pull_requests` の `assert_called_once_with(...)` が完全検証済みで、個別 assert は重複。

## 判断（残置したもの）

精査の結果、以下は **意図的に残置**（issue の「回帰検出力を落とさず」に従う）:
- `test_schema.py` の description 網羅・`_OUTPUT_MAP` カバレッジ・`__abstractmethods__` ガード → 有用な不変条件（コマンド追加時の漏れを検出）。
- `test_pr.py` / `test_repo.py` の full-kwargs `assert_called_once_with` → アダプタ契約の明示として妥当。partial assert への置換は検証を弱めるため見送り。
- `test_label.py` の table 出力 substring（`#d73a4a` 等）→ 安定文字列で format-order 非依存。table 固有レンダリングの検証として価値あり。

## 検証

- 全 **3793 passed**（frozen は 6 ケース parametrize で挙動維持、削除は重複分のみ）。
- `ruff check` / `ruff format --check` green。