### PR TITLE
fix: 監査で確証された High 3件を修正（reviewers list クラッシュ / merge ブランチ破壊 / Gitea ラベル取りこぼし）

### DIFF
--- a/src/gfo/adapter/gitea.py
+++ b/src/gfo/adapter/gitea.py
@@ -696,8 +696,16 @@ class GiteaAdapter(GitHubLikeAdapter, GitServiceAdapter):
         return self._to_label(resp.json())
 
     def delete_label(self, *, name: str) -> None:
-        resp = self._client.get(f"{self._repos_path()}/labels")
-        for label in resp.json():
+        # ラベル一覧はデフォルトで先頭ページ（約30件）しか返さないため、
+        # 単発 GET だと30件超のリポジトリで実在ラベルを取りこぼし false
+        # NotFoundError になる。list_labels と同様に全件取得する。
+        labels = paginate_link_header(
+            self._client,
+            f"{self._repos_path()}/labels",
+            per_page_key="limit",
+            limit=0,
+        )
+        for label in labels:
             if label.get("name") == name:
                 self._client.delete(f"{self._repos_path()}/labels/{label['id']}")
                 return
@@ -711,9 +719,15 @@ class GiteaAdapter(GitHubLikeAdapter, GitServiceAdapter):
         color: str | None = None,
         description: str | None = None,
     ) -> Label:
-        resp = self._client.get(f"{self._repos_path()}/labels")
+        # delete_label と同じ理由でページネーションして全件取得する。
+        labels = paginate_link_header(
+            self._client,
+            f"{self._repos_path()}/labels",
+            per_page_key="limit",
+            limit=0,
+        )
         label_id = None
-        for label in resp.json():
+        for label in labels:
             if label.get("name") == name:
                 label_id = label["id"]
                 break

--- a/src/gfo/commands/pr.py
+++ b/src/gfo/commands/pr.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import argparse
+import json
 
 import gfo.git_util
 from gfo.commands import get_adapter, open_in_browser, read_file_arg
 from gfo.exceptions import ConfigError
 from gfo.i18n import _
