### PR TITLE
fix(cli): parse 段階のエラーにも非 TTY の auto-JSON を適用する

### DIFF
--- a/src/gfo/cli.py
+++ b/src/gfo/cli.py
@@ -1921,6 +1921,19 @@ def _pre_parse_format(argv: list[str] | None) -> str | None:
     return None
 
 
+def _pre_parse_resolve_format(argv: list[str] | None) -> str:
+    """parse 段階のエラー用に出力フォーマットを解決する。
+
+    _resolve_format と同じ優先順位（--jq > --format > config > TTY 検出）を適用し、
+    非 TTY の auto-JSON を parse 段階のエラーにも効かせる。config.toml が読めない
+    場合でもエラー報告自体は継続する必要があるため table にフォールバックする。
+    """
+    try:
+        return _resolve_format(_pre_parse_format(argv), None)
+    except GfoError:
+        return "table"
+
+
 _GLOBAL_FLAGS = {"--format", "--jq", "--remote", "--repo", "-R", "--account"}
 
 # auth/init は独自の --account を持つためホイスト対象から除外
@@ -1977,24 +1990,27 @@ def main(argv: list[str] | None = None) -> int:
             argv = _hoist_global_flags(sys.argv[1:])
         args = parser.parse_args(argv)
     except ConfigError as err:
-        pre_fmt = _pre_parse_format(argv)
-        if pre_fmt == "json":
+        if _pre_parse_resolve_format(argv) == "json":
             print(format_error_json(err), file=sys.stderr)
         else:
             print(str(err), file=sys.stderr)
         return err.exit_code
 
     if args.command is None:
-        parser.print_help()
+        if _pre_parse_resolve_format(argv) == "json":
+            no_cmd_err = GfoError(_("No command specified."))
+            no_cmd_err.hint = _("Run 'gfo --help' to see available commands.")
+            print(format_error_json(no_cmd_err), file=sys.stderr)
+        else:
+            parser.print_help()
         return 1
 
     # --repo と --remote の排他検証
     repo_value = getattr(args, "global_repo", None)
     remote_value = getattr(args, "global_remote", None)
     if repo_value and remote_value:
-        pre_fmt = _pre_parse_format(argv)
         excl_err = ConfigError(_("--repo and --remote are mutually exclusive."))
-        if pre_fmt == "json":
+        if _pre_parse_resolve_format(argv) == "json":
             print(format_error_json(excl_err), file=sys.stderr)
         else:
             print(str(excl_err), file=sys.stderr)
@@ -2018,8 +2034,17 @@ def main(argv: list[str] | None = None) -> int:
         key = (args.command, getattr(args, "subcommand", None))
 
         if key not in _DISPATCH:
-            # サブコマンド未指定の場合、該当コマンドの help を表示
-            subparser_map[args.command].print_help()
+            # サブコマンド未指定の場合、該当コマンドの help を表示（JSON モードでは構造化エラー）
+            if resolved_fmt == "json":
+                no_sub_err = GfoError(
+                    _("No subcommand specified for '{command}'.").format(command=args.command)
+                )
+                no_sub_err.hint = _(
+                    "Run 'gfo {command} --help' to see available subcommands."
+                ).format(command=args.command)
+                print(format_error_json(no_sub_err), file=sys.stderr)
+            else:
+                subparser_map[args.command].print_help()
             return 1
 
         handler = _DISPATCH[key]

--- a/src/gfo/locale/ja/LC_MESSAGES/gfo.po
+++ b/src/gfo/locale/ja/LC_MESSAGES/gfo.po
@@ -107,6 +107,18 @@ msgstr "{value} は正の整数ではありません"
 msgid "{value} is not a non-negative integer"
 msgstr "{value} は 0 以上の整数ではありません"
 
