### PR TITLE
fix(http): host検証の末尾ドット正規化と絶対URLのTLS検証強化

### DIFF
--- a/src/gfo/http.py
+++ b/src/gfo/http.py
@@ -85,7 +85,9 @@ def _is_cloud_host_tls_forced(host: str | None) -> bool:
     """クラウド固定ホスト（GFO_INSECURE で TLS 無効化を許さないホスト）かを判定する。"""
     if not host:
         return False
-    h = host.lower()
+    # 末尾ドット付き FQDN（例: "github.com."）も同一ホストとして正規化する。
+    # 正規化しないとクラウド固定ホストの TLS 強制判定を素通りしてしまう。
+    h = host.lower().rstrip(".")
     if h in _CLOUD_HOSTS_TLS_FORCED:
         return True
     return any(h.endswith(s) for s in _CLOUD_HOST_SUFFIXES_TLS_FORCED)
@@ -397,6 +399,9 @@ class HttpClient:
                     data=f,
                     headers=upload_headers,
                     timeout=timeout,
+                    # 呼び出し側指定の絶対 URL。クラウド固定ホスト宛なら GFO_INSECURE
+                    # でも TLS 検証を強制する（self-hosted base での upload 先漏えい防止）。
+                    verify=_verify_for_url(url),
                 )
 
         return self._retry_loop(_post)
@@ -443,7 +448,11 @@ class HttpClient:
         """
         merged_params = {**self._default_params, **self._auth_params, **(params or {})}
         return self._retry_loop(
-            lambda: self._session.get(url, params=merged_params, timeout=timeout)
+            # 呼び出し側指定の絶対 URL。クラウド固定ホスト宛なら GFO_INSECURE でも
+            # TLS 検証を強制する（self-hosted base からの absolute URL 取得時の保護）。
+            lambda: self._session.get(
+                url, params=merged_params, timeout=timeout, verify=_verify_for_url(url)
+            )
         )
 
     def _handle_response(self, response: requests.Response) -> None:

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -102,6 +102,24 @@ class TestTlsVerifyPolicy:
         assert _is_cloud_host_tls_forced("GitHub.com") is True
         assert _is_cloud_host_tls_forced("MYSPACE.BACKLOG.COM") is True
 
+    def test_trailing_dot_fqdn_normalized(self):
+        """末尾ドット付き FQDN もクラウド固定ホストとして判定する（TLS 強制すり抜け防止）。"""
+        from gfo.http import _is_cloud_host_tls_forced
+
+        assert _is_cloud_host_tls_forced("github.com.") is True
+        assert _is_cloud_host_tls_forced("api.github.com.") is True
+        assert _is_cloud_host_tls_forced("GitHub.com.") is True
+        assert _is_cloud_host_tls_forced("myspace.backlog.com.") is True
+
+    def test_trailing_dot_verify_forced_under_insecure(self, monkeypatch):
+        """GFO_INSECURE 相当 (_VERIFY_SSL=False) でも末尾ドット cloud host は TLS 検証する。"""
+        import gfo.http
+
+        monkeypatch.setattr(gfo.http, "_VERIFY_SSL", False)
+        assert gfo.http._verify_for_url("https://github.com./o/r") is True
+        # self-hosted は従来どおり _VERIFY_SSL に従う
+        assert gfo.http._verify_for_url("https://internal.example.com/x") is False
+
     def test_none_returns_false(self):
         from gfo.http import _is_cloud_host_tls_forced
 
@@ -1480,6 +1498,52 @@ class TestUploadFileRetry:
         resp = client.upload_file_absolute(upload_url, str(test_file), name="asset.zip")
         assert resp.status_code == 201
         assert responses.calls[0].request.body == b"zip content"
+
+    def test_upload_file_absolute_forces_tls_for_cloud_url(self, tmp_path, monkeypatch):
+        """self-hosted base (_VERIFY_SSL=False) でも cloud 宛 absolute upload は verify=True。"""
+        from unittest.mock import MagicMock
+
+        import gfo.http
+
+        monkeypatch.setattr(gfo.http, "_VERIFY_SSL", False)
+        test_file = tmp_path / "a.zip"
+        test_file.write_bytes(b"x")
+        client = HttpClient("https://internal.example.com")  # self-hosted base
+        captured: dict = {}
+        fake_resp = MagicMock()
+        fake_resp.status_code = 201
+
+        def fake_post(url, **kwargs):
+            captured.update(kwargs)
+            return fake_resp
+
+        monkeypatch.setattr(client._session, "post", fake_post)
+        client.upload_file_absolute(
+            "https://uploads.github.com/repos/o/r/releases/1/assets",
+            str(test_file),
+            name="a.zip",
+        )
+        assert captured["verify"] is True
+
+    def test_get_absolute_forces_tls_for_cloud_url(self, monkeypatch):
+        """self-hosted base (_VERIFY_SSL=False) でも cloud 宛 absolute GET は verify=True。"""
+        from unittest.mock import MagicMock
+
+        import gfo.http
+
+        monkeypatch.setattr(gfo.http, "_VERIFY_SSL", False)
+        client = HttpClient("https://internal.example.com")  # self-hosted base
+        captured: dict = {}
+        fake_resp = MagicMock()
+        fake_resp.status_code = 200
+
+        def fake_get(url, **kwargs):
+            captured.update(kwargs)
+            return fake_resp
+
+        monkeypatch.setattr(client._session, "get", fake_get)
+        client.get_absolute("https://api.github.com/repos/o/r/releases")
+        assert captured["verify"] is True
 
     @responses.activate
     def test_upload_multipart_name_override(self, tmp_path):


### PR DESCRIPTION
## 概要

セキュリティ監査由来の TLS ハードニング 2 点（`tmp/security-audit-*.md`）。

### 1. 末尾ドット FQDN の正規化
`_is_cloud_host_tls_forced` は `urlparse().hostname` の値をそのまま判定していたため、末尾ドット付き FQDN（`github.com.` 等、DNS 上は同一ホスト）が固定ホスト集合にもサフィックスにも一致せず、`GFO_INSECURE=1` 時にクラウドホストの TLS 検証が無効化され得た。`rstrip(".")` で正規化する。

### 2. 絶対 URL の per-URL TLS 検証
`upload_file_absolute` / `get_absolute` は呼び出し側指定の絶対 URL に対し、`session.verify`（`base_url` から init 時に固定）を使っていた。self-hosted base ＋ `GFO_INSECURE=1` の状態で cloud 宛（`uploads.github.com` 等）にリクエストする際、TLS 検証が無効のままになる。`request_stream` と同様に per-URL の `_verify_for_url(url)` を渡して、クラウド固定ホスト宛は常に TLS 検証する。

## テスト
- 末尾ドット: `_is_cloud_host_tls_forced` / `_verify_for_url` の判定を追加検証。
- 絶対 URL: self-hosted base + `_VERIFY_SSL=False` でも cloud 宛 `upload_file_absolute` / `get_absolute` が `verify=True` になることを検証。

全 3797 件 green。挙動互換: 通常の cloud/self-hosted 利用に変化なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)