### PR TITLE
fix(cli): list 系 --limit で 0 を「全件取得」として許可する

### DIFF
--- a/docs/commands.ja.md
+++ b/docs/commands.ja.md
@@ -198,7 +198,7 @@ gfo pr list [--state {open,closed,merged,all}] [--limit N] [--author USER] [--la
 | オプション | デフォルト | 説明 |
 |---|---|---|
 | `--state` / `-s` | `open` | 表示する PR の状態 |
-| `--limit` / `-L` | `30` | 取得件数の上限 |
+| `--limit` / `-L` | `30` | 取得件数の上限（`0` で全件取得） |
 | `--author` / `-A` | — | 作成者でフィルタ |
 | `--label` / `-l` | — | ラベルでフィルタ |
 | `--assignee` / `-a` | — | 担当者でフィルタ |
@@ -584,7 +584,7 @@ gfo issue list [--state {open,closed,all}] [--assignee USER] [--label LABEL] [--
 | `--author` / `-A` | — | 作成者でフィルタ |
 | `--milestone` / `-m` | — | マイルストーンでフィルタ |
 | `--search` / `-S` | — | タイトル/説明でフィルタ |
-| `--limit` / `-L` | `30` | 取得件数の上限 |
+| `--limit` / `-L` | `30` | 取得件数の上限（`0` で全件取得） |
 
 ```bash
 gfo issue list
@@ -1989,7 +1989,7 @@ gfo ci artifact download RUN_ID ARTIFACT_ID [--dir DIR]
 
 | オプション | デフォルト | 説明 |
 |---|---|---|
-| `--limit` / `-L` | `30` | 取得件数の上限 |
+| `--limit` / `-L` | `30` | 取得件数の上限（`0` で全件取得） |
 | `--dir` | `.` | 出力ディレクトリ |
 
 ```bash
@@ -2249,7 +2249,7 @@ gfo notification list [--unread-only] [--limit N]
 | オプション | デフォルト | 説明 |
 |---|---|---|
 | `--unread-only` | false | 未読のみ表示 |
-| `--limit N` | 30 | 取得件数の上限 |
+| `--limit N` | 30 | 取得件数の上限（`0` で全件取得） |
 
 ```bash
 gfo notification list --unread-only
@@ -2760,7 +2760,7 @@ gfo package list [--type TYPE] [--limit N]
 | オプション | 説明 |
 |---|---|
 | `--type` | パッケージタイプでフィルタ（例: `npm`, `maven`, `docker`, `pypi`, `nuget`, `rubygems`） |
-| `--limit` / `-L` | 取得件数の上限 |
+| `--limit` / `-L` | 取得件数の上限（`0` で全件取得） |
 
 ```bash
 gfo package list

--- a/src/gfo/adapter/gitlab.py
+++ b/src/gfo/adapter/gitlab.py
@@ -2279,7 +2279,7 @@ class GitLabAdapter(GitServiceAdapter):
                 )
             )
         events.sort(key=lambda ev: ev.created_at)
-        return events[:limit]
+        return events[:limit] if limit > 0 else events
 
     # --- Issue Lock ---
 

--- a/src/gfo/cli.py
+++ b/src/gfo/cli.py
@@ -66,6 +66,21 @@ def _positive_int(value: str) -> int:
     return ivalue
 
 
+def _non_negative_int(value: str) -> int:
+    """argparse type: 0 以上の整数のみ受け付ける（0 は「無制限」の意）。"""
+    try:
+        ivalue = int(value)
+    except ValueError as e:
+        raise argparse.ArgumentTypeError(
+            _("{value} is not a non-negative integer").format(value=value)
+        ) from e
+    if ivalue < 0:
+        raise argparse.ArgumentTypeError(
+            _("{value} is not a non-negative integer").format(value=value)
+        )
+    return ivalue
+
+
 class _GfoArgumentParser(argparse.ArgumentParser):
     """argparse のエラーを ConfigError に変換するサブクラス。"""
 
@@ -298,7 +313,11 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
         help=_("Filter by state"),
     )
     pr_list.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
     pr_list.add_argument("--author", "-A", help=_("Filter by author"))
     pr_list.add_argument("--label", "-l", help=_("Filter by label"))
@@ -435,7 +454,11 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     pr_comment_list = pr_comment_sub.add_parser("list", help=_("List comments"))
     pr_comment_list.add_argument("number", type=int, help=_("PR number"))
     pr_comment_list.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
     pr_comment_create = pr_comment_sub.add_parser("create", help=_("Create comment"))
     pr_comment_create.add_argument("number", type=int, help=_("PR number"))
