### PR TITLE
test(cli): バージョン assert を __version__ の動的参照に統一

### DIFF
--- a/.claude/skills/bump-version/SKILL.md
+++ b/.claude/skills/bump-version/SKILL.md
@@ -55,13 +55,10 @@ git log $(git describe --tags --abbrev=0)..HEAD --oneline
 
 ### 3. ファイル更新
 
-以下の 4 ファイルを更新する:
+以下の 3 ファイルを更新する（`tests/test_cli.py` は `__version__` を動的参照するため bump 不要）:
 
 #### `src/gfo/__init__.py`
 - `__version__` を新バージョンに更新
-
-#### `tests/test_cli.py`
-- `gfo {旧バージョン}` を含むアサーションを `gfo {新バージョン}` に置換
 
 #### `CHANGELOG.md`（英語）
 - `# Changelog` の直後（最初の `## [...]` の前）に新バージョンのセクションを挿入
@@ -91,9 +88,9 @@ git log $(git describe --tags --abbrev=0)..HEAD --oneline
 
 ### 4. コミット
 
-更新した 4 ファイルをステージしてコミットする:
+更新した 3 ファイルをステージしてコミットする:
 ```bash
-git add src/gfo/__init__.py tests/test_cli.py CHANGELOG.md CHANGELOG.ja.md
+git add src/gfo/__init__.py CHANGELOG.md CHANGELOG.ja.md
 git commit -m "chore: バージョン X.Y.Z リリース準備"
 ```
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release
-description: PR 経由でリリースを一括実行する。main がクリーンか検証 → release-v<X.Y.Z> ブランチを切る → バージョン bump（__init__.py / test_cli.py / CHANGELOG 2種）→ PR 作成 → CI green 後に --merge → main のマージコミットに注釈タグ → タグ push。タグ push（v*）が release.yml をトリガーし PyPI へ自動公開する。「リリース」「リリースして」「deploy」「PyPI に公開」と言われたときに使う。
+description: PR 経由でリリースを一括実行する。main がクリーンか検証 → release-v<X.Y.Z> ブランチを切る → バージョン bump（__init__.py / CHANGELOG 2種）→ PR 作成 → CI green 後に --merge → main のマージコミットに注釈タグ → タグ push。タグ push（v*）が release.yml をトリガーし PyPI へ自動公開する。「リリース」「リリースして」「deploy」「PyPI に公開」と言われたときに使う。
 allowed-tools: AskUserQuestion, Bash, Read, Edit, Write, Glob, Grep
 ---
 
@@ -80,14 +80,13 @@ main（preflight で最新化済み）から:
 git switch -c release-v<new>
 ```
 
-### 3. バージョン bump（4 ファイル）と CHANGELOG 作成
+### 3. バージョン bump（3 ファイル）と CHANGELOG 作成
 
-release ブランチ上で以下 4 ファイルを更新する。CHANGELOG の中身は最新タグ以降のコミットを分類して書く
+release ブランチ上で以下 3 ファイルを更新する（`tests/test_cli.py` は `__version__` を動的参照するため bump 不要）。CHANGELOG の中身は最新タグ以降のコミットを分類して書く
 （`feat:`→Added/追加、`fix:`→Fixed/修正、`test:`→Tests/テスト、その他で価値あるもの→Other/その他。
 `docs:`/`chore:` 単独は原則含めない）。英語版と日本語版は項目数・順序を一致させる。
 
 - **`src/gfo/__init__.py`**: `__version__` を新バージョンに更新。
-- **`tests/test_cli.py`**: `gfo {旧バージョン}` を含むアサーションを `gfo {新バージョン}` に置換。
 - **`CHANGELOG.md`（英語）**: `# Changelog` 直後（最初の `## [...]` の前）に新セクションを挿入。
 
   ```markdown
@@ -110,7 +109,7 @@ CHANGELOG のエントリは具体的なコマンド名・オプション名を�
 ### 4. bump コミット
 
 ```bash
-git add src/gfo/__init__.py tests/test_cli.py CHANGELOG.md CHANGELOG.ja.md
+git add src/gfo/__init__.py CHANGELOG.md CHANGELOG.ja.md
 git commit -m "chore(release): バージョン <new> リリース準備"
 ```
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from gfo import __version__
 from gfo.cli import (
     _DISPATCH,
     _ensure_utf8_stdio,
@@ -65,7 +66,7 @@ def test_parser_version(capsys):
         parser.parse_args(["--version"])
     assert exc.value.code == 0
     captured = capsys.readouterr()
-    assert "gfo 0.10.1" in captured.out
+    assert f"gfo {__version__}" in captured.out
 
 
 def test_parser_init_defaults():
@@ -809,7 +810,7 @@ def test_main_version(capsys):
         main(["--version"])
     assert exc.value.code == 0
     captured = capsys.readouterr()
-    assert "gfo 0.10.1" in captured.out
+    assert f"gfo {__version__}" in captured.out
 
 
 def test_main_subcommand_only_returns_1(capsys):


### PR DESCRIPTION
## 概要
Closes #72

tests/test_cli.py がバージョン文字列 `gfo 0.10.1` をリテラルで 2 箇所（L68 / L812 相当）に固定しており、バージョン情報が `src/gfo/__init__.py` + テスト 2 箇所の 3 重管理になっていた。

## 変更内容
- `tests/test_cli.py`: `from gfo import __version__` を import し、`assert f"gfo {__version__}" in captured.out` の動的 assert に変更（2 箇所）
- `.claude/skills/bump-version/SKILL.md`: bump 対象を 4 ファイル → 3 ファイルに（test_cli.py を除外）
- `.claude/skills/release/SKILL.md`: 同上（description・手順・git add 例を更新）

## テスト
- `uv run pytest tests/test_cli.py`: 151 passed
- `uv run ruff check` / `ruff format --check` / `mypy src/gfo`: すべて green

🤖 Generated with [Claude Code](https://claude.com/claude-code)