### PR TITLE
fix(config): Windows 上の mypy で get_config_dir が unreachable 判定される問題を修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,11 @@ jobs:
       - name: Type check (mypy)
         run: uv run mypy src/gfo
 
+      # Windows ローカル開発 (README/CLAUDE の手順) でも green を保つため、
+      # sys.platform 分岐の unreachable を win32 視点でも検証する (issue #62)。
+      - name: Type check (mypy, --platform win32)
+        run: uv run mypy --platform win32 src/gfo
+
       # runner は 4 vCPU 固定なので xdist は -n 4 を明示 (auto でも同等だが意図を固定)。
       # カバレッジは max leg のみ取得する (matrix.cov)。min leg は cov 無し = 高速。
       # 3.13 (max) は coverage の sysmon コアを使い計測オーバーヘッドを抑える (3.11 は非対応)。

--- a/src/gfo/config.py
+++ b/src/gfo/config.py
@@ -75,10 +75,11 @@ def get_config_dir() -> Path:
         if appdata:
             return Path(appdata) / "gfo"
         return Path.home() / "AppData" / "Roaming" / "gfo"
-    xdg_config_home = os.environ.get("XDG_CONFIG_HOME", "").strip()
-    if xdg_config_home:
-        return Path(xdg_config_home) / "gfo"
-    return Path.home() / ".config" / "gfo"
+    else:  # mypy (win32) の platform 分岐枝刈りに載せるため明示的な else が必要
+        xdg_config_home = os.environ.get("XDG_CONFIG_HOME", "").strip()
+        if xdg_config_home:
+            return Path(xdg_config_home) / "gfo"
+        return Path.home() / ".config" / "gfo"
 
 
 def get_config_path() -> Path:


### PR DESCRIPTION
## 概要

Closes #62

Windows 上（および `mypy --platform win32`）で `get_config_dir()` の非 Windows 分岐が unreachable と判定され `mypy src/gfo` が fail していた。

## 原因

`if sys.platform == "win32":` ブロックが `return` で完結しているため、後続の XDG 解決コードが **フロー到達不能**として警告される（`warn_unreachable = true`）。mypy は platform チェックの if/else 分岐は「意図的な枝刈り」として警告を抑制するが、フォールスルー形式はその対象外。

## 変更内容

- `src/gfo/config.py`: フォールスルーを明示的な `else:` に変更（挙動変更なし、インデントのみ）
- `.github/workflows/ci.yml`: 再発防止として test 両 leg に `mypy --platform win32 src/gfo` を追加。auth.py / auth_cmd.py の既存 platform 分岐も win32 視点で green なことを確認済み

## 検証

- `mypy src/gfo` / `mypy --platform win32 src/gfo` とも green
- 全 3844 件 pass、ruff green

🤖 Generated with [Claude Code](https://claude.com/claude-code)