### PR TITLE
docs(rules): CLAUDE.md / .claude/rules の記述を実装と同期する

### DIFF
--- a/.claude/rules/02-adapter-common.md
+++ b/.claude/rules/02-adapter-common.md
@@ -10,23 +10,39 @@ paths:
 
 ```
 GitServiceAdapter (ABC, adapter/base.py)
-├── GitHubAdapter           @register("github")
+├── GitHubAdapter           @register("github")      ※ GitHubLikeAdapter Mixin を併用
+│   └── GitBucketAdapter    @register("gitbucket")
 ├── GitLabAdapter           @register("gitlab")
 ├── BitbucketAdapter        @register("bitbucket")
 ├── BacklogAdapter          @register("backlog")
 ├── AzureDevOpsAdapter      @register("azure-devops")
-└── GiteaAdapter            @register("gitea")
+└── GiteaAdapter            @register("gitea")       ※ GitHubLikeAdapter Mixin を併用
     ├── ForgejoAdapter      @register("forgejo")
-    ├── GogsAdapter         @register("gogs")
-    └── GitBucketAdapter    @register("gitbucket")
+    └── GogsAdapter         @register("gogs")
 ```
 
-`GitHubLikeAdapter`（`adapter/base.py`）は GitHub/Gitea 系の共通 `_to_*` 変換ヘルパー Mixin。
+- `GitHubAdapter` / `GiteaAdapter` は `class XxxAdapter(GitHubLikeAdapter, GitServiceAdapter)` の多重継承。
+- `GitBucketAdapter` は **`GitHubAdapter` のサブクラス**（`GiteaAdapter` ではない。GitBucket は GitHub API 互換のため）。
+- `GitHubLikeAdapter`（`adapter/github_like.py`）は GitHub/Gitea 系の共通 `_to_*` 変換ヘルパー Mixin。
+  `base.py` 末尾の `GitHubLikeAdapter` は後方互換の再 export であり、定義の実体ではない。
+
+## 共有シンボルの import 経路（正典）
+
+新規アダプターは既存の具象アダプターと同じ経路で import すること:
+
+| シンボル | 経路 |
+|---|---|
+| `GitServiceAdapter`, `_wrap_conversion_error`, `_mask_token_in_exception` | `from .base import ...`（実体は `_helpers.py` だが `base.py` が再 export） |
+| データクラス（`PullRequest` 等） | `from .models import ...` |
+| `GitHubLikeAdapter`（GitHub/Gitea 系のみ） | `from .github_like import ...` |
+
+`github_like.py` 自身だけは `base.py` との循環参照回避のため `._helpers` から直接 import している。アダプター実装はこれを真似しないこと。
 
 ## データクラス規約
 
+全データクラスは `adapter/models.py` に集約する（標準ライブラリ以外に依存しない）。
 すべて `frozen=True, slots=True` の `@dataclass`:
-`PullRequest`, `Issue`, `Repository`, `Release`, `Label`, `Milestone`
+`PullRequest`, `Issue`, `Repository`, `Release`, `Label`, `Milestone` ほか
 
 ## create_or_update_file の戻り値
 

--- a/.claude/rules/08-gitea-family.md
+++ b/.claude/rules/08-gitea-family.md
@@ -20,7 +20,7 @@ paths:
 - **list_issues**: `type: "issues"` + `not r.get("pull_request")` でフィルタ
   - Gitea はissueレスポンスに `pull_request: null` が含まれる
 - **ページネーション**: `per_page_key="limit"`
-- **マイルストーン**: `number` フィールドなし → `id` でフォールバック（`base.py: _to_milestone`）
+- **マイルストーン**: `number` フィールドなし → `id` でフォールバック（`github_like.py: _to_milestone`）
 
 ## Gogs 固有
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@
 ## 技術スタック
 
 - **ランタイム依存**: `requests` のみ
-- **開発依存**（`[dependency-groups]` で管理）: `pytest`, `responses`（HTTP モック）, `pytest-cov`, `ruff`, `bandit`, `mypy`, `types-requests`, `pre-commit`
+- **開発依存**（`[dependency-groups]` で管理）: `pytest`, `responses`（HTTP モック）, `pytest-cov`, `pytest-xdist`（CI の `-n 4` 並列実行）, `ruff`, `bandit`, `mypy`, `types-requests`, `pre-commit`
 - **ビルド**: `hatchling`（バージョンは `src/gfo/__init__.py`）
 - **toolchain**: `mise`（python / uv を pin）+ `uv`（依存解決・`uv.lock` で frozen install）
 
