### PR TITLE
chore(security): .env を .gitignore に追加し誤コミット防止

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,9 @@ build/
 coverage.xml
 htmlcov/
 tests/integration/.env
+# プロジェクト直下や任意階層の .env（トークン等）の誤コミットを防ぐ。
+# 例として配布する .env.example は追跡対象に残す。
+.env
+.env.*
+!.env.example
 *.mo


### PR DESCRIPTION
## 概要

監査由来（`tmp/security-audit-*.md`）。従来 `.gitignore` は `tests/integration/.env` のみを無視しており、プロジェクト直下や任意階層の `.env`（トークン等を含み得る）が追跡対象になり得た。public リポジトリでの秘密情報の誤コミットを防ぐ。

## 変更
- `.env` / `.env.*` を無視。
- 配布用の `.env.example` は `!.env.example` で追跡対象に残す（`tests/integration/.env.example` が無視されないことを `git check-ignore` で確認済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)