### PR TITLE
fix: 監査の高インパクト横断3件（フィルタ前limit / gfo api トークン送出 / time entry 加算）

### DIFF
--- a/src/gfo/adapter/azure_devops.py
+++ b/src/gfo/adapter/azure_devops.py
@@ -1698,7 +1698,10 @@ class AzureDevOpsAdapter(GitServiceAdapter):
         resp = self._client.get(f"{self._wit_path()}/workitems/{number}/updates")
         updates = resp.json().get("value") or []
         events = []
-        for u in updates[:limit]:
+        # detail の無い update（フィールド変更を伴わないリビジョン）は除外する。
+        # フィルタ前に limit で切ると、先頭が空 detail の update のとき有効な
+        # イベントを取りこぼすため、全件走査してから limit を適用する。
+        for u in updates:
             fields = u.get("fields") or {}
             detail_parts = []
             for field_name, change in fields.items():
@@ -1719,6 +1722,8 @@ class AzureDevOpsAdapter(GitServiceAdapter):
                         detail="; ".join(detail_parts[:3]),
                     )
                 )
+        if limit > 0:
+            events = events[:limit]
         return events
 
     # --- Search PRs ---
@@ -1783,8 +1788,22 @@ class AzureDevOpsAdapter(GitServiceAdapter):
 
     def add_time_entry(self, issue_number: int, duration: int | float) -> TimeEntry:
         hours = duration / 3600
