### PR TITLE
docs(readme): Quick Start に非対話 init（CI / AI agent 向け）の導線を追加

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -53,6 +53,16 @@ gfo issue create --title "Bug report"
 gfo repo clone alice/my-project
 ```
 
+### 非対話環境（CI / AI agent）
+
+`gfo init` は検出結果の確認プロンプトを出すため、stdin がない環境では EOF エラーで失敗する。CI パイプラインや AI agent から実行する場合は `--non-interactive` を使うこと:
+
+```bash
+gfo init --non-interactive --type github --host github.com
+```
+
+トークンもプロンプトなしで設定するには `gfo auth login --token-stdin`（またはサービス別環境変数 `GITHUB_TOKEN` 等）を使う。
+
 ## 認証
 
 トークンの解決順序:

--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ gfo issue create --title "Bug report"
 gfo repo clone alice/my-project
 ```
 
+### Non-interactive environments (CI / AI agents)
+
+`gfo init` asks for confirmation of the detected service, so it fails with an EOF error when stdin is unavailable. In CI pipelines or when driven by an AI agent, use `--non-interactive`:
+
+```bash
+gfo init --non-interactive --type github --host github.com
+```
+
+For token setup without a prompt, use `gfo auth login --token-stdin` (or a service-specific environment variable such as `GITHUB_TOKEN`).
+
 ## Authentication
 
 Token resolution order:


### PR DESCRIPTION
## 概要
Closes #60

README の Quick Start は対話前提の `gfo init` のみを案内しており、CI や AI agent など stdin がない環境では検出確認プロンプトが EOF で失敗する。

## 変更内容
- `README.md` / `README.ja.md`: Quick Start 直後に「Non-interactive environments (CI / AI agents)」/「非対話環境（CI / AI agent）」サブセクションを追加
  - `gfo init --non-interactive --type github --host github.com` の例を記載
  - トークンの非対話設定として `gfo auth login --token-stdin` とサービス別環境変数を案内

ドキュメントのみの変更（コード変更なし）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)