### PR TITLE
test: upload retry テストの実 sleep を mock し 1s×2 を除去

### DIFF
--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1415,8 +1415,10 @@ class TestExtractNextLink:
 
 class TestUploadFileRetry:
     @responses.activate
-    def test_upload_file_retry_sends_data_on_second_attempt(self, tmp_path):
+    def test_upload_file_retry_sends_data_on_second_attempt(self, tmp_path, monkeypatch):
         """429 → 200 リトライで2回目もファイルデータが送信されることを検証する。"""
+        # Retry-After:0 は下限 1s にクランプされるため実 sleep を無効化する (検証対象は body)。
+        monkeypatch.setattr("gfo.http.time.sleep", lambda _: None)
         test_file = tmp_path / "test.bin"
         test_file.write_bytes(b"hello world")
         client = HttpClient(BASE, auth_header={"Authorization": "Bearer tok"}, max_retries=1)
@@ -1438,8 +1440,10 @@ class TestUploadFileRetry:
         assert responses.calls[1].request.body == b"hello world"
 
     @responses.activate
-    def test_upload_multipart_retry_sends_data_on_second_attempt(self, tmp_path):
+    def test_upload_multipart_retry_sends_data_on_second_attempt(self, tmp_path, monkeypatch):
         """429 → 200 リトライで multipart でも2回目にデータが送信されることを検証する。"""
+        # Retry-After:0 は下限 1s にクランプされるため実 sleep を無効化する (検証対象は body)。
+        monkeypatch.setattr("gfo.http.time.sleep", lambda _: None)
         test_file = tmp_path / "test.bin"
         test_file.write_bytes(b"binary data")
         client = HttpClient(BASE, auth_header={"Authorization": "Bearer tok"}, max_retries=1)


### PR DESCRIPTION
## 概要

`tests/test_http.py::TestUploadFileRetry` の 2 テストが durations 上位を独占（各 **1.00s**）していたため、実 sleep を mock して除去する。

## 原因

両テストは `Retry-After: 0` を送るが、`_parse_retry_after` が **下限 1s にクランプ**（`max(1, min(int(value), _MAX_RETRY_AFTER))`）するため、リトライ時に実 `time.sleep(1)` が走っていた。

## 変更

- 両テストに `monkeypatch` を追加し `gfo.http.time.sleep` を no-op に（既存の `test_429_retry_*` と同手法）。
- 検証対象は「2 回目リクエストに body が送られること」であり sleep 時間ではないため、回帰検出力は不変。

## 効果（ローカル実測）

- クラス所要: ~2s → **0.21s**
- 全スイート: 7.69s → 7.07s、**3793 passed**（回帰なし）
- durations 上位の 1.00s 外れ値が消え、トップは 0.29s（`python -m gfo` サブプロセス起動=本質的コスト）に。

🤖 Generated with [Claude Code](https://claude.com/claude-code)