### PR TITLE
fix(test): askpass ラッパーの権限を 0o700 に絞る

### DIFF
--- a/tests/integration/test_gitea.py
+++ b/tests/integration/test_gitea.py
@@ -59,7 +59,7 @@ class TestGiteaIntegration(GiteaFamilyIntegrationBase):
             wrapper_path = os.path.join(wrapper_dir, "askpass.sh")
             with open(wrapper_path, "w") as f:
                 f.write(f'#!/bin/sh\n"{sys.executable}" "{askpass_script}" "$1"\n')
-            os.chmod(wrapper_path, 0o755)
+            os.chmod(wrapper_path, 0o700)
         return {
             **os.environ,
             "GIT_ASKPASS": wrapper_path,


### PR DESCRIPTION
## 概要

CodeQL code-scanning アラート #21 (`py/overly-permissive-file`, high) の対応。

`tests/integration/test_gitea.py` の GIT_ASKPASS ラッパースクリプト生成で、`os.chmod(wrapper_path, 0o755)` により world-readable/executable な権限を付与していた。git は同一ユーザーで実行するため所有者のみの `0o700` で十分であり、world への読み取り・実行権限を除去する。

## 残り20件のアラートについて

`py/incomplete-url-substring-sanitization` の20件 (#1〜#20) は、すべてテストのアサーション (`assert "github.com" in ...`) であり URL サニタイズ検証ではないため false positive。`gh api` で `used in tests` として dismiss 済み。

クエリ自体の無効化や `paths-ignore: tests/` は採用しない。`src/gfo/detect.py` が remote URL からホスト名を抽出するコードであり、本クエリの監視対象として有効に残すべきため。

🤖 Generated with [Claude Code](https://claude.com/claude-code)