@@ -460,7 +483,11 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     issue_list.add_argument("--assignee", "-a", help=_("Filter by assignee"))
     issue_list.add_argument("--label", "-l", help=_("Filter by label"))
     issue_list.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
     issue_list.add_argument("--author", "-A", help=_("Filter by author"))
     issue_list.add_argument("--milestone", "-m", help=_("Filter by milestone"))
@@ -537,7 +564,11 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     repo_list = repo_sub.add_parser("list", help=_("List repositories"))
     repo_list.add_argument("--owner", "-o", help=_("Repository owner"))
     repo_list.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
     repo_list.add_argument(
         "--archived", action="store_true", default=None, help=_("Show only archived repositories")
@@ -653,7 +684,11 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     # gfo repo contributors
     repo_contributors = repo_sub.add_parser("contributors", help=_("List repository contributors"))
     repo_contributors.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
 
     # gfo repo archive
@@ -711,7 +746,11 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     release_sub = release_parser.add_subparsers(dest="subcommand")
     release_list = release_sub.add_parser("list", help=_("List releases"))
     release_list.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
     _release_list_draft = release_list.add_mutually_exclusive_group()
     _release_list_draft.add_argument(
@@ -899,7 +938,11 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     issue_comment_list = issue_comment_sub.add_parser("list", help=_("List comments"))
     issue_comment_list.add_argument("number", type=int, help=_("Issue number"))
     issue_comment_list.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
     issue_comment_create = issue_comment_sub.add_parser("create", help=_("Create comment"))
     issue_comment_create.add_argument("number", type=int, help=_("Issue number"))
@@ -927,7 +970,11 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     branch_view.add_argument("name", help=_("Branch name"))
     branch_list = branch_sub.add_parser("list", help=_("List branches"))
     branch_list.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
     branch_create = branch_sub.add_parser("create", help=_("Create branch"))
     branch_create.add_argument("name", help=_("Branch name"))
@@ -942,7 +989,11 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     tag_view.add_argument("name", help=_("Tag name"))
     tag_list = tag_sub.add_parser("list", help=_("List tags"))
     tag_list.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
     tag_create = tag_sub.add_parser("create", help=_("Create tag"))
     tag_create.add_argument("name", help=_("Tag name"))
@@ -959,7 +1010,11 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     status_list = status_sub.add_parser("list", help=_("List commit statuses"))
     status_list.add_argument("ref", help=_("Commit ref"))
     status_list.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
     status_create = status_sub.add_parser("create", help=_("Create commit status"))
     status_create.add_argument("ref", help=_("Commit ref"))
@@ -997,7 +1052,11 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     webhook_sub = webhook_parser.add_subparsers(dest="subcommand")
     webhook_list = webhook_sub.add_parser("list", help=_("List webhooks"))
     webhook_list.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
     webhook_create = webhook_sub.add_parser("create", help=_("Create webhook"))
     webhook_create.add_argument("--url", required=True, help=_("Webhook URL"))
@@ -1029,7 +1088,11 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     deploy_key_view.add_argument("id", type=int, help=_("Deploy key ID"))
     deploy_key_list = deploy_key_sub.add_parser("list", help=_("List deploy keys"))
     deploy_key_list.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
     deploy_key_create = deploy_key_sub.add_parser("create", help=_("Create deploy key"))
     deploy_key_create.add_argument("--title", "-t", required=True, help=_("Title"))
@@ -1047,7 +1110,11 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     collab_sub = collab_parser.add_subparsers(dest="subcommand")
     collab_list = collab_sub.add_parser("list", help=_("List collaborators"))
     collab_list.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
     collab_add = collab_sub.add_parser("add", help=_("Add collaborator"))
     collab_add.add_argument("username", help=_("Username"))
@@ -1066,7 +1133,11 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     ci_list = ci_sub.add_parser("list", help=_("List pipelines"))
     ci_list.add_argument("--ref", help=_("Git ref"))
     ci_list.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
     ci_view = ci_sub.add_parser("view", help=_("View pipeline details"))
     ci_view.add_argument("id", help=_("Pipeline ID"))
@@ -1100,7 +1171,11 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     ci_workflow_sub = ci_workflow.add_subparsers(dest="workflow_action")
     ci_wf_list = ci_workflow_sub.add_parser("list", help=_("List workflows"))
     ci_wf_list.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
     ci_wf_enable = ci_workflow_sub.add_parser("enable", help=_("Enable workflow"))
     ci_wf_enable.add_argument("id", help=_("Workflow ID"))
@@ -1112,7 +1187,11 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     ci_art_list = ci_artifact_sub.add_parser("list", help=_("List artifacts"))
     ci_art_list.add_argument("run_id", help=_("Pipeline run ID"))
     ci_art_list.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
     ci_art_download = ci_artifact_sub.add_parser("download", help=_("Download artifact"))
     ci_art_download.add_argument("run_id", help=_("Pipeline run ID"))
@@ -1132,12 +1211,20 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     search_repos = search_sub.add_parser("repos", help=_("Search repositories"))
     search_repos.add_argument("query", help=_("Search query"))
     search_repos.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
     search_issues = search_sub.add_parser("issues", help=_("Search issues"))
     search_issues.add_argument("query", help=_("Search query"))
     search_issues.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
 
     # gfo wiki → サブサブコマンド
@@ -1145,7 +1232,11 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     wiki_sub = wiki_parser.add_subparsers(dest="subcommand")
     wiki_list = wiki_sub.add_parser("list", help=_("List wiki pages"))
     wiki_list.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
     wiki_view = wiki_sub.add_parser("view", help=_("View wiki page"))
     wiki_view.add_argument("id", help=_("Page ID"))
@@ -1189,7 +1280,11 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     issue_timeline = issue_sub.add_parser("timeline", help=_("List issue timeline events"))
     issue_timeline.add_argument("number", type=int, help=_("Issue number"))
     issue_timeline.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
 
     # gfo issue pin / unpin
@@ -1217,7 +1312,11 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
         "--state", choices=["open", "closed", "merged", "all"], help=_("Filter by state")
     )
     search_prs.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
 
     # gfo search commits
@@ -1227,14 +1326,22 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     search_commits.add_argument("--since", help=_("Start date"))
     search_commits.add_argument("--until", help=_("End date"))
     search_commits.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
 
     # gfo search code
     search_code = search_sub.add_parser("code", help=_("Search code"))
     search_code.add_argument("query", help=_("Search query"))
     search_code.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
 
     # gfo label clone
@@ -1282,7 +1389,11 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     package_list = package_sub.add_parser("list", help=_("List packages"))
     package_list.add_argument("--type", dest="type", help=_("Package type"))
     package_list.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
     package_view = package_sub.add_parser("view", help=_("View package details"))
     package_view.add_argument("package_type", help=_("Package type"))
@@ -1303,7 +1414,11 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     bp_sub = bp_parser.add_subparsers(dest="subcommand")
     bp_list = bp_sub.add_parser("list", help=_("List branch protection rules"))
     bp_list.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
     bp_view = bp_sub.add_parser("view", help=_("View branch protection rule"))
     bp_view.add_argument("branch", help=_("Branch name"))
@@ -1355,7 +1470,11 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     tp_sub = tp_parser.add_subparsers(dest="subcommand")
     tp_list = tp_sub.add_parser("list", help=_("List tag protection rules"))
     tp_list.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
     tp_create = tp_sub.add_parser("create", help=_("Create tag protection rule"))
     tp_create.add_argument("pattern", help=_("Tag pattern"))
@@ -1375,7 +1494,11 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     notif_list = notif_sub.add_parser("list", help=_("List notifications"))
     notif_list.add_argument("--unread-only", action="store_true", help=_("Show unread only"))
     notif_list.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
     notif_read = notif_sub.add_parser("read", help=_("Mark notifications as read"))
     notif_read.add_argument("id", nargs="?", metavar="ID", help=_("Notification ID"))
@@ -1388,19 +1511,31 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     org_sub = org_parser.add_subparsers(dest="subcommand")
     org_list = org_sub.add_parser("list", help=_("List organizations"))
     org_list.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
     org_view = org_sub.add_parser("view", help=_("View organization details"))
     org_view.add_argument("name", help=_("Organization name"))
     org_members = org_sub.add_parser("members", help=_("List members"))
     org_members.add_argument("name", help=_("Organization name"))
     org_members.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
     org_repos = org_sub.add_parser("repos", help=_("List repositories"))
     org_repos.add_argument("name", help=_("Organization name"))
     org_repos.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
     org_create = org_sub.add_parser("create", help=_("Create organization"))
     org_create.add_argument("name", help=_("Organization name"))
@@ -1423,7 +1558,11 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     ssh_key_view.add_argument("id", help=_("SSH key ID"))
     ssh_key_list = ssh_key_sub.add_parser("list", help=_("List SSH keys"))
     ssh_key_list.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
     ssh_key_create = ssh_key_sub.add_parser("create", help=_("Create SSH key"))
     ssh_key_create.add_argument("--title", "-t", required=True, help=_("Title"))
@@ -1440,7 +1579,11 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     gpg_key_view.add_argument("id", help=_("GPG key ID"))
     gpg_key_list = gpg_key_sub.add_parser("list", help=_("List GPG keys"))
     gpg_key_list.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
     gpg_key_create = gpg_key_sub.add_parser("create", help=_("Create GPG key"))
     gpg_key_create.add_argument("--key", required=True, help=_("GPG public key"))
@@ -1454,7 +1597,11 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     secret_sub = secret_parser.add_subparsers(dest="subcommand")
     secret_list = secret_sub.add_parser("list", help=_("List secrets"))
     secret_list.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
     secret_list.add_argument("--org", help=_("Organization scope"))
     secret_set = secret_sub.add_parser("set", help=_("Set secret"))
@@ -1477,7 +1624,11 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     variable_sub = variable_parser.add_subparsers(dest="subcommand")
     variable_list = variable_sub.add_parser("list", help=_("List variables"))
     variable_list.add_argument(
-        "--limit", "-L", type=_positive_int, default=30, help=_("Maximum number of results")
+        "--limit",
+        "-L",
+        type=_non_negative_int,
+        default=30,
+        help=_("Maximum number of results (0 for unlimited)"),
     )
     variable_list.add_argument("--org", help=_("Organization scope"))
     variable_set = variable_sub.add_parser("set", help=_("Set variable"))

--- a/src/gfo/commands/release.py
+++ b/src/gfo/commands/release.py
@@ -19,7 +19,7 @@ def handle_list(args: argparse.Namespace, *, fmt: str, jq: str | None = None) ->
     draft = getattr(args, "draft", None)
     prerelease = getattr(args, "prerelease", None)
     has_filter = draft is not None or prerelease is not None
-    limit: int = 0 if has_filter else (args.limit or 30)
+    limit: int = 0 if has_filter else args.limit
     releases = adapter.list_releases(limit=limit)
     if draft is not None:
         releases = [r for r in releases if r.draft == draft]

--- a/src/gfo/locale/ja/LC_MESSAGES/gfo.po
+++ b/src/gfo/locale/ja/LC_MESSAGES/gfo.po
@@ -104,6 +104,9 @@ msgstr "エラー: --jq の式は空にできません。"
 msgid "{value} is not a positive integer"
 msgstr "{value} は正の整数ではありません"
 
+msgid "{value} is not a non-negative integer"
+msgstr "{value} は 0 以上の整数ではありません"
+
 msgid "Unexpected error: {err}"
 msgstr "予期しないエラー: {err}"
 
@@ -1120,8 +1123,8 @@ msgstr "プレリリースとしてマークする"
 msgid "Mask variable in logs"
 msgstr "ログ内で変数をマスクする"
 
-msgid "Maximum number of results"
-msgstr "最大取得件数"
+msgid "Maximum number of results (0 for unlimited)"
+msgstr "最大取得件数（0 で無制限）"
 
 msgid "Merge method"
 msgstr "マージ方法"

--- a/tests/test_adapters/test_gitlab.py
+++ b/tests/test_adapters/test_gitlab.py
@@ -3868,6 +3868,54 @@ class TestIssueSubscribe:
             gitlab_adapter.subscribe_issue(999)
 
 
+class TestGetIssueTimeline:
+    def _add_event_mocks(self, mock_responses):
+        mock_responses.add(
+            responses.GET,
+            f"{PROJECT}/issues/1/resource_state_events",
+            json=[
+                {
+                    "id": 1,
+                    "state": "closed",
+                    "user": {"username": "alice"},
+                    "created_at": "2024-01-01T00:00:00Z",
+                },
+                {
+                    "id": 2,
+                    "state": "reopened",
+                    "user": {"username": "bob"},
+                    "created_at": "2024-01-02T00:00:00Z",
+                },
+            ],
+            status=200,
+        )
+        mock_responses.add(
+            responses.GET,
+            f"{PROJECT}/issues/1/resource_label_events",
+            json=[
+                {
+                    "id": 3,
+                    "action": "add",
+                    "label": {"name": "bug"},
+                    "user": {"username": "alice"},
+                    "created_at": "2024-01-03T00:00:00Z",
+                },
+            ],
+            status=200,
+        )
+
+    def test_limit_truncates(self, mock_responses, gitlab_adapter):
+        self._add_event_mocks(mock_responses)
+        events = gitlab_adapter.get_issue_timeline(1, limit=2)
+        assert len(events) == 2
+
+    def test_limit_zero_returns_all(self, mock_responses, gitlab_adapter):
+        self._add_event_mocks(mock_responses)
+        events = gitlab_adapter.get_issue_timeline(1, limit=0)
+        assert len(events) == 3
+        assert [e.id for e in events] == [1, 2, 3]
+
+
 class TestOrgSecrets:
     def test_list_org_secrets(self, mock_responses, gitlab_adapter):
         mock_responses.add(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,7 @@ from gfo.cli import (
     _DISPATCH,
     _ensure_utf8_stdio,
     _hoist_global_flags,
+    _non_negative_int,
     _positive_int,
     _pre_parse_format,
     _resolve_format,
@@ -57,6 +58,33 @@ def test_positive_int_float_string_raises():
         _positive_int("1.5")
 
 
+# ── _non_negative_int のテスト ──
+
+
+def test_non_negative_int_valid():
+    assert _non_negative_int("1") == 1
+    assert _non_negative_int("100") == 100
+
+
+def test_non_negative_int_zero_allowed():
+    assert _non_negative_int("0") == 0
+
+
+def test_non_negative_int_negative_raises():
+    with pytest.raises(argparse.ArgumentTypeError, match="-5 is not a non-negative integer"):
+        _non_negative_int("-5")
+
+
+def test_non_negative_int_non_integer_raises():
+    with pytest.raises(argparse.ArgumentTypeError, match="abc is not a non-negative integer"):
+        _non_negative_int("abc")
+
+
+def test_non_negative_int_float_string_raises():
+    with pytest.raises(argparse.ArgumentTypeError, match="1.5 is not a non-negative integer"):
+        _non_negative_int("1.5")
+
+
 # ── create_parser のテスト ──
 
 
@@ -67,6 +95,18 @@ def test_parser_version(capsys):
     assert exc.value.code == 0
     captured = capsys.readouterr()
     assert f"gfo {__version__}" in captured.out
+
+
+def test_parser_limit_zero_means_unlimited():
+    parser, _ = create_parser()
+    args = parser.parse_args(["issue", "list", "--limit", "0"])
+    assert args.limit == 0
+
+
+def test_parser_limit_negative_rejected():
+    parser, _ = create_parser()
+    with pytest.raises(ConfigError):
+        parser.parse_args(["issue", "list", "--limit", "-1"])
 
 
 def test_parser_init_defaults():

--- a/tests/test_commands/test_release.py
+++ b/tests/test_commands/test_release.py
@@ -64,6 +64,13 @@ class TestHandleList:
 
         self.adapter.list_releases.assert_called_once_with(limit=30)
 
+    def test_limit_zero_passed_through(self, sample_config):
+        args = make_args(limit=0)
+        with _patch_all(sample_config, self.adapter):
+            release_cmd.handle_list(args, fmt="table")
+
+        self.adapter.list_releases.assert_called_once_with(limit=0)
+
     def test_outputs_results(self, sample_config, capsys):
         args = make_args(limit=30)
         with _patch_all(sample_config, self.adapter):


### PR DESCRIPTION
## 概要

Closes #65

ページネーション実装（`paginate_*`）は `limit=0` を「無制限」として扱うのに、CLI の `--limit` が `_positive_int` で 0 を拒否していたため、全件取得を指定する手段がなかった。

## 変更内容

- `_non_negative_int` を追加し、全 34 箇所の `--limit` に適用（`--interval` は従来どおり `_positive_int`）
- help を `Maximum number of results (0 for unlimited)` に変更（`ci download --timeout` の流儀に合わせた）。ja 訳を `.po` に追加
- limit=0 が正しく機能しなかった 2 箇所を修正:
  - `release list`: `args.limit or 30` が 0 を 30 に変換していた → `args.limit` をそのまま渡す
  - GitLab `get_issue_timeline`: 末尾の `events[:limit]` が limit=0 で空リストを返していた → `limit > 0` ガードを追加
- `docs/commands.ja.md` の `--limit` 説明 5 箇所に「`0` で全件取得」を追記

## テスト

- `_non_negative_int` の単体テスト（0 許可 / 負数・非整数拒否）
- パーサーで `--limit 0` 受理・`--limit -1` 拒否
- `release list --limit 0` が `list_releases(limit=0)` に素通しされること
- GitLab `get_issue_timeline` の limit=0（全件）/ limit=2（切り詰め）

全 3834 件 pass、ruff / mypy green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)