-from gfo.output import output
+from gfo.output import apply_jq_filter, output
 
 
 def handle_list(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -88,6 +89,19 @@ def handle_merge(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -
     import warnings
 
     adapter = get_adapter()
+    # --delete-branch は実際のマージ完了後にのみブランチを削除する。
+    # --auto は「予約」のみで即時マージしないため、併用するとマージ前に
+    # ソースブランチが消える。--disable-auto も同様にマージしない。
+    # 即時削除の意味論を満たせない組み合わせは明示的に拒否する。
+    if getattr(args, "delete_branch", False) and (
+        getattr(args, "auto", False) or getattr(args, "disable_auto", False)
+    ):
+        raise ConfigError(
+            _(
+                "--delete-branch cannot be combined with --auto/--disable-auto "
+                "(the branch would be deleted before the merge completes)."
+            )
+        )
     if getattr(args, "squash", False):
         method = "squash"
     elif getattr(args, "rebase", False):
@@ -218,8 +232,19 @@ def handle_reviewers(args: argparse.Namespace, *, fmt: str, jq: str | None = Non
         adapter.remove_reviewers(args.number, args.users)
         print(_("Removed reviewers from PR #{number}.").format(number=args.number))
     else:
+        # list_requested_reviewers は list[str] を返すため output() は使えない
+        # (dataclass を前提に fields/asdict を呼びクラッシュする)。
+        # collaborator / org members 同様、apply_jq_filter を直接適用する。
         reviewers = adapter.list_requested_reviewers(args.number)
-        output(reviewers, fmt=fmt, jq=jq)
+        if fmt == "json":
+            json_str = json.dumps(reviewers, ensure_ascii=False)
+            if jq is not None:
+                print(apply_jq_filter(json_str, jq))
+            else:
+                print(json_str)
+        else:
+            for reviewer in reviewers:
+                print(reviewer)
 
 
 def handle_update_branch(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:

--- a/tests/test_adapters/test_gitea.py
+++ b/tests/test_adapters/test_gitea.py
@@ -1517,6 +1517,27 @@ class TestDeleteLabel:
         with pytest.raises(NotFoundError):
             gitea_adapter.delete_label(name="bug")
 
+    def test_delete_label_on_second_page(self, mock_responses, gitea_adapter):
+        """先頭ページに無いラベルも全件取得して削除できること（取りこぼし回帰）。"""
+        # 1 ページ目（Link ヘッダで 2 ページ目を示す。目的のラベルは無い）
+        mock_responses.add(
+            responses.GET,
+            f"{REPOS}/labels",
+            json=[{"id": 1, "name": "other", "color": "d73a4a", "description": ""}],
+            status=200,
+            headers={"Link": f'<{REPOS}/labels?page=2>; rel="next"'},
+        )
+        # 2 ページ目（目的のラベルはこちら）
+        mock_responses.add(
+            responses.GET,
+            f"{REPOS}/labels",
+            json=[{"id": 99, "name": "bug", "color": "d73a4a", "description": ""}],
+            status=200,
+        )
+        mock_responses.add(responses.DELETE, f"{REPOS}/labels/99", status=204)
+        gitea_adapter.delete_label(name="bug")
+        assert mock_responses.calls[-1].request.url.endswith("/labels/99")
+
 
 class TestUpdateLabel:
     def test_update(self, mock_responses, gitea_adapter):
@@ -1580,6 +1601,31 @@ class TestUpdateLabel:
         assert "name" not in req_body
         assert "color" not in req_body
         assert "description" not in req_body
+
+    def test_update_label_on_second_page(self, mock_responses, gitea_adapter):
+        """先頭ページに無いラベルも全件取得して更新できること（取りこぼし回帰）。"""
+        mock_responses.add(
+            responses.GET,
+            f"{REPOS}/labels",
+            json=[{"id": 1, "name": "other", "color": "d73a4a", "description": ""}],
+            status=200,
+            headers={"Link": f'<{REPOS}/labels?page=2>; rel="next"'},
+        )
+        mock_responses.add(
+            responses.GET,
+            f"{REPOS}/labels",
+            json=[{"id": 99, "name": "bug", "color": "d73a4a", "description": ""}],
+            status=200,
+        )
+        mock_responses.add(
+            responses.PATCH,
+            f"{REPOS}/labels/99",
+            json=_label_data(name="bug-fix"),
+            status=200,
+        )
+        label = gitea_adapter.update_label(name="bug", new_name="bug-fix")
+        assert label.name == "bug-fix"
+        assert mock_responses.calls[-1].request.url.endswith("/labels/99")
 
 
 class TestDeleteMilestone:

--- a/tests/test_commands/test_pr.py
+++ b/tests/test_commands/test_pr.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -710,6 +711,33 @@ class TestHandleReviewers:
         out = capsys.readouterr().out
         assert "[]" in out
 
+    def test_list_action_non_empty_json(self, capsys):
+        """list[str] を json 出力してもクラッシュしないこと（output() 誤用の回帰）。"""
+        with patch_adapter("gfo.commands.pr") as adapter:
+            adapter.list_requested_reviewers.return_value = ["alice", "bob"]
+            args = make_args(number=1, reviewer_action=None)
+            pr_cmd.handle_reviewers(args, fmt="json")
+        out = capsys.readouterr().out
+        assert json.loads(out) == ["alice", "bob"]
+
+    def test_list_action_non_empty_table(self, capsys):
+        """table 出力では各レビュアーを1行ずつ表示すること。"""
+        with patch_adapter("gfo.commands.pr") as adapter:
+            adapter.list_requested_reviewers.return_value = ["alice", "bob"]
+            args = make_args(number=1, reviewer_action=None)
+            pr_cmd.handle_reviewers(args, fmt="table")
+        out = capsys.readouterr().out
+        assert out.splitlines() == ["alice", "bob"]
+
+    def test_list_action_jq(self, capsys):
+        """--jq が list[str] 出力に接続されていること。"""
+        with patch_adapter("gfo.commands.pr") as adapter:
+            adapter.list_requested_reviewers.return_value = ["alice", "bob"]
+            args = make_args(number=1, reviewer_action=None)
+            pr_cmd.handle_reviewers(args, fmt="json", jq=".[0]")
+        out = capsys.readouterr().out
+        assert "alice" in out
+
     def test_add_action(self):
         with patch_adapter("gfo.commands.pr") as adapter:
             args = make_args(number=1, reviewer_action="add", users=["user1", "user2"])
@@ -759,6 +787,15 @@ class TestHandleMergeAuto:
             assert "--subject/--body" in str(w[0].message)
         adapter.enable_auto_merge.assert_called_once()
 
+    def test_auto_with_delete_branch_raises(self):
+        """--auto + --delete-branch はマージ前にブランチが消えるため拒否すること。"""
+        with patch_adapter("gfo.commands.pr") as adapter:
+            args = make_args(number=1, squash=False, auto=True, delete_branch=True)
+            with pytest.raises(ConfigError, match="--delete-branch cannot be combined"):
+                pr_cmd.handle_merge(args, fmt="table")
+        adapter.enable_auto_merge.assert_not_called()
+        adapter.delete_branch.assert_not_called()
+
 
 class TestHandleMergeDisableAuto:
     def test_disable_auto_merge_calls_adapter(self):
@@ -767,6 +804,15 @@ class TestHandleMergeDisableAuto:
             pr_cmd.handle_merge(args, fmt="table")
         adapter.disable_auto_merge.assert_called_once_with(1)
         adapter.merge_pull_request.assert_not_called()
+
+    def test_disable_auto_with_delete_branch_raises(self):
+        """--disable-auto + --delete-branch も同様に拒否すること。"""
+        with patch_adapter("gfo.commands.pr") as adapter:
+            args = make_args(number=1, squash=False, disable_auto=True, delete_branch=True)
+            with pytest.raises(ConfigError, match="--delete-branch cannot be combined"):
+                pr_cmd.handle_merge(args, fmt="table")
+        adapter.disable_auto_merge.assert_not_called()
+        adapter.delete_branch.assert_not_called()
         adapter.enable_auto_merge.assert_not_called()
 
     def test_disable_auto_prints_message(self, capsys):


### PR DESCRIPTION
多エージェント監査（ultracode）で確証された **High** 3 件を、いずれも回帰テスト付きで修正する。Critical 級の欠陥は検出されず、本 PR は確実にユーザー操作で発火する 3 件に絞る。

## 修正内容

### 1. `gfo pr reviewers list` が必ずクラッシュ (`commands/pr.py`)
`list_requested_reviewers()` の返す `list[str]` を `output()` に渡しており、`output()` が dataclass を前提に `fields`/`asdict` を呼ぶため `TypeError`。レビュアーが1人でも要求されている PR で table/json/plain いずれでも失敗していた。`02-adapter-common.md` の「`list[str]` を返すハンドラは `apply_jq_filter` を直接適用」に違反。collaborator / org members と同じ分岐に置換し `--jq` も接続。

### 2. `pr merge --auto/--disable-auto` + `--delete-branch` で未マージのままブランチ削除 (`commands/pr.py`)
auto-merge は予約のみで即時マージしないのに、末尾で無条件にソースブランチを削除しており、未マージの作業ブランチを破壊していた。即時削除の意味論を満たせない組み合わせを `ConfigError` で明示拒否する。

### 3. Gitea `delete_label`/`update_label` がラベル一覧を全件取得せず取りこぼす (`adapter/gitea.py`)
単発 GET では先頭ページ（約30件）しか返らず、30件超のリポジトリで実在ラベルに false `NotFoundError`。`list_labels` 同様 `paginate_link_header(limit=0)` で全件取得に修正。Forgejo/Gogs も継承するため波及。

## テスト
- 非空 `list[str]` の json/table/jq 出力、矛盾フラグ拒否（`--auto`/`--disable-auto` × `--delete-branch`）の回帰テスト
- ラベルが2ページ目にあるケースの delete/update 回帰テスト
- ruff / ruff format / mypy / bandit / pytest（3807 passed）すべて green

🤖 Generated with [Claude Code](https://claude.com/claude-code)