@@ -85,7 +85,7 @@ uv run pre-commit install
 
 GitHub Rules（`main` ブランチ保護・リリースタグ保護）は free プランでは実効しないが、**規律として遵守する**。
 
-- **`main` へ直接 commit / push・force-push しない。** 必ず feature branch を切る（`git switch -c <kebab>`）→ commit → push → `gh pr create --base main` → **CI green を確認して self-merge**（squash）。
+- **`main` へ直接 commit / push・force-push しない。** 必ず feature branch を切る（`git switch -c <kebab>`）→ commit → push → `gh pr create --base main` → **CI green を確認して self-merge**（`gh pr merge --merge`。squash はリポジトリ設定で無効）。
 - **赤い CI はマージしない。**
 - 問題を見つけたら **issue を起票** してから着手する。
 - リリースタグ（保護対象）を勝手に作成・移動・削除しない。
@@ -118,8 +118,12 @@ Conventional Commits（日本語 subject、header ≤72 目安）。scope 例: `
 src/gfo/
 ├── cli.py / auth.py / config.py / detect.py / exceptions.py
 ├── git_util.py / http.py / output.py
+├── i18n.py / _context.py / locale/   # gettext（ja）。.po を commit、.mo は hatch_build.py がビルド時生成
 ├── adapter/
-│   ├── base.py          # 抽象基底クラス + データクラス定義
+│   ├── base.py          # GitServiceAdapter 抽象基底クラス（共有ヘルパーの再 export 元）
+│   ├── models.py        # データクラス定義（PullRequest, Issue ほか）
+│   ├── github_like.py   # GitHubLikeAdapter: GitHub/Gitea 系共通の _to_* 変換 Mixin
+│   ├── _helpers.py      # _wrap_conversion_error 等（base ⇔ github_like の循環参照回避）
 │   ├── registry.py      # @register デコレータ, create_adapter()
 │   ├── github.py / gitlab.py / bitbucket.py / azure_devops.py
 │   ├── backlog.py / gitea.py / forgejo.py / gogs.py / gitbucket.py


### PR DESCRIPTION
## 概要

Closes #71

AI agent が一次情報として参照する CLAUDE.md / `.claude/rules/` と実装の乖離を解消する。issue の指摘 5 点すべてを実装と突き合わせて確認・修正した。

## 変更内容

### .claude/rules/02-adapter-common.md
- 継承ツリーを実装に同期: `GitBucketAdapter` を `GitHubAdapter` の子に移動（`gitbucket.py:49`。rules 08 の正しい記載とも整合）、`GitHubAdapter` / `GiteaAdapter` の `GitHubLikeAdapter` Mixin 多重継承を明示
- `GitHubLikeAdapter` の定義場所を `adapter/github_like.py` に訂正（`base.py` 末尾は後方互換の再 export である旨も明記）
- **共有シンボルの import 経路（正典）** セクションを新設: ヘルパーは `from .base import`、データクラスは `from .models import`、Mixin は `from .github_like import`。`github_like.py` だけが循環参照回避で `._helpers` 直 import であり真似しないことを明記
- データクラスの集約先が `adapter/models.py` であることを明記

### .claude/rules/08-gitea-family.md
- `_to_milestone` の定義場所を `base.py` → `github_like.py`（:119）に訂正（同種の乖離を追加発見）

### CLAUDE.md
- ディレクトリマップに `i18n.py` / `_context.py` / `locale/`（.po commit・.mo ビルド時生成）と `adapter/models.py` / `github_like.py` / `_helpers.py` を追加。`base.py` の説明から「データクラス定義」を除去
- 開発依存リストに `pytest-xdist` を追記（`pyproject.toml:34`、CI の `-n 4` が依存）
- self-merge の方式を「squash」→「`gh pr merge --merge`（squash はリポジトリ設定で無効）」に訂正（`allow_squash_merge: false` を API で確認済み・同種の乖離を追加発見）

🤖 Generated with [Claude Code](https://claude.com/claude-code)