+msgid "No command specified."
+msgstr "コマンドが指定されていません。"
+
+msgid "Run 'gfo --help' to see available commands."
+msgstr "利用可能なコマンドは 'gfo --help' で確認できます。"
+
+msgid "No subcommand specified for '{command}'."
+msgstr "'{command}' のサブコマンドが指定されていません。"
+
+msgid "Run 'gfo {command} --help' to see available subcommands."
+msgstr "利用可能なサブコマンドは 'gfo {command} --help' で確認できます。"
+
 msgid "Unexpected error: {err}"
 msgstr "予期しないエラー: {err}"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -15,6 +16,7 @@ from gfo.cli import (
     _non_negative_int,
     _positive_int,
     _pre_parse_format,
+    _pre_parse_resolve_format,
     _resolve_format,
     create_parser,
     main,
@@ -839,7 +841,11 @@ def test_dispatch_table_all_callable():
 
 
 def test_main_no_args_returns_1(capsys):
-    result = main([])
+    with (
+        patch("gfo.cli.get_configured_output_format", return_value=None),
+        patch.dict("os.environ", {"GFO_NO_AUTO_JSON": "1"}, clear=False),
+    ):
+        result = main([])
     assert result == 1
     captured = capsys.readouterr()
     assert "gfo" in captured.out  # help テキストに prog 名が含まれる
@@ -854,8 +860,93 @@ def test_main_version(capsys):
 
 
 def test_main_subcommand_only_returns_1(capsys):
-    result = main(["pr"])
+    with (
+        patch("gfo.cli.get_configured_output_format", return_value=None),
+        patch.dict("os.environ", {"GFO_NO_AUTO_JSON": "1"}, clear=False),
+    ):
+        result = main(["pr"])
     assert result == 1
+    captured = capsys.readouterr()
+    assert "pr" in captured.out  # サブコマンドの help が表示される
+
+
+def test_main_no_args_json_when_non_tty(capsys):
+    """非 TTY の auto-JSON でコマンド未指定が構造化エラーになる。"""
+    with (
+        patch("gfo.cli.get_configured_output_format", return_value=None),
+        patch("gfo.cli.sys.stdout") as mock_stdout,
+        patch.dict("os.environ", {}, clear=False),
+    ):
+        mock_stdout.isatty.return_value = False
+        import os
+
+        os.environ.pop("GFO_NO_AUTO_JSON", None)
+        result = main([])
+    assert result == 1
+    err = capsys.readouterr().err
+    data = json.loads(err)
+    assert data["error"] == "general_error"
+    assert data["exit_code"] == 1
+    assert "hint" in data
+
+
+def test_main_subcommand_only_json_when_non_tty(capsys):
+    """非 TTY の auto-JSON でサブコマンド未指定が構造化エラーになる。"""
+    with (
+        patch("gfo.cli.get_configured_output_format", return_value=None),
+        patch("gfo.cli.sys.stdout") as mock_stdout,
+        patch.dict("os.environ", {}, clear=False),
+    ):
+        mock_stdout.isatty.return_value = False
+        import os
+
+        os.environ.pop("GFO_NO_AUTO_JSON", None)
+        result = main(["pr"])
+    assert result == 1
+    err = capsys.readouterr().err
+    data = json.loads(err)
+    assert data["error"] == "general_error"
+    assert "pr" in data["message"]
+    assert "hint" in data
+
+
+def test_main_argparse_error_auto_json_when_non_tty(capsys):
+    """非 TTY の auto-JSON で argparse エラーが構造化される。"""
+    with (
+        patch("gfo.cli.get_configured_output_format", return_value=None),
+        patch("gfo.cli.sys.stdout") as mock_stdout,
+        patch.dict("os.environ", {}, clear=False),
+    ):
+        mock_stdout.isatty.return_value = False
+        import os
+
+        os.environ.pop("GFO_NO_AUTO_JSON", None)
+        result = main(["pr", "list", "--unknown-flag"])
+    assert result == 6
+    err = capsys.readouterr().err
+    data = json.loads(err)
+    assert data["error"] == "config_error"
+    assert "unrecognized arguments" in data["message"]
+
+
+def test_main_repo_remote_exclusive_auto_json_when_non_tty(capsys):
+    """非 TTY の auto-JSON で --repo/--remote 排他エラーが構造化される。"""
+    with (
+        patch("gfo.cli.get_configured_output_format", return_value=None),
+        patch("gfo.cli.sys.stdout") as mock_stdout,
+        patch.dict("os.environ", {}, clear=False),
+    ):
+        mock_stdout.isatty.return_value = False
+        import os
+
+        os.environ.pop("GFO_NO_AUTO_JSON", None)
+        result = main(["--repo", "github.com/o/r", "--remote", "upstream", "pr", "list"])
+    assert result == 6
+    err = capsys.readouterr().err
+    data = json.loads(err)
+    assert data["error"] == "config_error"
+    assert "--repo" in data["message"]
+    assert "--remote" in data["message"]
 
 
 def test_main_normal_dispatch():
@@ -1254,6 +1345,54 @@ def test_pre_parse_format_flag():
 
 def test_pre_parse_format_jq():
     assert _pre_parse_format(["--jq", ".command"]) == "json"
+
+
+# ── _pre_parse_resolve_format のテスト ──
+
+
+def test_pre_parse_resolve_format_explicit_wins():
+    assert _pre_parse_resolve_format(["--format", "plain", "pr", "list"]) == "plain"
+
+
+def test_pre_parse_resolve_format_config_wins():
+    with (
+        patch("gfo.cli.get_configured_output_format", return_value="plain"),
+        patch("gfo.cli.sys.stdout") as mock_stdout,
+    ):
+        mock_stdout.isatty.return_value = False
+        assert _pre_parse_resolve_format(["pr", "list"]) == "plain"
+
+
+def test_pre_parse_resolve_format_non_tty_auto_json():
+    with (
+        patch("gfo.cli.get_configured_output_format", return_value=None),
+        patch("gfo.cli.sys.stdout") as mock_stdout,
+        patch.dict("os.environ", {}, clear=False),
+    ):
+        mock_stdout.isatty.return_value = False
+        import os
+
+        os.environ.pop("GFO_NO_AUTO_JSON", None)
+        assert _pre_parse_resolve_format(["pr", "list"]) == "json"
+
+
+def test_pre_parse_resolve_format_no_auto_json_env():
+    with (
+        patch("gfo.cli.get_configured_output_format", return_value=None),
+        patch("gfo.cli.sys.stdout") as mock_stdout,
+        patch.dict("os.environ", {"GFO_NO_AUTO_JSON": "1"}, clear=False),
+    ):
+        mock_stdout.isatty.return_value = False
+        assert _pre_parse_resolve_format(["pr", "list"]) == "table"
+
+
+def test_pre_parse_resolve_format_broken_config_falls_back_to_table():
+    """config.toml が壊れていてもエラー報告を継続できるよう table に落ちる。"""
+    with patch(
+        "gfo.cli.get_configured_output_format",
+        side_effect=ConfigError("broken config"),
+    ):
+        assert _pre_parse_resolve_format(["pr", "list"]) == "table"
 
 
 # ── --remote グローバルオプションのテスト ──

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,21 +2,43 @@
 
 from __future__ import annotations
 
+import json
+import os
 import subprocess
 import sys
 
 
-def test_python_m_gfo_no_args():
-    """python -m gfo は引数なしで exit code 1 を返す。"""
+def test_python_m_gfo_no_args(tmp_path):
+    """python -m gfo は引数なしで exit code 1 を返す（auto-JSON 無効時は help）。"""
+    env = {**os.environ, "GFO_NO_AUTO_JSON": "1", "XDG_CONFIG_HOME": str(tmp_path)}
     result = subprocess.run(
         [sys.executable, "-m", "gfo"],
         capture_output=True,
         stdin=subprocess.DEVNULL,
         text=True,
         encoding="utf-8",
+        env=env,
     )
     assert result.returncode == 1
     assert "gfo" in result.stdout  # help テキスト
+
+
+def test_python_m_gfo_no_args_non_tty_json(tmp_path):
+    """python -m gfo は非 TTY の auto-JSON で構造化エラーを stderr に返す。"""
+    env = {**os.environ, "XDG_CONFIG_HOME": str(tmp_path)}
+    env.pop("GFO_NO_AUTO_JSON", None)
+    result = subprocess.run(
+        [sys.executable, "-m", "gfo"],
+        capture_output=True,
+        stdin=subprocess.DEVNULL,
+        text=True,
+        encoding="utf-8",
+        env=env,
+    )
+    assert result.returncode == 1
+    data = json.loads(result.stderr)
+    assert data["error"] == "general_error"
+    assert data["exit_code"] == 1
 
 
 def test_python_m_gfo_version():


### PR DESCRIPTION
## 概要

Closes #66

ハンドラ実行中の `GfoError` は非 TTY で自動的に JSON 化されるのに、parse 段階のエラーは明示的な `--format` / `--jq` しか見ていなかったため、pipe / AI agent 実行時にエラー種別によって機械可読性が変わっていた。

## 変更内容

- `_pre_parse_resolve_format()` を新設。`_pre_parse_format()`（明示指定の簡易判定）の結果を `_resolve_format()` に通し、実行時と同じ優先順位（`--jq` > `--format` > config > TTY 検出 + `GFO_NO_AUTO_JSON`）を parse 段階にも適用する。config.toml が壊れていてもエラー報告を継続できるよう `GfoError` 時は table にフォールバック。
- 適用経路:
  - argparse 由来の `ConfigError`（不正な引数等）→ JSON モードでは `config_error` / exit 6
  - `--repo` / `--remote` 排他エラー → 同上
  - コマンド未指定 / サブコマンド未指定 → JSON モードでは help の代わりに `general_error` + `hint` を stderr へ。**exit code は従来どおり 1 を維持**（TTY か否かで exit code が変わらないようにするため）。table モードでは従来どおり help を表示。

## テスト

- `_pre_parse_resolve_format` 単体（明示指定 / config / auto-JSON / opt-out / config 破損フォールバック）
- main() E2E: 上記 4 経路の非 TTY auto-JSON 化
- `python -m gfo`（subprocess・実 pipe）: auto-JSON で構造化エラー / `GFO_NO_AUTO_JSON=1` で help（`XDG_CONFIG_HOME` を tmp に向けて hermetic 化）

実 CLI でも全経路の JSON 化・opt-out 時の help 表示を確認済み。全 3844 件 pass、ruff / mypy green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)