### PR TITLE
fix(cli): batch pr / issue migrate の部分失敗で非 0 exit code を返す

### DIFF
--- a/.claude/rules/01-exceptions.md
+++ b/.claude/rules/01-exceptions.md
@@ -21,6 +21,7 @@ GfoError
 │   └── ServerError         # 5xx
 ├── NetworkError            # ConnectionError/Timeout/SSLError
 ├── NotSupportedError       # サービスが非対応の操作
+├── PartialFailureError     # 一括処理（batch / migrate）で 1 件以上失敗
 └── UnsupportedServiceError # 未知のサービス種別
 ```
 
@@ -32,6 +33,7 @@ GfoError
 | トークン未設定 | `AuthError` |
 | API レスポンス構造が予期しない | `GfoError`（KeyError/TypeError/AttributeError をラップ） |
 | HTTP 内部のバリデーション | `ValueError`（そのまま OK） |
+| 一括処理の部分失敗（結果出力後の exit code シグナル） | `PartialFailureError` |
 
 ## `_to_*` 内のラップパターン（必須）
 

--- a/src/gfo/commands/batch.py
+++ b/src/gfo/commands/batch.py
@@ -6,7 +6,7 @@ import argparse
 from dataclasses import dataclass
 
 from gfo.commands import create_adapter_from_spec, parse_service_spec
-from gfo.exceptions import ConfigError, GfoError
+from gfo.exceptions import ConfigError, GfoError, PartialFailureError
 from gfo.i18n import _
 from gfo.output import output
 
@@ -73,3 +73,8 @@ def handle_batch_pr(args: argparse.Namespace, *, fmt: str, jq: str | None = None
             )
 
     output(results, fmt=fmt, fields=["repo", "number", "url", "status", "error"], jq=jq)
+
+    # 1 件でも失敗があれば非 0 の exit code で失敗を通知する（結果出力は済んでいる）
+    failed = sum(1 for r in results if r.status == "failed")
+    if failed:
+        raise PartialFailureError(failed, len(results))

--- a/src/gfo/commands/issue.py
+++ b/src/gfo/commands/issue.py
@@ -15,7 +15,7 @@ from gfo.commands import (
     parse_service_spec,
     read_file_arg,
 )
-from gfo.exceptions import ConfigError, GfoError, NotSupportedError
+from gfo.exceptions import ConfigError, GfoError, NotSupportedError, PartialFailureError
 
 if TYPE_CHECKING:
     from gfo.adapter.base import GitServiceAdapter
@@ -471,3 +471,8 @@ def handle_migrate(args: argparse.Namespace, *, fmt: str, jq: str | None = None)
         results.append(result)
 
     output(results, fmt=fmt, fields=["source_number", "target_number", "success", "error"], jq=jq)
+
+    # 1 件でも失敗があれば非 0 の exit code で失敗を通知する（結果出力は済んでいる）
+    failed = sum(1 for r in results if not r.success)
+    if failed:
+        raise PartialFailureError(failed, len(results))

--- a/src/gfo/exceptions.py
+++ b/src/gfo/exceptions.py
@@ -18,6 +18,7 @@ class ExitCode(IntEnum):
     NOT_SUPPORTED = 5
     CONFIG = 6
     NETWORK = 7
+    PARTIAL_FAILURE = 8
 
 
 class GfoError(Exception):
@@ -178,6 +179,26 @@ class NotSupportedError(GfoError):
         )
         if web_url:
             self.hint = web_url
+
+
+class PartialFailureError(GfoError):
+    """一括処理（batch / migrate 等）で 1 件以上が失敗した。
+
+    個々の失敗は結果リスト（status / success / error フィールド）に集約済みで、
+    stdout への結果出力後に raise される。exit code で失敗を検知できるようにする
+    ためのシグナルであり、全件失敗の場合もこの例外を用いる。
+    """
+
+    error_code = "partial_failure"
+    exit_code = ExitCode.PARTIAL_FAILURE
+
+    def __init__(self, failed: int, total: int):
+        self.failed = failed
+        self.total = total
+        super().__init__(
+            _("{failed} of {total} operations failed.").format(failed=failed, total=total)
+        )
+        self.hint = _("Inspect the status/error fields of each item in the output for details.")
 
 
 class UnsupportedServiceError(GfoError):

--- a/src/gfo/locale/ja/LC_MESSAGES/gfo.po
+++ b/src/gfo/locale/ja/LC_MESSAGES/gfo.po
@@ -141,6 +141,12 @@ msgstr "サーバーエラーです。しばらくしてから再試行してく
 msgid "{service} does not support {operation}. Use the web interface instead."
 msgstr "{service} は {operation} に対応していません。Web インターフェースを使用してください。"
 
+msgid "{failed} of {total} operations failed."
+msgstr "{total} 件中 {failed} 件の操作が失敗しました。"
+
+msgid "Inspect the status/error fields of each item in the output for details."
+msgstr "詳細は出力の各項目の status / error フィールドを確認してください。"
+
 msgid "Unsupported service type: {service_type}"
 msgstr "未対応のサービス種別: {service_type}"
 

--- a/tests/test_commands/test_batch.py
+++ b/tests/test_commands/test_batch.py
@@ -9,7 +9,7 @@ import pytest
 
 from gfo.adapter.base import PullRequest
 from gfo.commands import batch as batch_cmd
-from gfo.exceptions import ConfigError, HttpError
+from gfo.exceptions import ConfigError, ExitCode, HttpError, PartialFailureError
 from tests.test_commands.conftest import make_args
 
 
@@ -100,8 +100,12 @@ class TestHandleBatchPr:
             batch_pr_action="create",
         )
 
-        batch_cmd.handle_batch_pr(args, fmt="table")
+        with pytest.raises(PartialFailureError) as exc:
+            batch_cmd.handle_batch_pr(args, fmt="table")
 
+        assert exc.value.failed == 1
+        assert exc.value.total == 2
+        assert exc.value.exit_code == ExitCode.PARTIAL_FAILURE
         captured = capsys.readouterr()
         assert "created" in captured.out
         assert "failed" in captured.out
@@ -224,8 +228,11 @@ class TestHandleBatchPr:
             batch_pr_action="create",
         )
 
-        batch_cmd.handle_batch_pr(args, fmt="json")
+        with pytest.raises(PartialFailureError) as exc:
+            batch_cmd.handle_batch_pr(args, fmt="json")
 
+        assert exc.value.failed == 2
+        assert exc.value.total == 2
         captured = capsys.readouterr()
         data = json.loads(captured.out)
         assert len(data) == 2
@@ -251,7 +258,8 @@ class TestHandleBatchPr:
             batch_pr_action="create",
         )
 
-        batch_cmd.handle_batch_pr(args, fmt="json")
+        with pytest.raises(PartialFailureError):
+            batch_cmd.handle_batch_pr(args, fmt="json")
 
         captured = capsys.readouterr()
         data = json.loads(captured.out)
@@ -379,8 +387,11 @@ class TestHandleBatchPr:
             batch_pr_action="create",
         )
 
-        batch_cmd.handle_batch_pr(args, fmt="json")
+        with pytest.raises(PartialFailureError) as exc:
+            batch_cmd.handle_batch_pr(args, fmt="json")
 
+        assert exc.value.failed == 1
+        assert exc.value.total == 3
         captured = capsys.readouterr()
         data = json.loads(captured.out)
         assert len(data) == 3

--- a/tests/test_commands/test_issue_migrate.py
+++ b/tests/test_commands/test_issue_migrate.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import json
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from gfo.adapter.base import Comment, Issue, Label
 from gfo.commands import issue as issue_cmd
 from gfo.commands.issue import _migrate_one_issue, _sync_labels
-from gfo.exceptions import HttpError, NotSupportedError
+from gfo.exceptions import ExitCode, HttpError, NotSupportedError, PartialFailureError
 from tests.test_commands.conftest import make_args
 
 
@@ -332,8 +334,12 @@ class TestMigratePartialFailure:
             numbers="1,2",
             migrate_all=False,
         )
-        issue_cmd.handle_migrate(args, fmt="json")
+        with pytest.raises(PartialFailureError) as exc:
+            issue_cmd.handle_migrate(args, fmt="json")
 
+        assert exc.value.failed == 1
+        assert exc.value.total == 2
+        assert exc.value.exit_code == ExitCode.PARTIAL_FAILURE
         captured = capsys.readouterr()
         results = json.loads(captured.out)
         assert len(results) == 2


### PR DESCRIPTION
## 概要
Closes #64

`gfo batch pr` / `gfo issue migrate` は個々の失敗を結果リスト（`status="failed"` / `success=false`）に集約するが、ハンドラが正常 return するため exit code が常に 0 だった。シェルスクリプト・CI・AI agent が exit code だけでは失敗を検知できなかった。

## 変更内容
- `src/gfo/exceptions.py`: `ExitCode.PARTIAL_FAILURE = 8` と `PartialFailureError`（failed / total 件数を保持、hint 付き）を新設
- `src/gfo/commands/batch.py` / `src/gfo/commands/issue.py`: 結果リストの出力**後**に failed 件数を集計し、1 件以上あれば `PartialFailureError` を raise
  - stdout には従来どおり全件の結果 JSON/table が出力され、エラーサマリは stderr（`--format json` 時は構造化 JSON）に出る
  - 全件失敗も同じ exit code 8（部分/全件の区別は結果リストで判別可能）
- `src/gfo/locale/ja/LC_MESSAGES/gfo.po`: 新メッセージ 2 件の日本語訳を追加
- `.claude/rules/01-exceptions.md`: 例外ツリー・使い分け表に反映
- テスト: 既存の失敗系テストを raises 検証に更新（exit code 8 / failed・total 件数を検証）

## テスト
- `uv run pytest`: 3824 passed
- `ruff check` / `ruff format --check` / `mypy` / `bandit`: すべて green

🤖 Generated with [Claude Code](https://claude.com/claude-code)