### PR TITLE
fix(auth): auth status を共通 output() に乗せて --jq / --format plain を有効化

### DIFF
--- a/src/gfo/commands/auth_cmd.py
+++ b/src/gfo/commands/auth_cmd.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import dataclasses
 import getpass
 import sys
 
@@ -11,6 +12,18 @@ import gfo.detect
 from gfo.detect import normalize_host
 from gfo.exceptions import ConfigError, DetectionError, GitCommandError
 from gfo.i18n import _
+from gfo.output import output
+
+
+@dataclasses.dataclass
+class _AuthStatusEntry:
+    """auth status の 1 エントリ。共通 output() に乗せるための dataclass。"""
+
+    host: str
+    status: str
+    source: str
+    account: str
+    active: str
 
 
 def handle_login(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -86,50 +99,23 @@ def handle_login(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -
 
 def handle_status(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo auth status のハンドラ。"""
-    entries = gfo.auth.get_auth_status()
+    entries = [_AuthStatusEntry(**e) for e in gfo.auth.get_auth_status()]
+
+    if fmt == "json":
+        output(entries, fmt=fmt, jq=jq)
+        return
 
     if not entries:
-        if fmt == "json":
-            print("[]")
-        else:
+        if fmt != "plain":
             print(_("No tokens configured."))
         return
 
-    if fmt == "json":
-        import json
-
-        print(json.dumps(entries, ensure_ascii=False, indent=2))
-        return
-
-    col_widths = {
-        "host": max(len(e["host"]) for e in entries),
-        "account": max(
-            (len(e["account"]) + len(e["active"]) + (1 if e["active"] else 0)) for e in entries
-        ),
-        "status": max(len(e["status"]) for e in entries),
-        "source": max(len(e["source"]) for e in entries),
-    }
-    col_widths["host"] = min(max(col_widths["host"], 4), 50)
-    col_widths["account"] = min(max(col_widths["account"], 7), 30)
-    col_widths["status"] = min(max(col_widths["status"], 6), 20)
-    col_widths["source"] = min(max(col_widths["source"], 6), 40)
-
-    header = (
-        f"{_('HOST'):<{col_widths['host']}}  "
-        f"{_('ACCOUNT'):<{col_widths['account']}}  "
-        f"{_('STATUS'):<{col_widths['status']}}  "
-        f"{_('SOURCE'):<{col_widths['source']}}"
-    )
-    print(header)
-    print("-" * len(header))
-    for e in entries:
-        account_display = f"{e['account']} {e['active']}" if e["active"] else e["account"]
-        print(
-            f"{e['host']:<{col_widths['host']}}  "
-            f"{account_display:<{col_widths['account']}}  "
-            f"{e['status']:<{col_widths['status']}}  "
-            f"{e['source']:<{col_widths['source']}}"
-        )
+    # table / plain では active マーク (*) を account 列に畳み込んで表示する
+    display = [
+        dataclasses.replace(e, account=f"{e.account} {e.active}" if e.active else e.account)
+        for e in entries
+    ]
+    output(display, fmt=fmt, fields=["host", "account", "status", "source"])
 
 
 def handle_switch(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:

--- a/tests/test_commands/test_auth_cmd.py
+++ b/tests/test_commands/test_auth_cmd.py
@@ -698,3 +698,71 @@ class TestHandleStatusJson:
         captured = capsys.readouterr()
         data = json.loads(captured.out)
         assert data == []
+
+    def test_status_jq_applied(self, capsys):
+        """--jq 指定時に jq フィルタが適用される。"""
+        entries = [
+            {
+                "host": "github.com",
+                "status": "configured",
+                "source": "credentials.toml",
+                "account": "default",
+                "active": "*",
+            },
+        ]
+        args = make_args()
+
+        with (
+            patch("gfo.commands.auth_cmd.gfo.auth.get_auth_status", return_value=entries),
+            patch("gfo.output.apply_jq_filter", return_value='"github.com"') as mock_jq,
+        ):
+            auth_cmd.handle_status(args, fmt="json", jq=".[].host")
+
+        mock_jq.assert_called_once()
+        assert ".[].host" in mock_jq.call_args[0]
+        captured = capsys.readouterr()
+        assert '"github.com"' in captured.out
+
+    def test_status_jq_applied_when_empty(self, capsys):
+        """トークンなしでも --jq 指定時は jq フィルタを通す。"""
+        args = make_args()
+
+        with (
+            patch("gfo.commands.auth_cmd.gfo.auth.get_auth_status", return_value=[]),
+            patch("gfo.output.apply_jq_filter", return_value="0") as mock_jq,
+        ):
+            auth_cmd.handle_status(args, fmt="json", jq="length")
+
+        mock_jq.assert_called_once()
+        captured = capsys.readouterr()
+        assert "0" in captured.out
+
+    def test_status_plain_format(self, capsys):
+        """fmt="plain" でタブ区切り・ヘッダーなしの出力になる。"""
+        entries = [
+            {
+                "host": "github.com",
+                "status": "configured",
+                "source": "credentials.toml",
+                "account": "default",
+                "active": "*",
+            },
+        ]
+        args = make_args()
+
+        with patch("gfo.commands.auth_cmd.gfo.auth.get_auth_status", return_value=entries):
+            auth_cmd.handle_status(args, fmt="plain")
+
+        captured = capsys.readouterr()
+        assert "HOST" not in captured.out
+        assert "github.com\tdefault *\tconfigured\tcredentials.toml" in captured.out
+
+    def test_status_plain_empty_outputs_nothing(self, capsys):
+        """fmt="plain" かつトークンなし → 何も出力しない。"""
+        args = make_args()
+
+        with patch("gfo.commands.auth_cmd.gfo.auth.get_auth_status", return_value=[]):
+            auth_cmd.handle_status(args, fmt="plain")
+
+        captured = capsys.readouterr()
+        assert captured.out == ""


### PR DESCRIPTION
## 概要
Closes #69

`gfo auth status` が独自の json/table 描画を持っており、`--jq` が無視され `--format plain` も table にフォールバックしていた。他コマンド（`user whoami` / `config get` 等）と `--jq` / `--format` の効き方が不一致だった。

## 変更内容
- `src/gfo/commands/auth_cmd.py`: `_AuthStatusEntry` dataclass を導入し、`handle_status` を共通 `output()` 経由に変更
  - `--jq` が JSON 出力に適用されるようになった（空リスト時も適用）
  - `--format plain` がタブ区切り・ヘッダーなし出力として機能するようになった
  - active マーク (`*`) は table/plain では従来どおり account 列に畳み込み表示
  - JSON のキー順・構造は従来と同一（host / status / source / account / active）
- `tests/test_commands/test_auth_cmd.py`: jq 適用（通常・空）、plain 出力、plain 空の 4 テストを追加

## テスト
- `uv run pytest`: 3824 passed（既存の handle_status テストも無変更で green）
- `uv run ruff check` / `ruff format --check` / `mypy src/gfo`: すべて green
- 実 CLI で `--jq '.[].host'` / `--format plain` の動作を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)