### PR TITLE
fix(release): リリースタグを署名タグ (git tag -s) で作成する

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -157,15 +157,18 @@ gh pr merge <pr-number> --merge --delete-branch
 
 ### 7. main を取得してタグを作成・push
 
-マージ後、main HEAD はマージコミットになる。ローカル main を同期し、その HEAD に注釈タグを打つ:
+マージ後、main HEAD はマージコミットになる。ローカル main を同期し、その HEAD に**署名タグ**を打つ:
 
 ```bash
 git switch main
 git pull --ff-only origin main
-git tag -a v<new> -m "<タグメッセージ>"
+git tag -s v<new> -m "<タグメッセージ>"
 git push origin v<new>
 ```
 
+- **`-s`（署名タグ）を使う**。`-a`（注釈のみ）だと `tag.gpgsign` 未設定の環境で未署名タグになり
+  GitHub で Verified が付かない。`-s` なら設定に依存せず常に署名する（署名鍵未設定なら失敗するので
+  異常に気づける）。タグ作成後、`git cat-file tag v<new> | grep -q 'BEGIN .* SIGNATURE'` で署名を確認するとよい。
 - タグメッセージは `git log --no-merges --oneline <last-tag>..HEAD` から要約（単一テーマなら命名、
   複数なら `Release v<new>`、いずれもリポ言語）。
 - **タグ push がリリースの不可逆点**。release.yml（`push` tags `v*`）が起動し PyPI へ公開される。


### PR DESCRIPTION
## 背景

`release` スキルの手順7はタグ作成に `git tag -a`（注釈のみ）を使っていた。グローバル設定は
`commit.gpgsign=true` だが**タグ署名は別設定（`tag.gpgsign`）**で、これが未設定だと `git tag -a`
は未署名タグになる。実際 `v0.10.1` が未署名で作成され、GitHub で Verified が付かなかった
（`v0.9.0` / `v0.10.0` は `git tag -s` で署名済みだったのと対照的）。

## 変更内容

- 手順7のタグ作成を `git tag -a` → **`git tag -s`** に変更。設定（`tag.gpgsign`）の有無に依存せず
  常に署名する（署名鍵未設定なら失敗するので異常に気づける）。
- タグ作成後に `git cat-file tag` で署名有無を確認する手順を追記。

ドキュメント（スキル）のみの変更。`v0.10.1` 自体はタグ不変の規律により変更しない（次タグから署名される）。