+        # CompletedWork への JSON Patch "add" は加算ではなく置換（設定）であり、
+        # 複数回呼ぶと過去の記録が消える。base の「加算」契約に合わせ、現在値を
+        # GET してから加算する read-modify-write にする。
+        resp = self._client.get(f"{self._wit_path()}/workitems/{issue_number}")
+        fields = resp.json().get("fields") or {}
+        current = fields.get("Microsoft.VSTS.Scheduling.CompletedWork") or 0
+        try:
+            new_total = float(current) + hours
+        except (TypeError, ValueError):
+            new_total = hours
         patch = [
-            {"op": "add", "path": "/fields/Microsoft.VSTS.Scheduling.CompletedWork", "value": hours}
+            {
+                "op": "add",
+                "path": "/fields/Microsoft.VSTS.Scheduling.CompletedWork",
+                "value": new_total,
+            }
         ]
         self._client.patch(
             f"{self._wit_path()}/workitems/{issue_number}",

--- a/src/gfo/adapter/backlog.py
+++ b/src/gfo/adapter/backlog.py
@@ -919,5 +919,16 @@ class BacklogAdapter(GitServiceAdapter):
 
     def add_time_entry(self, issue_number: int, duration: int | float) -> TimeEntry:
         hours = round(duration / 3600, 2)
-        self._client.patch(f"/issues/{issue_number}", json={"actualHours": hours})
+        # 他の issue 操作と同じく issueKey 形式（PROJECT-番号）でアクセスする。
+        # 生の番号だと別 issue を更新するか 404 になる。
+        issue_key = f"{self._project_key}-{issue_number}"
+        # actualHours の PATCH は上書きであり、base の「加算」契約に反する。
+        # 現在値を GET してから加算する read-modify-write にする。
+        resp = self._client.get(f"/issues/{issue_key}")
+        current = resp.json().get("actualHours") or 0
+        try:
+            new_total = round(float(current) + hours, 2)
+        except (TypeError, ValueError):
+            new_total = hours
+        self._client.patch(f"/issues/{issue_key}", json={"actualHours": new_total})
         return TimeEntry(id=0, user="", duration=int(duration), created_at="")

--- a/src/gfo/adapter/base.py
+++ b/src/gfo/adapter/base.py
@@ -1054,6 +1054,13 @@ class GitServiceAdapter(ABC):
         raise NotSupportedError(self.service_name, "issue time list")
 
     def add_time_entry(self, issue_number: int, duration: int | float) -> TimeEntry:
+        """Issue に作業時間（秒）を**加算**する。
+
+        セマンティクス契約: 既存の記録時間に duration を足し込むこと（上書きしない）。
+        個別の time entry を持つ API（Gitea 等）は追加レコードを作り、合計値しか
+        持たない API（GitLab / Azure DevOps / Backlog 等）は read-modify-write で
+        既存値に加算する。全アダプターでこの「加算」契約を守ること。
+        """
         raise NotSupportedError(self.service_name, "issue time add")
 
     def delete_time_entry(self, issue_number: int, entry_id: int | str) -> None:

--- a/src/gfo/adapter/bitbucket.py
+++ b/src/gfo/adapter/bitbucket.py
@@ -1159,12 +1159,16 @@ class BitbucketAdapter(GitServiceAdapter):
 
     def list_secrets(self, *, scope: str | None = None, limit: int = 30) -> list[Secret]:
         self._warn_unsupported_params("secret list", scope=scope)
+        # secured フィルタを伴うため、フィルタ前に limit を適用すると取りこぼす。
+        # 全件取得 → secured フィルタ → limit 適用の順にする。
         results = paginate_response_body(
             self._client,
             f"{self._repos_path()}/pipelines_config/variables/",
-            limit=limit,
+            limit=0,
         )
         secured = [d for d in results if d.get("secured")]
+        if limit > 0:
+            secured = secured[:limit]
         return [Secret(name=d["key"], created_at="", updated_at="") for d in secured]
 
     def set_secret(self, name: str, value: str, *, scope: str | None = None) -> Secret:
@@ -1204,12 +1208,16 @@ class BitbucketAdapter(GitServiceAdapter):
 
     def list_variables(self, *, scope: str | None = None, limit: int = 30) -> list[Variable]:
         self._warn_unsupported_params("variable list", scope=scope)
+        # not secured フィルタを伴うため、フィルタ前に limit を適用すると取りこぼす。
+        # 全件取得 → フィルタ → limit 適用の順にする。
         results = paginate_response_body(
             self._client,
             f"{self._repos_path()}/pipelines_config/variables/",
-            limit=limit,
+            limit=0,
         )
         unsecured = [d for d in results if not d.get("secured")]
+        if limit > 0:
+            unsecured = unsecured[:limit]
         return [
             Variable(name=d["key"], value=d.get("value") or "", created_at="", updated_at="")
             for d in unsecured

--- a/src/gfo/adapter/gitlab.py
+++ b/src/gfo/adapter/gitlab.py
@@ -1753,8 +1753,12 @@ class GitLabAdapter(GitServiceAdapter):
 
     def list_secrets(self, *, scope: str | None = None, limit: int = 30) -> list[Secret]:
         base = self._variables_base_path(scope)
-        results = paginate_page_param(self._client, base, limit=limit)
+        # masked フィルタを伴うため、フィルタ前に limit を適用すると取りこぼす。
+        # 全件取得 → masked フィルタ → limit 適用の順にする。
+        results = paginate_page_param(self._client, base, limit=0)
         masked = [d for d in results if d.get("masked")]
+        if limit > 0:
+            masked = masked[:limit]
         return [Secret(name=d["key"], created_at="", updated_at="") for d in masked]
 
     def set_secret(self, name: str, value: str, *, scope: str | None = None) -> Secret:

--- a/src/gfo/commands/api.py
+++ b/src/gfo/commands/api.py
@@ -15,6 +15,28 @@ from gfo.output import apply_jq_filter
 _DISALLOWED_HEADERS = {"authorization", "cookie", "host", "proxy-authorization"}
 
 
+def _validate_api_path(path: str) -> str:
+    """API パスがベース URL のオリジンを変えないことを検証する。
+
+    `gfo api` の PATH は argparse の自由入力で、`HttpClient.request` は
+    `base_url + path` を素朴に連結する（同一オリジン検証を持たない）。
+    先頭 `/` で始まらないパス（例: `@evil.com/...`, `.evil.com/...`,
+    絶対 URL）はベースの authority を差し替えてしまい、認証トークンが
+    攻撃者ホストへ送出される。相対パス（先頭 `/`、ただし `//` は不可）に
+    限定し、制御文字も拒否する。
+    """
+    if any(c in path for c in ("\r", "\n", "\x00")):
+        raise ConfigError(_("PATH contains control characters; refused."))
+    if not path.startswith("/") or path.startswith("//"):
+        raise ConfigError(
+            _(
+                "PATH must be a relative path starting with '/' "
+                "(e.g. '/repos/owner/repo'). Absolute URLs are not allowed."
+            )
+        )
+    return path
+
+
 def _parse_headers(header_list: list[str] | None) -> dict[str, str]:
     """--header 引数をパースして dict に変換する。
 
@@ -57,7 +79,7 @@ def handle_api(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> 
     client = create_http_client(config.service_type, config.api_url, token)
 
     method = args.method.upper()
-    path = args.path
+    path = _validate_api_path(args.path)
     headers = _parse_headers(getattr(args, "header", None))
     data = getattr(args, "data", None)
     try:

--- a/tests/test_adapters/test_azure_devops.py
+++ b/tests/test_adapters/test_azure_devops.py
@@ -2581,6 +2581,34 @@ class TestGetIssueTimeline:
         assert events[0].actor == "Alice"
         assert "System.State: Active" in events[0].detail
 
+    def test_timeline_limit_applied_after_filter(self, mock_responses, azure_devops_adapter):
+        """detail 無し update を除外してから limit を適用する（フィルタ前 limit の回帰）。
+
+        先頭が detail 空の update でも、後続の有効な update を取りこぼさないこと。
+        """
+        mock_responses.add(
+            responses.GET,
+            f"{WIT}/workitems/1/updates",
+            json={
+                "value": [
+                    # detail 空（フィールド変更なし）の update が先頭
+                    {"id": 1, "revisedBy": {"displayName": "Alice"}, "fields": {}},
+                    # 有効な update（limit=1 でもこれが返るべき）
+                    {
+                        "id": 2,
+                        "revisedBy": {"displayName": "Bob"},
+                        "revisedDate": "2025-01-02T00:00:00Z",
+                        "fields": {"System.State": {"newValue": "Active"}},
+                    },
+                ]
+            },
+            status=200,
+        )
+        events = azure_devops_adapter.get_issue_timeline(1, limit=1)
+        assert len(events) == 1
+        assert events[0].id == 2
+        assert "System.State: Active" in events[0].detail
+
     def test_timeline_empty_updates(self, mock_responses, azure_devops_adapter):
         """更新なし → 空リスト。"""
         mock_responses.add(
@@ -2799,8 +2827,22 @@ class TestSearchCommits:
 
 
 class TestAddTimeEntry:
+    @staticmethod
+    def _add_workitem_get(mock_responses, completed=None):
+        """add_time_entry が現在値読み取りに使う GET をモックする。"""
+        fields = {}
+        if completed is not None:
+            fields["Microsoft.VSTS.Scheduling.CompletedWork"] = completed
+        mock_responses.add(
+            responses.GET,
+            f"{WIT}/workitems/1",
+            json={"id": 1, "fields": fields},
+            status=200,
+        )
+
     def test_add_time_entry_converts_seconds_to_hours(self, mock_responses, azure_devops_adapter):
-        """3600秒 → 1時間。"""
+        """3600秒 → 1時間（既存値なし）。"""
+        self._add_workitem_get(mock_responses)
         mock_responses.add(
             responses.PATCH,
             f"{WIT}/workitems/1",
@@ -2808,8 +2850,7 @@ class TestAddTimeEntry:
             status=200,
         )
         azure_devops_adapter.add_time_entry(1, 3600)
-        req = mock_responses.calls[0].request
-        body = json.loads(req.body)
+        body = json.loads(mock_responses.calls[-1].request.body)
         completed_op = next(
             op for op in body if op["path"] == "/fields/Microsoft.VSTS.Scheduling.CompletedWork"
         )
@@ -2817,6 +2858,7 @@ class TestAddTimeEntry:
 
     def test_add_time_entry_partial_hour(self, mock_responses, azure_devops_adapter):
         """1800秒 → 0.5時間。"""
+        self._add_workitem_get(mock_responses)
         mock_responses.add(
             responses.PATCH,
             f"{WIT}/workitems/1",
@@ -2824,15 +2866,31 @@ class TestAddTimeEntry:
             status=200,
         )
         azure_devops_adapter.add_time_entry(1, 1800)
-        req = mock_responses.calls[0].request
-        body = json.loads(req.body)
+        body = json.loads(mock_responses.calls[-1].request.body)
         completed_op = next(
             op for op in body if op["path"] == "/fields/Microsoft.VSTS.Scheduling.CompletedWork"
         )
         assert completed_op["value"] == 0.5
 
+    def test_add_time_entry_accumulates(self, mock_responses, azure_devops_adapter):
+        """既存 CompletedWork に加算する（上書きしない）回帰テスト。"""
+        self._add_workitem_get(mock_responses, completed=2.0)
+        mock_responses.add(
+            responses.PATCH,
+            f"{WIT}/workitems/1",
+            json=_issue_data(id=1),
+            status=200,
+        )
+        azure_devops_adapter.add_time_entry(1, 3600)  # +1h
+        body = json.loads(mock_responses.calls[-1].request.body)
+        completed_op = next(
+            op for op in body if op["path"] == "/fields/Microsoft.VSTS.Scheduling.CompletedWork"
+        )
+        assert completed_op["value"] == 3.0
+
     def test_add_time_entry_returns_stub(self, mock_responses, azure_devops_adapter):
         """返値の id=0, user="", created_at=""。"""
+        self._add_workitem_get(mock_responses)
         mock_responses.add(
             responses.PATCH,
             f"{WIT}/workitems/1",

--- a/tests/test_adapters/test_backlog.py
+++ b/tests/test_adapters/test_backlog.py
@@ -1935,3 +1935,44 @@ class TestToWikiPage:
         data = {"id": 3, "name": None, "content": "body"}
         page = BacklogAdapter._to_wiki_page(data)
         assert page.title == ""
+
+
+class TestAddTimeEntry:
+    def test_uses_issue_key_and_accumulates(self, mock_responses, backlog_adapter):
+        """issueKey 形式でアクセスし、既存 actualHours に加算すること（回帰）。"""
+        mock_responses.add(
+            responses.GET,
+            f"{BASE}/issues/TEST-1",
+            json={"id": 1, "actualHours": 2.0},
+            status=200,
+        )
+        mock_responses.add(
+            responses.PATCH,
+            f"{BASE}/issues/TEST-1",
+            json=_issue_data(),
+            status=200,
+        )
+        result = backlog_adapter.add_time_entry(1, 3600)  # +1.0h
+        # 生番号 /issues/1 ではなく issueKey /issues/TEST-1 を使う
+        assert all("/issues/TEST-1" in c.request.url for c in mock_responses.calls)
+        req_body = json.loads(mock_responses.calls[-1].request.body)
+        assert req_body["actualHours"] == 3.0
+        assert result.duration == 3600
+
+    def test_no_existing_hours(self, mock_responses, backlog_adapter):
+        """既存値が無い場合は追加分のみになること。"""
+        mock_responses.add(
+            responses.GET,
+            f"{BASE}/issues/TEST-1",
+            json={"id": 1},
+            status=200,
+        )
+        mock_responses.add(
+            responses.PATCH,
+            f"{BASE}/issues/TEST-1",
+            json=_issue_data(),
+            status=200,
+        )
+        backlog_adapter.add_time_entry(1, 1800)  # 0.5h
+        req_body = json.loads(mock_responses.calls[-1].request.body)
+        assert req_body["actualHours"] == 0.5

--- a/tests/test_adapters/test_bitbucket.py
+++ b/tests/test_adapters/test_bitbucket.py
@@ -2165,3 +2165,51 @@ class TestListPullRequestsSearchEscape:
         decoded_url = unquote(url)
         # エスケープされた \" が title~ フィルタ内に含まれることを確認
         assert 'title~"test\\"value"' in decoded_url
+
+
+class TestPipelineVariablesFilterOrder:
+    _VARS = f"{REPOS}/pipelines_config/variables/"
+
+    def test_list_secrets_secured_on_later_page_not_dropped(
+        self, mock_responses, bitbucket_adapter
+    ):
+        """secured フィルタは全件取得後に適用し、後方ページの秘密を取りこぼさない。"""
+        mock_responses.add(
+            responses.GET,
+            self._VARS,
+            json={
+                "values": [{"key": "PLAIN", "uuid": "{1}", "secured": False}],
+                "next": f"{self._VARS}?page=2",
+            },
+            status=200,
+        )
+        mock_responses.add(
+            responses.GET,
+            self._VARS,
+            json={"values": [{"key": "SECRET", "uuid": "{2}", "secured": True}]},
+            status=200,
+        )
+        secrets = bitbucket_adapter.list_secrets(limit=1)
+        assert [s.name for s in secrets] == ["SECRET"]
+
+    def test_list_variables_unsecured_on_later_page_not_dropped(
+        self, mock_responses, bitbucket_adapter
+    ):
+        """not secured フィルタも全件取得後に適用し、後方ページの変数を取りこぼさない。"""
+        mock_responses.add(
+            responses.GET,
+            self._VARS,
+            json={
+                "values": [{"key": "SECRET", "uuid": "{1}", "secured": True}],
+                "next": f"{self._VARS}?page=2",
+            },
+            status=200,
+        )
+        mock_responses.add(
+            responses.GET,
+            self._VARS,
+            json={"values": [{"key": "PLAIN", "uuid": "{2}", "value": "v", "secured": False}]},
+            status=200,
+        )
+        variables = bitbucket_adapter.list_variables(limit=1)
+        assert [v.name for v in variables] == ["PLAIN"]

--- a/tests/test_adapters/test_gitlab.py
+++ b/tests/test_adapters/test_gitlab.py
@@ -3889,6 +3889,28 @@ class TestOrgSecrets:
         gitlab_adapter.delete_secret("GROUP_SECRET", scope="my-group")
 
 
+class TestListSecretsFilterOrder:
+    def test_masked_on_later_page_not_dropped(self, mock_responses, gitlab_adapter):
+        """masked フィルタは全件取得後に適用し、後方ページの秘密を取りこぼさない。"""
+        # page1: masked でない変数のみ（続きあり）
+        mock_responses.add(
+            responses.GET,
+            f"{PROJECT}/variables",
+            json=[{"key": "PLAIN", "value": "v", "masked": False}],
+            status=200,
+            headers={"X-Next-Page": "2"},
+        )
+        # page2: 探している masked 秘密
+        mock_responses.add(
+            responses.GET,
+            f"{PROJECT}/variables",
+            json=[{"key": "SECRET", "value": "***", "masked": True}],
+            status=200,
+        )
+        secrets = gitlab_adapter.list_secrets(limit=1)
+        assert [s.name for s in secrets] == ["SECRET"]
+
+
 class TestOrgVariables:
     def test_list_org_variables(self, mock_responses, gitlab_adapter):
         mock_responses.add(

--- a/tests/test_commands/test_api.py
+++ b/tests/test_commands/test_api.py
@@ -102,6 +102,31 @@ class TestHandleApi:
             with pytest.raises(ConfigError):
                 api_cmd.handle_api(args, fmt="json")
 
+    @pytest.mark.parametrize(
+        "evil_path",
+        [
+            "@evil.com/x",  # userinfo 注入でホスト差し替え
+            ".evil.com/x",  # サフィックス付加でホスト差し替え
+            "//evil.com/x",  # プロトコル相対
+            "https://evil.com/x",  # 絶対 URL
+            "repos/owner/repo",  # 先頭スラッシュ無し（authority へ吸収され得る）
+        ],
+    )
+    def test_rejects_origin_changing_path(self, sample_config, mock_client, evil_path):
+        """ベース URL のオリジンを変え得る PATH はトークン漏えい防止のため拒否する。"""
+        args = make_args(method="GET", path=evil_path, data=None, header=None)
+        with _patch_all(sample_config, mock_client):
+            with pytest.raises(ConfigError, match="PATH"):
+                api_cmd.handle_api(args, fmt="json")
+        mock_client.request.assert_not_called()
+
+    def test_rejects_path_with_control_chars(self, sample_config, mock_client):
+        args = make_args(method="GET", path="/x\r\nHost: evil", data=None, header=None)
+        with _patch_all(sample_config, mock_client):
+            with pytest.raises(ConfigError, match="control characters"):
+                api_cmd.handle_api(args, fmt="json")
+        mock_client.request.assert_not_called()
+
     def test_method_uppercased(self, sample_config, mock_client, capsys):
         args = make_args(method="patch", path="/test", data='{"x": 1}', header=None)
         with _patch_all(sample_config, mock_client):


### PR DESCRIPTION
多エージェント監査で確証された横断的・高インパクトな 3 テーマを、回帰テスト付きで一括是正する。前回 PR #47（High 3件）の続き。

## 1. フィルタ前 limit の取りこぼし（`02-adapter-common.md` 規約違反）
同一エンドポイント（masked/secured 混在）を `limit` 件取得してからフィルタするため、対象種別が後方ページに散ると取りこぼしていた。**全件取得（limit=0）→ フィルタ → `[:limit]`** に統一。
- GitLab `list_secrets`
- Bitbucket `list_secrets` / `list_variables`
- Azure DevOps `get_issue_timeline`（detail 空 update を除外してから limit）

## 2. `gfo api` の PATH 無検証によるトークン送出（セキュリティ）
PATH が無検証で `HttpClient.request` が `base_url + path` を素朴連結するため、`@evil.com/...` / `.evil.com/...` / 絶対 URL でベースの authority を差し替えると認証トークンが攻撃者ホストへ送出され得た（`download_file` 等が持つ同一オリジン検証がこの経路に無かった）。**PATH を先頭 `/`（`//` 不可）の相対パスに限定**し、制御文字も拒否。

## 3. time entry の上書き → 加算に統一（データ損失）
`add_time_entry` は本来「加算」だが、Azure DevOps（`CompletedWork`）と Backlog（`actualHours`）は**上書き**しており、複数回呼ぶと過去の記録が消えていた（Gitea/GitLab の加算契約と不整合）。現在値を GET して加算する read-modify-write に修正。あわせて Backlog の issueKey 誤参照（生番号 → `PROJECT-番号`）も是正。`base.add_time_entry` に加算契約を docstring 明記。

## テスト
- 後方ページの masked/secured/unsecured 取りこぼし、Azure timeline の limit 適用順、オリジン差し替え PATH 拒否、time entry 加算・issueKey の回帰テストを追加（+13）
- ruff / format / mypy / bandit / pytest（**3820 passed**）すべて green

🤖 Generated with [Claude Code](https://claude.com/claude-code)