### PR TITLE
feat(cli): mutation 系コマンドの成功メッセージを --format json で構造化する

### DIFF
--- a/docs/commands.ja.md
+++ b/docs/commands.ja.md
@@ -13,6 +13,20 @@
 | `--account ACCOUNT` | マルチアカウントのトークン解決に使用するアカウント名（`gfo auth login --account` 参照） | — |
 | `--version` | バージョンを表示して終了 | — |
 
+### mutation 系コマンドの JSON 出力
+
+create / delete / close などの mutation 系コマンドの成功メッセージは、`--format json`（および非 TTY 時の auto-JSON）では構造化 JSON になります。`result`（実行結果の動詞）+ 対象を特定するフィールド + `message`（ローカライズ済みメッセージ）の形式です。
+
+```console
+$ gfo repo delete --yes --format json
+{"result": "deleted", "repository": "owner/repo", "message": "Deleted repository 'owner/repo'."}
+
+$ gfo issue close 7 --jq .result
+"closed"
+```
+
+エラー側の JSON（`{"error": ..., "message": ..., "exit_code": ...}`）と対になっており、成功・失敗とも機械可読です。確認プロンプトを拒否した場合は `{"result": "aborted", ...}` が返ります。
+
 ---
 
 ## gfo init

--- a/src/gfo/commands/auth_cmd.py
+++ b/src/gfo/commands/auth_cmd.py
@@ -12,7 +12,7 @@ import gfo.detect
 from gfo.detect import normalize_host
 from gfo.exceptions import ConfigError, DetectionError, GitCommandError
 from gfo.i18n import _
-from gfo.output import output
+from gfo.output import output, output_result
 
 
 @dataclasses.dataclass
@@ -94,7 +94,14 @@ def handle_login(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -
 
     account = getattr(args, "account", "default")
     gfo.auth.save_token(host, token, account=account)
-    print(_("Token saved for {host} (account: {account})").format(host=host, account=account))
+    output_result(
+        _("Token saved for {host} (account: {account})").format(host=host, account=account),
+        result="saved",
+        host=host,
+        account=account,
+        fmt=fmt,
+        jq=jq,
+    )
 
 
 def handle_status(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -132,7 +139,14 @@ def handle_switch(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
             ) from e
 
     gfo.auth.switch_account(host, args.account)
-    print(_("Switched to account '{account}' for {host}").format(account=args.account, host=host))
+    output_result(
+        _("Switched to account '{account}' for {host}").format(account=args.account, host=host),
+        result="switched",
+        host=host,
+        account=args.account,
+        fmt=fmt,
+        jq=jq,
+    )
 
 
 def handle_token(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -184,6 +198,19 @@ def handle_logout(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
     gfo.auth.remove_token(host, account=account)
 
     if account:
-        print(_("Logged out account '{account}' from {host}").format(account=account, host=host))
+        output_result(
+            _("Logged out account '{account}' from {host}").format(account=account, host=host),
+            result="logged_out",
+            host=host,
+            account=account,
+            fmt=fmt,
+            jq=jq,
+        )
     else:
-        print(_("Logged out from {host}").format(host=host))
+        output_result(
+            _("Logged out from {host}").format(host=host),
+            result="logged_out",
+            host=host,
+            fmt=fmt,
+            jq=jq,
+        )

--- a/src/gfo/commands/branch.py
+++ b/src/gfo/commands/branch.py
@@ -6,7 +6,7 @@ import argparse
 
 from gfo.commands import get_adapter
 from gfo.i18n import _
-from gfo.output import output
+from gfo.output import output, output_result
 
 
 def handle_view(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -34,4 +34,10 @@ def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
     """gfo branch delete <name> のハンドラ。"""
     adapter = get_adapter()
     adapter.delete_branch(name=args.name)
-    print(_("Deleted branch '{name}'.").format(name=args.name))
+    output_result(
+        _("Deleted branch '{name}'.").format(name=args.name),
+        result="deleted",
+        fmt=fmt,
+        jq=jq,
+        branch=args.name,
+    )

--- a/src/gfo/commands/branch_protect.py
+++ b/src/gfo/commands/branch_protect.py
@@ -6,7 +6,7 @@ import argparse
 
 from gfo.commands import get_adapter
 from gfo.i18n import _
-from gfo.output import output
+from gfo.output import output, output_result
 
 
 def handle_list(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -46,4 +46,10 @@ def handle_remove(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
     """gfo branch-protect remove <branch> のハンドラ。"""
     adapter = get_adapter()
     adapter.remove_branch_protection(args.branch)
-    print(_("Removed branch protection for '{branch}'.").format(branch=args.branch))
+    output_result(
+        _("Removed branch protection for '{branch}'.").format(branch=args.branch),
+        result="removed",
+        fmt=fmt,
+        jq=jq,
+        branch=args.branch,
+    )

--- a/src/gfo/commands/ci.py
+++ b/src/gfo/commands/ci.py
@@ -7,7 +7,7 @@ import argparse
 from gfo.commands import get_adapter
 from gfo.exceptions import ConfigError
 from gfo.i18n import _
-from gfo.output import output
+from gfo.output import output, output_result
 
 
 def handle_list(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -28,14 +28,26 @@ def handle_cancel(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
     """gfo ci cancel <id> のハンドラ。"""
     adapter = get_adapter()
     adapter.cancel_pipeline(args.id)
-    print(_("Canceled pipeline run '{id}'.").format(id=args.id))
+    output_result(
+        _("Canceled pipeline run '{id}'.").format(id=args.id),
+        result="canceled",
+        id=args.id,
+        fmt=fmt,
+        jq=jq,
+    )
 
 
 def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo ci delete <id> のハンドラ。"""
     adapter = get_adapter()
     adapter.delete_pipeline_run(args.id)
-    print(_("Deleted pipeline run '{id}'.").format(id=args.id))
+    output_result(
+        _("Deleted pipeline run '{id}'.").format(id=args.id),
+        result="deleted",
+        id=args.id,
+        fmt=fmt,
+        jq=jq,
+    )
 
 
 def handle_trigger(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -89,7 +101,7 @@ def handle_watch(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -
             break
         if timeout > 0 and (time.monotonic() - start) >= timeout:
             sys.stderr.write("\n")
-            print(_("Timed out after {timeout} seconds.").format(timeout=timeout))
+            print(_("Timed out after {timeout} seconds.").format(timeout=timeout), file=sys.stderr)
             break
         time.sleep(args.interval)
     output(pipeline, fmt=fmt, jq=jq)
@@ -102,7 +114,13 @@ def handle_download(args: argparse.Namespace, *, fmt: str, jq: str | None = None
     path = adapter.download_run_logs(
         args.id, job_id=getattr(args, "job", None), output_dir=output_dir
     )
-    print(_("Downloaded: {path}").format(path=path))
+    output_result(
+        _("Downloaded: {path}").format(path=path),
+        result="downloaded",
+        path=path,
+        fmt=fmt,
+        jq=jq,
+    )
 
 
 def handle_workflow(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -111,9 +129,9 @@ def handle_workflow(args: argparse.Namespace, *, fmt: str, jq: str | None = None
     if action == "list":
         _handle_workflow_list(args, fmt=fmt, jq=jq)
     elif action == "enable":
-        _handle_workflow_enable(args)
+        _handle_workflow_enable(args, fmt=fmt, jq=jq)
     elif action == "disable":
-        _handle_workflow_disable(args)
+        _handle_workflow_disable(args, fmt=fmt, jq=jq)
     else:
         raise ConfigError(_("Specify a subcommand: list, enable, disable"))
 
@@ -124,16 +142,28 @@ def _handle_workflow_list(args: argparse.Namespace, *, fmt: str, jq: str | None 
     output(workflows, fmt=fmt, fields=["id", "name", "path", "state"], jq=jq)
 
 
-def _handle_workflow_enable(args: argparse.Namespace) -> None:
+def _handle_workflow_enable(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     adapter = get_adapter()
     adapter.enable_workflow(args.id)
-    print(_("Enabled workflow '{id}'.").format(id=args.id))
+    output_result(
+        _("Enabled workflow '{id}'.").format(id=args.id),
+        result="enabled",
+        id=args.id,
+        fmt=fmt,
+        jq=jq,
+    )
 
 
-def _handle_workflow_disable(args: argparse.Namespace) -> None:
+def _handle_workflow_disable(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     adapter = get_adapter()
     adapter.disable_workflow(args.id)
-    print(_("Disabled workflow '{id}'.").format(id=args.id))
+    output_result(
+        _("Disabled workflow '{id}'.").format(id=args.id),
+        result="disabled",
+        id=args.id,
+        fmt=fmt,
+        jq=jq,
+    )
 
 
 def handle_artifact(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -142,7 +172,7 @@ def handle_artifact(args: argparse.Namespace, *, fmt: str, jq: str | None = None
     if action == "list":
         _handle_artifact_list(args, fmt=fmt, jq=jq)
     elif action == "download":
-        _handle_artifact_download(args)
+        _handle_artifact_download(args, fmt=fmt, jq=jq)
     else:
         raise ConfigError(_("Specify a subcommand: list, download"))
 
@@ -153,8 +183,14 @@ def _handle_artifact_list(args: argparse.Namespace, *, fmt: str, jq: str | None 
     output(artifacts, fmt=fmt, fields=["id", "name", "size", "created_at"], jq=jq)
 
 
-def _handle_artifact_download(args: argparse.Namespace) -> None:
+def _handle_artifact_download(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     adapter = get_adapter()
     output_dir = getattr(args, "dir", ".") or "."
     path = adapter.download_artifact(args.run_id, args.artifact_id, output_dir=output_dir)
-    print(_("Downloaded: {path}").format(path=path))
+    output_result(
+        _("Downloaded: {path}").format(path=path),
+        result="downloaded",
+        path=path,
+        fmt=fmt,
+        jq=jq,
+    )

--- a/src/gfo/commands/collaborator.py
+++ b/src/gfo/commands/collaborator.py
@@ -7,7 +7,7 @@ import json
 
 from gfo.commands import get_adapter
 from gfo.i18n import _
-from gfo.output import apply_jq_filter
+from gfo.output import apply_jq_filter, output_result
 
 
 def handle_list(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -29,11 +29,23 @@ def handle_add(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> 
     """gfo collaborator add <username> のハンドラ。"""
     adapter = get_adapter()
     adapter.add_collaborator(username=args.username, permission=args.permission)
-    print(_("Added collaborator '{username}'.").format(username=args.username))
+    output_result(
+        _("Added collaborator '{username}'.").format(username=args.username),
+        result="added",
+        fmt=fmt,
+        jq=jq,
+        username=args.username,
+    )
 
 
 def handle_remove(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo collaborator remove <username> のハンドラ。"""
     adapter = get_adapter()
     adapter.remove_collaborator(username=args.username)
-    print(_("Removed collaborator '{username}'.").format(username=args.username))
+    output_result(
+        _("Removed collaborator '{username}'.").format(username=args.username),
+        result="removed",
+        fmt=fmt,
+        jq=jq,
+        username=args.username,
+    )

--- a/src/gfo/commands/comment.py
+++ b/src/gfo/commands/comment.py
@@ -7,7 +7,7 @@ import argparse
 from gfo.commands import get_adapter
 from gfo.exceptions import ConfigError
 from gfo.i18n import _
-from gfo.output import output
+from gfo.output import output, output_result
 
 
 def _dispatch(args: argparse.Namespace, resource: str, *, fmt: str, jq: str | None = None) -> None:
@@ -27,7 +27,13 @@ def _dispatch(args: argparse.Namespace, resource: str, *, fmt: str, jq: str | No
         output(comment, fmt=fmt, jq=jq)
     elif action == "delete":
         adapter.delete_comment(resource, args.comment_id)
-        print(_("Deleted comment '{comment_id}'.").format(comment_id=args.comment_id))
+        output_result(
+            _("Deleted comment '{comment_id}'.").format(comment_id=args.comment_id),
+            result="deleted",
+            comment_id=args.comment_id,
+            fmt=fmt,
+            jq=jq,
+        )
 
 
 def handle_pr_comment(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:

--- a/src/gfo/commands/deploy_key.py
+++ b/src/gfo/commands/deploy_key.py
@@ -6,7 +6,7 @@ import argparse
 
 from gfo.commands import get_adapter
 from gfo.i18n import _
-from gfo.output import output
+from gfo.output import output, output_result
 
 
 def handle_view(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -38,4 +38,10 @@ def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
     """gfo deploy-key delete <id> のハンドラ。"""
     adapter = get_adapter()
     adapter.delete_deploy_key(key_id=args.id)
-    print(_("Deleted deploy key '{id}'.").format(id=args.id))
+    output_result(
+        _("Deleted deploy key '{id}'.").format(id=args.id),
+        result="deleted",
+        fmt=fmt,
+        jq=jq,
+        id=args.id,
+    )

--- a/src/gfo/commands/file.py
+++ b/src/gfo/commands/file.py
@@ -9,7 +9,7 @@ import sys
 from gfo.commands import get_adapter
 from gfo.exceptions import ConfigError, NotFoundError
 from gfo.i18n import _
-from gfo.output import apply_jq_filter
+from gfo.output import apply_jq_filter, output_result
 
 
 def _validate_repo_path(path: str) -> None:
@@ -65,9 +65,23 @@ def handle_put(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> 
         branch=args.branch,
     )
     if commit_sha:
-        print(_("Updated file '{path}' (commit: {sha}).").format(path=args.path, sha=commit_sha))
+        output_result(
+            _("Updated file '{path}' (commit: {sha}).").format(path=args.path, sha=commit_sha),
+            result="updated",
+            fmt=fmt,
+            jq=jq,
+            path=args.path,
+            sha=commit_sha,
+        )
     else:
-        print(_("Updated file '{path}'.").format(path=args.path))
+        output_result(
+            _("Updated file '{path}'.").format(path=args.path),
+            result="updated",
+            fmt=fmt,
+            jq=jq,
+            path=args.path,
+            sha=None,
+        )
 
 
 def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -76,4 +90,10 @@ def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
     adapter = get_adapter()
     _content, sha = adapter.get_file_content(args.path, ref=args.branch)
     adapter.delete_file(args.path, sha=sha, message=args.message, branch=args.branch)
-    print(_("Deleted file '{path}'.").format(path=args.path))
+    output_result(
+        _("Deleted file '{path}'.").format(path=args.path),
+        result="deleted",
+        fmt=fmt,
+        jq=jq,
+        path=args.path,
+    )

--- a/src/gfo/commands/gpg_key.py
+++ b/src/gfo/commands/gpg_key.py
@@ -6,7 +6,7 @@ import argparse
 
 from gfo.commands import get_adapter
 from gfo.i18n import _
-from gfo.output import output
+from gfo.output import output, output_result
 
 
 def handle_view(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -34,4 +34,10 @@ def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
     """gfo gpg-key delete <id> のハンドラ。"""
     adapter = get_adapter()
     adapter.delete_gpg_key(key_id=args.id)
-    print(_("Deleted GPG key '{id}'.").format(id=args.id))
+    output_result(
+        _("Deleted GPG key '{id}'.").format(id=args.id),
+        result="deleted",
+        fmt=fmt,
+        jq=jq,
+        id=args.id,
+    )

--- a/src/gfo/commands/init.py
+++ b/src/gfo/commands/init.py
@@ -15,6 +15,7 @@ from gfo.detect import DetectResult, detect_from_url, detect_service, normalize_
 from gfo.exceptions import ConfigError, DetectionError, GitCommandError
 from gfo.git_util import get_remote_url, git_config_set
 from gfo.i18n import _
+from gfo.output import output_result
 
 _VALID_SERVICE_TYPES = frozenset(
     {
@@ -34,12 +35,12 @@ _VALID_SERVICE_TYPES = frozenset(
 def handle(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo init のハンドラ。"""
     if getattr(args, "non_interactive", False):
-        _handle_non_interactive(args)
+        _handle_non_interactive(args, fmt=fmt, jq=jq)
     else:
-        _handle_interactive(args)
+        _handle_interactive(args, fmt=fmt, jq=jq)
 
 
-def _handle_non_interactive(args: argparse.Namespace) -> None:
+def _handle_non_interactive(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """--non-interactive モードの処理。"""
     service_type = getattr(args, "type", None)
     host = getattr(args, "host", None)
@@ -97,10 +98,17 @@ def _handle_non_interactive(args: argparse.Namespace) -> None:
     account = getattr(args, "account", None)
     if account:
         git_config_set("gfo.account", account)
-    print(_("Initialized: {service_type} at {host}").format(service_type=service_type, host=host))
+    output_result(
+        _("Initialized: {service_type} at {host}").format(service_type=service_type, host=host),
+        result="initialized",
+        service_type=service_type,
+        host=host,
+        fmt=fmt,
+        jq=jq,
+    )
 
 
-def _handle_interactive(args: argparse.Namespace) -> None:
+def _handle_interactive(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """対話モードの処理。"""
     detect_result: DetectResult | None = None
 
@@ -217,4 +225,11 @@ def _handle_interactive(args: argparse.Namespace) -> None:
     account = getattr(args, "account", None)
     if account:
         git_config_set("gfo.account", account)
-    print(_("Initialized: {service_type} at {host}").format(service_type=service_type, host=host))
+    output_result(
+        _("Initialized: {service_type} at {host}").format(service_type=service_type, host=host),
+        result="initialized",
+        service_type=service_type,
+        host=host,
+        fmt=fmt,
+        jq=jq,
+    )

--- a/src/gfo/commands/issue.py
+++ b/src/gfo/commands/issue.py
@@ -20,7 +20,7 @@ from gfo.exceptions import ConfigError, GfoError, NotSupportedError, PartialFail
 if TYPE_CHECKING:
     from gfo.adapter.base import GitServiceAdapter
 from gfo.i18n import _
-from gfo.output import output
+from gfo.output import output, output_result
 
 
 @dataclass(frozen=True, slots=True)
@@ -122,21 +122,39 @@ def handle_close(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -
     """gfo issue close <number> のハンドラ。"""
     adapter = get_adapter()
     adapter.close_issue(args.number)
-    print(_("Closed issue #{number}.").format(number=args.number))
+    output_result(
+        _("Closed issue #{number}.").format(number=args.number),
+        result="closed",
+        number=args.number,
+        fmt=fmt,
+        jq=jq,
+    )
 
 
 def handle_reopen(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo issue reopen <number> のハンドラ。"""
     adapter = get_adapter()
     adapter.reopen_issue(args.number)
-    print(_("Reopened issue #{number}.").format(number=args.number))
+    output_result(
+        _("Reopened issue #{number}.").format(number=args.number),
+        result="reopened",
+        number=args.number,
+        fmt=fmt,
+        jq=jq,
+    )
 
 
 def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo issue delete <number> のハンドラ。"""
     adapter = get_adapter()
     adapter.delete_issue(args.number)
-    print(_("Deleted issue '{number}'.").format(number=args.number))
+    output_result(
+        _("Deleted issue '{number}'.").format(number=args.number),
+        result="deleted",
+        number=args.number,
+        fmt=fmt,
+        jq=jq,
+    )
 
 
 def handle_edit(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -172,10 +190,15 @@ def handle_reaction(args: argparse.Namespace, *, fmt: str, jq: str | None = None
         output(reaction, fmt=fmt, jq=jq)
     elif action == "remove":
         adapter.remove_issue_reaction(args.number, args.reaction)
-        print(
+        output_result(
             _("Removed reaction '{reaction}' from issue #{number}.").format(
                 reaction=args.reaction, number=args.number
-            )
+            ),
+            result="removed",
+            reaction=args.reaction,
+            number=args.number,
+            fmt=fmt,
+            jq=jq,
         )
 
 
@@ -190,17 +213,27 @@ def handle_depends(args: argparse.Namespace, *, fmt: str, jq: str | None = None)
         output(deps, fmt=fmt, fields=["number", "title", "state"], jq=jq)
     elif action == "add":
         adapter.add_issue_dependency(args.number, args.depends_on)
-        print(
+        output_result(
             _("Added dependency #{depends_on} to issue #{number}.").format(
                 depends_on=args.depends_on, number=args.number
-            )
+            ),
+            result="added",
+            depends_on=args.depends_on,
+            number=args.number,
+            fmt=fmt,
+            jq=jq,
         )
     elif action == "remove":
         adapter.remove_issue_dependency(args.number, args.depends_on)
-        print(
+        output_result(
             _("Removed dependency #{depends_on} from issue #{number}.").format(
                 depends_on=args.depends_on, number=args.number
-            )
+            ),
+            result="removed",
+            depends_on=args.depends_on,
+            number=args.number,
+            fmt=fmt,
+            jq=jq,
         )
 
 
@@ -215,42 +248,78 @@ def handle_lock(args: argparse.Namespace, *, fmt: str, jq: str | None = None) ->
     """gfo issue lock <number> のハンドラ。"""
     adapter = get_adapter()
     adapter.lock_issue(args.number, reason=getattr(args, "reason", None))
-    print(_("Locked issue #{number}.").format(number=args.number))
+    output_result(
+        _("Locked issue #{number}.").format(number=args.number),
+        result="locked",
+        number=args.number,
+        fmt=fmt,
+        jq=jq,
+    )
 
 
 def handle_unlock(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo issue unlock <number> のハンドラ。"""
     adapter = get_adapter()
     adapter.unlock_issue(args.number)
-    print(_("Unlocked issue #{number}.").format(number=args.number))
+    output_result(
+        _("Unlocked issue #{number}.").format(number=args.number),
+        result="unlocked",
+        number=args.number,
+        fmt=fmt,
+        jq=jq,
+    )
 
 
 def handle_subscribe(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo issue subscribe <number> のハンドラ。"""
     adapter = get_adapter()
     adapter.subscribe_issue(args.number)
-    print(_("Subscribed to issue #{number}.").format(number=args.number))
+    output_result(
+        _("Subscribed to issue #{number}.").format(number=args.number),
+        result="subscribed",
+        number=args.number,
+        fmt=fmt,
+        jq=jq,
+    )
 
 
 def handle_unsubscribe(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo issue unsubscribe <number> のハンドラ。"""
     adapter = get_adapter()
     adapter.unsubscribe_issue(args.number)
-    print(_("Unsubscribed from issue #{number}.").format(number=args.number))
+    output_result(
+        _("Unsubscribed from issue #{number}.").format(number=args.number),
+        result="unsubscribed",
+        number=args.number,
+        fmt=fmt,
+        jq=jq,
+    )
 
 
 def handle_pin(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo issue pin <number> のハンドラ。"""
     adapter = get_adapter()
     adapter.pin_issue(args.number)
-    print(_("Pinned issue '{number}'.").format(number=args.number))
+    output_result(
+        _("Pinned issue '{number}'.").format(number=args.number),
+        result="pinned",
+        number=args.number,
+        fmt=fmt,
+        jq=jq,
+    )
 
 
 def handle_unpin(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo issue unpin <number> のハンドラ。"""
     adapter = get_adapter()
     adapter.unpin_issue(args.number)
-    print(_("Unpinned issue '{number}'.").format(number=args.number))
+    output_result(
+        _("Unpinned issue '{number}'.").format(number=args.number),
+        result="unpinned",
+        number=args.number,
+        fmt=fmt,
+        jq=jq,
+    )
 
 
 def _parse_duration(s: str) -> int:
@@ -296,7 +365,13 @@ def handle_time(args: argparse.Namespace, *, fmt: str, jq: str | None = None) ->
         output(entry, fmt=fmt, jq=jq)
     elif action == "delete":
         adapter.delete_time_entry(args.number, args.entry_id)
-        print(_("Deleted time entry '{entry_id}'.").format(entry_id=args.entry_id))
+        output_result(
+            _("Deleted time entry '{entry_id}'.").format(entry_id=args.entry_id),
+            result="deleted",
+            entry_id=args.entry_id,
+            fmt=fmt,
+            jq=jq,
+        )
 
 
 def handle_status(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:

--- a/src/gfo/commands/label.py
+++ b/src/gfo/commands/label.py
@@ -8,7 +8,7 @@ import re
 from gfo.commands import get_adapter
 from gfo.exceptions import ConfigError
 from gfo.i18n import _
-from gfo.output import output
+from gfo.output import output, output_result
 
 
 def handle_list(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -48,7 +48,13 @@ def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
         raise ConfigError(_("name must not be empty."))
     adapter = get_adapter()
     adapter.delete_label(name=name)
-    print(_("Deleted label '{name}'.").format(name=name))
+    output_result(
+        _("Deleted label '{name}'.").format(name=name),
+        result="deleted",
+        name=name,
+        fmt=fmt,
+        jq=jq,
+    )
 
 
 def handle_edit(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -122,4 +128,11 @@ def handle_clone(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -
         else:
             adapter.create_label(name=lb.name, color=lb.color, description=lb.description)
         created += 1
-    print(_("Cloned {count} labels from '{source}'.").format(count=created, source=source_repo))
+    output_result(
+        _("Cloned {count} labels from '{source}'.").format(count=created, source=source_repo),
+        result="cloned",
+        count=created,
+        source=source_repo,
+        fmt=fmt,
+        jq=jq,
+    )

--- a/src/gfo/commands/milestone.py
+++ b/src/gfo/commands/milestone.py
@@ -7,7 +7,7 @@ import argparse
 from gfo.commands import get_adapter, open_in_browser
 from gfo.exceptions import ConfigError
 from gfo.i18n import _
-from gfo.output import output
+from gfo.output import output, output_result
 
 
 def handle_list(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -38,7 +38,13 @@ def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
     """gfo milestone delete のハンドラ。"""
     adapter = get_adapter()
     adapter.delete_milestone(number=args.number)
-    print(_("Deleted milestone '{number}'.").format(number=args.number))
+    output_result(
+        _("Deleted milestone '{number}'.").format(number=args.number),
+        result="deleted",
+        number=args.number,
+        fmt=fmt,
+        jq=jq,
+    )
 
 
 def handle_view(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -68,11 +74,23 @@ def handle_close(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -
     """gfo milestone close のハンドラ。"""
     adapter = get_adapter()
     adapter.update_milestone(args.number, state="closed")
-    print(_("Closed milestone '{number}'.").format(number=args.number))
+    output_result(
+        _("Closed milestone '{number}'.").format(number=args.number),
+        result="closed",
+        number=args.number,
+        fmt=fmt,
+        jq=jq,
+    )
 
 
 def handle_reopen(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo milestone reopen のハンドラ。"""
     adapter = get_adapter()
     adapter.update_milestone(args.number, state="open")
-    print(_("Reopened milestone '{number}'.").format(number=args.number))
+    output_result(
+        _("Reopened milestone '{number}'.").format(number=args.number),
+        result="reopened",
+        number=args.number,
+        fmt=fmt,
+        jq=jq,
+    )

--- a/src/gfo/commands/notification.py
+++ b/src/gfo/commands/notification.py
@@ -7,7 +7,7 @@ import argparse
 from gfo.commands import get_adapter
 from gfo.exceptions import GfoError
 from gfo.i18n import _
-from gfo.output import output
+from gfo.output import output, output_result
 
 
 def handle_list(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -34,7 +34,19 @@ def handle_read(args: argparse.Namespace, *, fmt: str, jq: str | None = None) ->
         raise GfoError(_("Specify a notification ID or --all."))
     if args.mark_all:
         adapter.mark_all_notifications_read()
-        print(_("Marked all notifications as read."))
+        output_result(
+            _("Marked all notifications as read."),
+            result="marked_read",
+            fmt=fmt,
+            jq=jq,
+            all=True,
+        )
     else:
         adapter.mark_notification_read(args.id)
-        print(_("Marked notification '{id}' as read.").format(id=args.id))
+        output_result(
+            _("Marked notification '{id}' as read.").format(id=args.id),
+            result="marked_read",
+            fmt=fmt,
+            jq=jq,
+            id=args.id,
+        )

--- a/src/gfo/commands/org.py
+++ b/src/gfo/commands/org.py
@@ -6,7 +6,7 @@ import argparse
 import json
 
 from gfo.commands import get_adapter
-from gfo.output import apply_jq_filter, output
+from gfo.output import apply_jq_filter, output, output_result
 
 
 def handle_list(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -79,7 +79,13 @@ def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
             ).format(name=args.name)
         )
         if confirm.lower() not in ("y", "yes"):
-            print(_("Aborted."))
+            output_result(_("Aborted."), result="aborted", fmt=fmt, jq=jq)
             return
     adapter.delete_organization(args.name)
-    print(_("Deleted organization '{name}'.").format(name=args.name))
+    output_result(
+        _("Deleted organization '{name}'.").format(name=args.name),
+        result="deleted",
+        fmt=fmt,
+        jq=jq,
+        name=args.name,
+    )

--- a/src/gfo/commands/package.py
+++ b/src/gfo/commands/package.py
@@ -6,7 +6,7 @@ import argparse
 
 from gfo.commands import get_adapter
 from gfo.i18n import _
-from gfo.output import output
+from gfo.output import output, output_result
 
 
 def handle_list(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -40,11 +40,17 @@ def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
             )
         )
         if confirm.lower() not in ("y", "yes"):
-            print(_("Aborted."))
+            output_result(_("Aborted."), result="aborted", fmt=fmt, jq=jq)
             return
     adapter.delete_package(args.package_type, args.name, args.version)
-    print(
+    output_result(
         _("Deleted package '{type}/{name}@{version}'.").format(
             type=args.package_type, name=args.name, version=args.version
-        )
+        ),
+        result="deleted",
+        fmt=fmt,
+        jq=jq,
+        package_type=args.package_type,
+        name=args.name,
+        version=args.version,
     )

--- a/src/gfo/commands/pr.py
+++ b/src/gfo/commands/pr.py
@@ -9,7 +9,7 @@ import gfo.git_util
 from gfo.commands import get_adapter, open_in_browser, read_file_arg
 from gfo.exceptions import ConfigError
 from gfo.i18n import _
-from gfo.output import apply_jq_filter, output
+from gfo.output import apply_jq_filter, output, output_result
 
 
 def handle_list(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -48,13 +48,26 @@ def handle_create(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
     else:
         body = args.body or ""
     if getattr(args, "dry_run", False):
-        print(_("Title: {title}").format(title=title))
-        print(_("Head:  {head} -> Base: {base}").format(head=head, base=base))
-        if args.draft:
-            print(_("Draft: yes"))
-        if body:
-            print(_("Body:"))
-            print(body)
+        if fmt == "json":
+            output_result(
+                _("Title: {title}").format(title=title),
+                result="dry_run",
+                fmt=fmt,
+                jq=jq,
+                title=title,
+                head=head,
+                base=base,
+                draft=bool(args.draft),
+                body=body,
+            )
+        else:
+            print(_("Title: {title}").format(title=title))
+            print(_("Head:  {head} -> Base: {base}").format(head=head, base=base))
+            if args.draft:
+                print(_("Draft: yes"))
+            if body:
+                print(_("Body:"))
+                print(body)
         return
     pr = adapter.create_pull_request(
         title=title,
@@ -115,12 +128,14 @@ def handle_merge(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -
         source_branch = pr_info.source_branch
     if getattr(args, "disable_auto", False):
         adapter.disable_auto_merge(args.number)
-        print(_("Disabled auto-merge for PR #{number}.").format(number=args.number))
+        result = "auto_merge_disabled"
+        message = _("Disabled auto-merge for PR #{number}.").format(number=args.number)
     elif getattr(args, "auto", False):
         if getattr(args, "subject", None) or getattr(args, "body", None):
             warnings.warn(_("--subject/--body are ignored when --auto is used."), stacklevel=1)
         adapter.enable_auto_merge(args.number, merge_method=method)
-        print(_("Enabled auto-merge for PR #{number}.").format(number=args.number))
+        result = "auto_merge_enabled"
+        message = _("Enabled auto-merge for PR #{number}.").format(number=args.number)
     else:
         adapter.merge_pull_request(
             args.number,
@@ -128,38 +143,70 @@ def handle_merge(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -
             title=getattr(args, "subject", None),
             message=getattr(args, "body", None),
         )
-        print(_("Merged PR #{number}.").format(number=args.number))
+        result = "merged"
+        message = _("Merged PR #{number}.").format(number=args.number)
+    deleted_branch = None
     if source_branch:
         adapter.delete_branch(name=source_branch)
-        print(_("Deleted branch '{branch}'.").format(branch=source_branch))
+        deleted_branch = source_branch
+    fields: dict[str, object] = {"number": args.number}
+    if deleted_branch:
+        fields["deleted_branch"] = deleted_branch
+    output_result(message, result=result, fmt=fmt, jq=jq, **fields)
+    if deleted_branch and fmt != "json":
+        print(_("Deleted branch '{branch}'.").format(branch=deleted_branch))
 
 
 def handle_close(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo pr close <number> のハンドラ。"""
     adapter = get_adapter()
     adapter.close_pull_request(args.number)
-    print(_("Closed PR #{number}.").format(number=args.number))
+    output_result(
+        _("Closed PR #{number}.").format(number=args.number),
+        result="closed",
+        fmt=fmt,
+        jq=jq,
+        number=args.number,
+    )
 
 
 def handle_reopen(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo pr reopen <number> のハンドラ。"""
     adapter = get_adapter()
     adapter.reopen_pull_request(args.number)
-    print(_("Reopened PR #{number}.").format(number=args.number))
+    output_result(
+        _("Reopened PR #{number}.").format(number=args.number),
+        result="reopened",
+        fmt=fmt,
+        jq=jq,
+        number=args.number,
+    )
 
 
 def handle_lock(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo pr lock <number> のハンドラ。"""
     adapter = get_adapter()
     adapter.lock_pull_request(args.number, reason=getattr(args, "reason", None))
-    print(_("Locked PR #{number}.").format(number=args.number))
+    output_result(
+        _("Locked PR #{number}.").format(number=args.number),
+        result="locked",
+        fmt=fmt,
+        jq=jq,
+        number=args.number,
+    )
 
 
 def handle_unlock(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo pr unlock <number> のハンドラ。"""
     adapter = get_adapter()
     adapter.unlock_pull_request(args.number)
-    print(_("Unlocked PR #{number}.").format(number=args.number))
+    output_result(
+        _("Unlocked PR #{number}.").format(number=args.number),
+        result="unlocked",
+        fmt=fmt,
+        jq=jq,
+        number=args.number,
+    )
 
 
 def handle_checkout(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -227,10 +274,22 @@ def handle_reviewers(args: argparse.Namespace, *, fmt: str, jq: str | None = Non
     action = getattr(args, "reviewer_action", None)
     if action == "add":
         adapter.request_reviewers(args.number, args.users)
-        print(_("Added reviewers to PR #{number}.").format(number=args.number))
+        output_result(
+            _("Added reviewers to PR #{number}.").format(number=args.number),
+            result="reviewers_added",
+            fmt=fmt,
+            jq=jq,
+            number=args.number,
+        )
     elif action == "remove":
         adapter.remove_reviewers(args.number, args.users)
-        print(_("Removed reviewers from PR #{number}.").format(number=args.number))
+        output_result(
+            _("Removed reviewers from PR #{number}.").format(number=args.number),
+            result="reviewers_removed",
+            fmt=fmt,
+            jq=jq,
+            number=args.number,
+        )
     else:
         # list_requested_reviewers は list[str] を返すため output() は使えない
         # (dataclass を前提に fields/asdict を呼びクラッシュする)。
@@ -251,14 +310,26 @@ def handle_update_branch(args: argparse.Namespace, *, fmt: str, jq: str | None =
     """gfo pr update-branch <number> のハンドラ。"""
     adapter = get_adapter()
     adapter.update_pull_request_branch(args.number)
-    print(_("Updated branch for PR #{number}.").format(number=args.number))
+    output_result(
+        _("Updated branch for PR #{number}.").format(number=args.number),
+        result="branch_updated",
+        fmt=fmt,
+        jq=jq,
+        number=args.number,
+    )
 
 
 def handle_ready(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo pr ready <number> のハンドラ。"""
     adapter = get_adapter()
     adapter.mark_pull_request_ready(args.number)
-    print(_("Marked PR #{number} as ready for review.").format(number=args.number))
+    output_result(
+        _("Marked PR #{number} as ready for review.").format(number=args.number),
+        result="ready",
+        fmt=fmt,
+        jq=jq,
+        number=args.number,
+    )
 
 
 def handle_status(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -285,11 +356,23 @@ def handle_subscribe(args: argparse.Namespace, *, fmt: str, jq: str | None = Non
     """gfo pr subscribe <number> のハンドラ。"""
     adapter = get_adapter()
     adapter.subscribe_pull_request(args.number)
-    print(_("Subscribed to PR #{number}.").format(number=args.number))
+    output_result(
+        _("Subscribed to PR #{number}.").format(number=args.number),
+        result="subscribed",
+        fmt=fmt,
+        jq=jq,
+        number=args.number,
+    )
 
 
 def handle_unsubscribe(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo pr unsubscribe <number> のハンドラ。"""
     adapter = get_adapter()
     adapter.unsubscribe_pull_request(args.number)
-    print(_("Unsubscribed from PR #{number}.").format(number=args.number))
+    output_result(
+        _("Unsubscribed from PR #{number}.").format(number=args.number),
+        result="unsubscribed",
+        fmt=fmt,
+        jq=jq,
+        number=args.number,
+    )

--- a/src/gfo/commands/release.py
+++ b/src/gfo/commands/release.py
@@ -7,7 +7,7 @@ import argparse
 from gfo.commands import get_adapter, open_in_browser, read_file_arg
 from gfo.exceptions import ConfigError, GfoError
 from gfo.i18n import _
-from gfo.output import output
+from gfo.output import output, output_result
 
 
 def handle_list(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -66,7 +66,13 @@ def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
         raise ConfigError(_("tag must not be empty. Use 'gfo release delete <tag>'."))
     adapter = get_adapter()
     adapter.delete_release(tag=tag)
-    print(_("Deleted release '{tag}'.").format(tag=tag))
+    output_result(
+        _("Deleted release '{tag}'.").format(tag=tag),
+        result="deleted",
+        fmt=fmt,
+        jq=jq,
+        tag=tag,
+    )
 
 
 def handle_view(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -163,7 +169,13 @@ def _handle_asset_download(args: argparse.Namespace, *, fmt: str, jq: str | None
             asset_id=asset_id,
             output_dir=output_dir,
         )
-        print(_("Downloaded: {path}").format(path=path))
+        output_result(
+            _("Downloaded: {path}").format(path=path),
+            result="downloaded",
+            fmt=fmt,
+            jq=jq,
+            path=path,
+        )
     elif pattern:
         # --pattern 経路は list_release_assets で取得済みの download_url を直接使う。
         # 旧実装は match 毎に download_release_asset を呼んでメタ情報を再取得していたが、
@@ -182,7 +194,13 @@ def _handle_asset_download(args: argparse.Namespace, *, fmt: str, jq: str | None
             if not Path(output_path).resolve().is_relative_to(Path(output_dir).resolve()):
                 raise GfoError(_("Invalid asset name: {name}").format(name=a.name))
             adapter.client.download_file(a.download_url, output_path)
-            print(_("Downloaded: {path}").format(path=output_path))
+            output_result(
+                _("Downloaded: {path}").format(path=output_path),
+                result="downloaded",
+                fmt=fmt,
+                jq=jq,
+                path=output_path,
+            )
     else:
         raise ConfigError(_("Specify --asset-id or --pattern."))
 
@@ -200,4 +218,10 @@ def _handle_asset_edit(args: argparse.Namespace, *, fmt: str, jq: str | None = N
 def _handle_asset_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     adapter = get_adapter()
     adapter.delete_release_asset(tag=args.tag, asset_id=args.asset_id)
-    print(_("Deleted asset '{asset_id}'.").format(asset_id=args.asset_id))
+    output_result(
+        _("Deleted asset '{asset_id}'.").format(asset_id=args.asset_id),
+        result="deleted",
+        fmt=fmt,
+        jq=jq,
+        asset_id=args.asset_id,
+    )

--- a/src/gfo/commands/repo.py
+++ b/src/gfo/commands/repo.py
@@ -19,7 +19,7 @@ from gfo.detect import detect_service, get_known_service_type, probe_unknown_hos
 from gfo.exceptions import ConfigError, DetectionError, GitCommandError
 from gfo.git_util import git_clone
 from gfo.i18n import _
-from gfo.output import output
+from gfo.output import output, output_result
 
 
 def handle_list(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -225,10 +225,16 @@ def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
             ).format(repo_name=repo_name)
         )
         if confirm.lower() not in ("y", "yes"):
-            print(_("Aborted."))
+            output_result(_("Aborted."), result="aborted", fmt=fmt, jq=jq)
             return
     adapter.delete_repository()
-    print(_("Deleted repository '{repo_name}'.").format(repo_name=repo_name))
+    output_result(
+        _("Deleted repository '{repo_name}'.").format(repo_name=repo_name),
+        result="deleted",
+        fmt=fmt,
+        jq=jq,
+        repository=repo_name,
+    )
 
 
 def handle_fork(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -242,7 +248,7 @@ def handle_sync_fork(args: argparse.Namespace, *, fmt: str, jq: str | None = Non
     """gfo repo sync のハンドラ。"""
     adapter = get_adapter()
     adapter.sync_fork(branch=getattr(args, "branch", None))
-    print(_("Fork synced with upstream."))
+    output_result(_("Fork synced with upstream."), result="synced", fmt=fmt, jq=jq)
 
 
 def handle_edit(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -277,10 +283,16 @@ def handle_archive(args: argparse.Namespace, *, fmt: str, jq: str | None = None)
             )
         )
         if confirm.lower() not in ("y", "yes"):
-            print(_("Aborted."))
+            output_result(_("Aborted."), result="aborted", fmt=fmt, jq=jq)
             return
     adapter.archive_repository()
-    print(_("Archived repository '{repo_name}'.").format(repo_name=repo_name))
+    output_result(
+        _("Archived repository '{repo_name}'.").format(repo_name=repo_name),
+        result="archived",
+        fmt=fmt,
+        jq=jq,
+        repository=repo_name,
+    )
 
 
 def handle_unarchive(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -288,7 +300,13 @@ def handle_unarchive(args: argparse.Namespace, *, fmt: str, jq: str | None = Non
     adapter = get_adapter()
     repo_name = f"{adapter.owner}/{adapter.repo}"
     adapter.update_repository(archived=False)
-    print(_("Unarchived repository '{repo_name}'.").format(repo_name=repo_name))
+    output_result(
+        _("Unarchived repository '{repo_name}'.").format(repo_name=repo_name),
+        result="unarchived",
+        fmt=fmt,
+        jq=jq,
+        repository=repo_name,
+    )
 
 
 def handle_languages(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -400,10 +418,16 @@ def handle_mirror(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
         output(mirror, fmt=fmt, jq=jq)
     elif action == "remove":
         adapter.delete_push_mirror(args.mirror_name)
-        print(_("Deleted push mirror '{name}'.").format(name=args.mirror_name))
+        output_result(
+            _("Deleted push mirror '{name}'.").format(name=args.mirror_name),
+            result="deleted",
+            fmt=fmt,
+            jq=jq,
+            name=args.mirror_name,
+        )
     elif action == "sync":
         adapter.sync_mirror()
-        print(_("Mirror sync triggered."))
+        output_result(_("Mirror sync triggered."), result="sync_triggered", fmt=fmt, jq=jq)
 
 
 def handle_transfer(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -417,17 +441,22 @@ def handle_transfer(args: argparse.Namespace, *, fmt: str, jq: str | None = None
             ).format(repo_name=repo_name, new_owner=args.new_owner)
         )
         if confirm.lower() not in ("y", "yes"):
-            print(_("Aborted."))
+            output_result(_("Aborted."), result="aborted", fmt=fmt, jq=jq)
             return
     team_ids = None
     raw = getattr(args, "team_id", None)
     if raw is not None:
         team_ids = [raw]
     adapter.transfer_repository(args.new_owner, team_ids=team_ids)
-    print(
+    output_result(
         _("Transferred repository '{repo_name}' to '{new_owner}'.").format(
             repo_name=repo_name, new_owner=args.new_owner
-        )
+        ),
+        result="transferred",
+        fmt=fmt,
+        jq=jq,
+        repository=repo_name,
+        new_owner=args.new_owner,
     )
 
 
@@ -435,13 +464,23 @@ def handle_star(args: argparse.Namespace, *, fmt: str, jq: str | None = None) ->
     """gfo repo star のハンドラ。"""
     adapter = get_adapter()
     adapter.star_repository()
-    print(_("Starred repository '{owner}/{repo}'.").format(owner=adapter.owner, repo=adapter.repo))
+    output_result(
+        _("Starred repository '{owner}/{repo}'.").format(owner=adapter.owner, repo=adapter.repo),
+        result="starred",
+        fmt=fmt,
+        jq=jq,
+        repository=f"{adapter.owner}/{adapter.repo}",
+    )
 
 
 def handle_unstar(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo repo unstar のハンドラ。"""
     adapter = get_adapter()
     adapter.unstar_repository()
-    print(
-        _("Unstarred repository '{owner}/{repo}'.").format(owner=adapter.owner, repo=adapter.repo)
+    output_result(
+        _("Unstarred repository '{owner}/{repo}'.").format(owner=adapter.owner, repo=adapter.repo),
+        result="unstarred",
+        fmt=fmt,
+        jq=jq,
+        repository=f"{adapter.owner}/{adapter.repo}",
     )

--- a/src/gfo/commands/secret.py
+++ b/src/gfo/commands/secret.py
@@ -8,7 +8,7 @@ import os
 from gfo.commands import get_adapter, read_file_arg
 from gfo.exceptions import GfoError
 from gfo.i18n import _
-from gfo.output import output
+from gfo.output import output, output_result
 
 
 def handle_list(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -45,4 +45,10 @@ def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
     adapter = get_adapter()
     scope = getattr(args, "org", None)
     adapter.delete_secret(args.name, scope=scope)
-    print(_("Deleted secret '{name}'.").format(name=args.name))
+    output_result(
+        _("Deleted secret '{name}'.").format(name=args.name),
+        result="deleted",
+        fmt=fmt,
+        jq=jq,
+        name=args.name,
+    )

--- a/src/gfo/commands/ssh_key.py
+++ b/src/gfo/commands/ssh_key.py
@@ -6,7 +6,7 @@ import argparse
 
 from gfo.commands import get_adapter
 from gfo.i18n import _
-from gfo.output import output
+from gfo.output import output, output_result
 
 
 def handle_view(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -34,4 +34,10 @@ def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
     """gfo ssh-key delete <id> のハンドラ。"""
     adapter = get_adapter()
     adapter.delete_ssh_key(key_id=args.id)
-    print(_("Deleted SSH key '{id}'.").format(id=args.id))
+    output_result(
+        _("Deleted SSH key '{id}'.").format(id=args.id),
+        result="deleted",
+        fmt=fmt,
+        jq=jq,
+        id=args.id,
+    )

--- a/src/gfo/commands/tag.py
+++ b/src/gfo/commands/tag.py
@@ -6,7 +6,7 @@ import argparse
 
 from gfo.commands import get_adapter
 from gfo.i18n import _
-from gfo.output import output
+from gfo.output import output, output_result
 
 
 def handle_view(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -34,4 +34,10 @@ def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
     """gfo tag delete <name> のハンドラ。"""
     adapter = get_adapter()
     adapter.delete_tag(name=args.name)
-    print(_("Deleted tag '{name}'.").format(name=args.name))
+    output_result(
+        _("Deleted tag '{name}'.").format(name=args.name),
+        result="deleted",
+        fmt=fmt,
+        jq=jq,
+        tag=args.name,
+    )

--- a/src/gfo/commands/tag_protect.py
+++ b/src/gfo/commands/tag_protect.py
@@ -6,7 +6,7 @@ import argparse
 
 from gfo.commands import get_adapter
 from gfo.i18n import _
-from gfo.output import output
+from gfo.output import output, output_result
 
 
 def handle_list(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -40,4 +40,10 @@ def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
     """gfo tag-protect delete <id> のハンドラ。"""
     adapter = get_adapter()
     adapter.delete_tag_protection(args.id)
-    print(_("Deleted tag protection '{id}'.").format(id=args.id))
+    output_result(
+        _("Deleted tag protection '{id}'.").format(id=args.id),
+        result="deleted",
+        fmt=fmt,
+        jq=jq,
+        id=args.id,
+    )

--- a/src/gfo/commands/variable.py
+++ b/src/gfo/commands/variable.py
@@ -6,7 +6,7 @@ import argparse
 
 from gfo.commands import get_adapter
 from gfo.i18n import _
-from gfo.output import output
+from gfo.output import output, output_result
 
 
 def handle_list(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -43,4 +43,10 @@ def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
     adapter = get_adapter()
     scope = getattr(args, "org", None)
     adapter.delete_variable(args.name, scope=scope)
-    print(_("Deleted variable '{name}'.").format(name=args.name))
+    output_result(
+        _("Deleted variable '{name}'.").format(name=args.name),
+        result="deleted",
+        fmt=fmt,
+        jq=jq,
+        name=args.name,
+    )

--- a/src/gfo/commands/webhook.py
+++ b/src/gfo/commands/webhook.py
@@ -6,7 +6,7 @@ import argparse
 
 from gfo.commands import get_adapter
 from gfo.i18n import _
-from gfo.output import output
+from gfo.output import output, output_result
 
 
 def handle_list(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -27,14 +27,26 @@ def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
     """gfo webhook delete <id> のハンドラ。"""
     adapter = get_adapter()
     adapter.delete_webhook(hook_id=args.id)
-    print(_("Deleted webhook '{id}'.").format(id=args.id))
+    output_result(
+        _("Deleted webhook '{id}'.").format(id=args.id),
+        result="deleted",
+        fmt=fmt,
+        jq=jq,
+        id=args.id,
+    )
 
 
 def handle_test(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo webhook test <id> のハンドラ。"""
     adapter = get_adapter()
     adapter.test_webhook(hook_id=args.id)
-    print(_("Tested webhook '{id}'.").format(id=args.id))
+    output_result(
+        _("Tested webhook '{id}'.").format(id=args.id),
+        result="tested",
+        fmt=fmt,
+        jq=jq,
+        id=args.id,
+    )
 
 
 def handle_edit(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:

--- a/src/gfo/commands/wiki.py
+++ b/src/gfo/commands/wiki.py
@@ -6,7 +6,7 @@ import argparse
 
 from gfo.commands import get_adapter
 from gfo.i18n import _
-from gfo.output import output
+from gfo.output import output, output_result
 
 
 def handle_list(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
@@ -41,7 +41,13 @@ def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
     """gfo wiki delete <id> のハンドラ。"""
     adapter = get_adapter()
     adapter.delete_wiki_page(args.id)
-    print(_("Deleted wiki page '{id}'.").format(id=args.id))
+    output_result(
+        _("Deleted wiki page '{id}'.").format(id=args.id),
+        result="deleted",
+        fmt=fmt,
+        jq=jq,
+        id=args.id,
+    )
 
 
 def handle_revisions(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:

--- a/src/gfo/output.py
+++ b/src/gfo/output.py
@@ -89,6 +89,33 @@ def format_error_json(err: GfoError) -> str:
     return json.dumps(d, ensure_ascii=False)
 
 
+def output_result(
+    message: str,
+    *,
+    result: str,
+    fmt: str = "table",
+    jq: str | None = None,
+    **fields: Any,
+) -> None:
+    """mutation 系コマンドの成功メッセージを出力する。
+
+    table / plain では従来どおり message を平文で出力し、json では
+    `{"result": <result>, **fields, "message": <message>}` の構造化 JSON を
+    出力する（エラー側の format_error_json と対になる成功側の機械可読出力）。
+    """
+    # output() と同様、jq 指定時は fmt を json に強制する
+    if jq and fmt != "json":
+        fmt = "json"
+    if fmt == "json":
+        json_str = json.dumps({"result": result, **fields, "message": message}, ensure_ascii=False)
+        if jq is not None:
+            print(apply_jq_filter(json_str, jq))
+        else:
+            print(json_str)
+    else:
+        print(message)
+
+
 def output(
     data: Any, *, fmt: str = "table", fields: list[str] | None = None, jq: str | None = None
 ) -> None:

--- a/tests/test_commands/test_auth_cmd.py
+++ b/tests/test_commands/test_auth_cmd.py
@@ -639,6 +639,31 @@ class TestHandleLogoutJson:
         assert "work" in captured.out
         assert "github.com" in captured.out
 
+    def test_logout_json_structured_output(self, capsys):
+        """fmt="json" で result / host / message を含む構造化 JSON を出力する。"""
+        args = make_args(host="github.com", account=None)
+
+        with patch("gfo.commands.auth_cmd.gfo.auth.remove_token"):
+            auth_cmd.handle_logout(args, fmt="json")
+
+        data = json.loads(capsys.readouterr().out)
+        assert data["result"] == "logged_out"
+        assert data["host"] == "github.com"
+        assert data["message"]
+
+    def test_logout_with_account_json_structured_output(self, capsys):
+        """fmt="json" + --account で account フィールドも含まれる。"""
+        args = make_args(host="github.com", account="work")
+
+        with patch("gfo.commands.auth_cmd.gfo.auth.remove_token"):
+            auth_cmd.handle_logout(args, fmt="json")
+
+        data = json.loads(capsys.readouterr().out)
+        assert data["result"] == "logged_out"
+        assert data["host"] == "github.com"
+        assert data["account"] == "work"
+        assert data["message"]
+
 
 class TestHandleSwitchJson:
     """handle_switch の fmt="json" テスト。"""
@@ -653,6 +678,19 @@ class TestHandleSwitchJson:
         captured = capsys.readouterr()
         assert "work" in captured.out
         assert "github.com" in captured.out
+
+    def test_switch_json_structured_output(self, capsys):
+        """fmt="json" で result / host / account / message を含む構造化 JSON を出力する。"""
+        args = make_args(host="github.com", account="work")
+
+        with patch("gfo.commands.auth_cmd.gfo.auth.switch_account"):
+            auth_cmd.handle_switch(args, fmt="json")
+
+        data = json.loads(capsys.readouterr().out)
+        assert data["result"] == "switched"
+        assert data["host"] == "github.com"
+        assert data["account"] == "work"
+        assert data["message"]
 
 
 class TestHandleStatusJson:

--- a/tests/test_commands/test_branch.py
+++ b/tests/test_commands/test_branch.py
@@ -175,3 +175,14 @@ class TestHandleDeleteSuccessMessage:
             branch_cmd.handle_delete(args, fmt="table")
         out = capsys.readouterr().out
         assert "feature/old" in out
+
+    def test_delete_json_format(self, capsys):
+        """fmt="json" で構造化 JSON（result / branch / message）が出力される。"""
+        with patch_adapter("gfo.commands.branch"):
+            args = make_args(name="feature/old")
+            branch_cmd.handle_delete(args, fmt="json")
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["result"] == "deleted"
+        assert data["branch"] == "feature/old"
+        assert data["message"]

--- a/tests/test_commands/test_branch_protect.py
+++ b/tests/test_commands/test_branch_protect.py
@@ -121,6 +121,17 @@ class TestHandleRemove:
         assert "Removed" in out
         assert "main" in out
 
+    def test_remove_json_format(self, capsys):
+        """fmt="json" で構造化 JSON（result / branch / message）が出力される。"""
+        with patch_adapter("gfo.commands.branch_protect"):
+            args = make_args(branch="main")
+            bp_cmd.handle_remove(args, fmt="json")
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["result"] == "removed"
+        assert data["branch"] == "main"
+        assert data["message"]
+
     def test_error_propagation(self):
         with patch_adapter("gfo.commands.branch_protect") as adapter:
             adapter.remove_branch_protection.side_effect = HttpError(404, "Not found")

--- a/tests/test_commands/test_ci.py
+++ b/tests/test_commands/test_ci.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import patch
 
 import pytest
@@ -75,6 +76,16 @@ class TestHandleCancel:
             ci_cmd.handle_cancel(args, fmt="table")
         out = capsys.readouterr().out
         assert "456" in out
+
+    def test_cancel_json_output(self, capsys):
+        """fmt="json" で構造化 JSON を出力する。"""
+        with patch_adapter("gfo.commands.ci"):
+            args = make_args(id="456")
+            ci_cmd.handle_cancel(args, fmt="json")
+        data = json.loads(capsys.readouterr().out)
+        assert data["result"] == "canceled"
+        assert data["id"] == "456"
+        assert data["message"]
 
 
 class TestHandleDelete:
@@ -251,8 +262,10 @@ class TestHandleWatch:
             args = make_args(id="123", interval=0, timeout=1)
             with patch("time.sleep"), patch("time.monotonic", side_effect=[0, 0, 2]):
                 ci_cmd.handle_watch(args, fmt="table")
-        out = capsys.readouterr().out
-        assert "Timed out" in out
+        # タイムアウト通知は診断メッセージのため stderr に出力される
+        # (json モードで stdout の JSON を壊さないため)
+        err = capsys.readouterr().err
+        assert "Timed out" in err
 
     def test_watch_error_propagation(self):
         with patch_adapter("gfo.commands.ci") as adapter:

--- a/tests/test_commands/test_collaborator.py
+++ b/tests/test_commands/test_collaborator.py
@@ -84,6 +84,17 @@ class TestHandleAdd:
                 collab_cmd.handle_add(args, fmt="table")
             adapter.add_collaborator.assert_called_once_with(username="user1", permission=perm)
 
+    def test_add_json_format(self, capsys):
+        """fmt="json" で構造化された成功 JSON が出力される。"""
+        with patch_adapter("gfo.commands.collaborator") as adapter:
+            args = make_args(username="charlie", permission="write")
+            collab_cmd.handle_add(args, fmt="json")
+        adapter.add_collaborator.assert_called_once_with(username="charlie", permission="write")
+        data = json.loads(capsys.readouterr().out)
+        assert data["result"] == "added"
+        assert data["username"] == "charlie"
+        assert data["message"]
+
     def test_add_error_propagation(self):
         """HttpError(403) がそのまま伝搬する。"""
         with patch_adapter("gfo.commands.collaborator") as adapter:

--- a/tests/test_commands/test_comment.py
+++ b/tests/test_commands/test_comment.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from gfo.adapter.base import Comment
@@ -69,6 +71,16 @@ class TestHandlePrComment:
         adapter.delete_comment.assert_called_once_with("pr", 42)
         out = capsys.readouterr().out
         assert "42" in out
+
+    def test_delete_json_format(self, capsys):
+        with patch_adapter("gfo.commands.comment") as adapter:
+            args = make_args(comment_action="delete", comment_id=42)
+            comment_cmd.handle_pr_comment(args, fmt="json")
+        adapter.delete_comment.assert_called_once_with("pr", 42)
+        data = json.loads(capsys.readouterr().out)
+        assert data["result"] == "deleted"
+        assert data["comment_id"] == 42
+        assert data["message"]
 
     def test_no_action_raises(self):
         args = make_args(comment_action=None)

--- a/tests/test_commands/test_deploy_key.py
+++ b/tests/test_commands/test_deploy_key.py
@@ -91,3 +91,14 @@ class TestHandleDelete:
             deploy_key_cmd.handle_delete(args, fmt="table")
         out = capsys.readouterr().out
         assert "99" in out
+
+    def test_json_format(self, capsys):
+        """fmt="json" のとき構造化 JSON が出力される。"""
+        with patch_adapter("gfo.commands.deploy_key"):
+            args = make_args(id=99)
+            deploy_key_cmd.handle_delete(args, fmt="json")
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["result"] == "deleted"
+        assert data["id"] == 99
+        assert data["message"]

--- a/tests/test_commands/test_file_cmd.py
+++ b/tests/test_commands/test_file_cmd.py
@@ -176,6 +176,38 @@ class TestHandlePutSuccessMessage:
         assert "new.txt" in out
         assert "commit" not in out
 
+    def test_put_json_format_with_sha(self, capsys):
+        """fmt="json" で構造化 JSON（result / path / sha / message）が出力される。"""
+        with patch_adapter("gfo.commands.file") as adapter:
+            adapter.get_file_content.return_value = ("old content", "abc123")
+            adapter.create_or_update_file.return_value = "def456"
+            args = make_args(path="readme.md", message="Update", branch=None)
+            with patch("gfo.commands.file.sys.stdin") as mock_stdin:
+                mock_stdin.read.return_value = "new content"
+                file_cmd.handle_put(args, fmt="json")
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["result"] == "updated"
+        assert data["path"] == "readme.md"
+        assert data["sha"] == "def456"
+        assert data["message"]
+
+    def test_put_json_format_without_sha(self, capsys):
+        """fmt="json" で commit SHA なしの場合 sha が null になる。"""
+        with patch_adapter("gfo.commands.file") as adapter:
+            adapter.get_file_content.side_effect = NotFoundError()
+            adapter.create_or_update_file.return_value = None
+            args = make_args(path="new.txt", message="Add file", branch=None)
+            with patch("gfo.commands.file.sys.stdin") as mock_stdin:
+                mock_stdin.read.return_value = "hello"
+                file_cmd.handle_put(args, fmt="json")
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["result"] == "updated"
+        assert data["path"] == "new.txt"
+        assert data["sha"] is None
+        assert data["message"]
+
 
 class TestHandleDeleteSuccessMessage:
     def test_delete_prints_success_message(self, capsys):
@@ -186,3 +218,15 @@ class TestHandleDeleteSuccessMessage:
             file_cmd.handle_delete(args, fmt="table")
         out = capsys.readouterr().out
         assert "old.txt" in out
+
+    def test_delete_json_format(self, capsys):
+        """fmt="json" で構造化 JSON（result / path / message）が出力される。"""
+        with patch_adapter("gfo.commands.file") as adapter:
+            adapter.get_file_content.return_value = ("content", "deadbeef")
+            args = make_args(path="old.txt", message="Remove file", branch=None)
+            file_cmd.handle_delete(args, fmt="json")
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["result"] == "deleted"
+        assert data["path"] == "old.txt"
+        assert data["message"]

--- a/tests/test_commands/test_gpg_key.py
+++ b/tests/test_commands/test_gpg_key.py
@@ -110,6 +110,17 @@ class TestHandleDelete:
         assert "Deleted" in out
         assert "1" in out
 
+    def test_json_format(self, capsys):
+        """fmt="json" のとき構造化 JSON が出力される。"""
+        with patch_adapter("gfo.commands.gpg_key"):
+            args = make_args(id=1)
+            gpg_key_cmd.handle_delete(args, fmt="json")
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["result"] == "deleted"
+        assert data["id"] == 1
+        assert data["message"]
+
     def test_calls_delete_gpg_key_string_id(self):
         with patch_adapter("gfo.commands.gpg_key") as adapter:
             args = make_args(id="abc-123")

--- a/tests/test_commands/test_init.py
+++ b/tests/test_commands/test_init.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import patch
 
 import pytest
@@ -353,6 +354,30 @@ class TestHandleNonInteractive:
         assert saved.host == "github.com"
         assert saved.owner == "owner"
         assert saved.repo == "repo"
+
+    def test_non_interactive_json_output(self, capsys):
+        """fmt="json" で result / service_type / host / message を含む構造化 JSON を出力する。"""
+        args = make_args(
+            non_interactive=True,
+            type="github",
+            host="github.com",
+            api_url=None,
+            project_key=None,
+        )
+
+        with (
+            patch(
+                "gfo.commands.init.get_remote_url", return_value="https://github.com/owner/repo.git"
+            ),
+            patch("gfo.commands.init.save_project_config"),
+        ):
+            init_cmd.handle(args, fmt="json")
+
+        data = json.loads(capsys.readouterr().out)
+        assert data["result"] == "initialized"
+        assert data["service_type"] == "github"
+        assert data["host"] == "github.com"
+        assert data["message"]
 
     def test_missing_type_raises_config_error(self):
         """type 未指定 → ConfigError。"""

--- a/tests/test_commands/test_issue.py
+++ b/tests/test_commands/test_issue.py
@@ -483,6 +483,16 @@ class TestHandleClose:
 
         self.adapter.close_issue.assert_called_once_with(42)
 
+    def test_json_format(self, capsys):
+        args = make_args(number=7)
+        with _patch_all(self.config, self.adapter):
+            issue_cmd.handle_close(args, fmt="json")
+
+        data = json.loads(capsys.readouterr().out)
+        assert data["result"] == "closed"
+        assert data["number"] == 7
+        assert data["message"]
+
 
 class TestHandleReopen:
     def setup_method(self):

--- a/tests/test_commands/test_label.py
+++ b/tests/test_commands/test_label.py
@@ -242,6 +242,16 @@ class TestHandleDelete:
         assert "bug" in out
         assert "Deleted" in out
 
+    def test_delete_json_format(self, sample_config, capsys):
+        args = make_args(name="bug")
+        with _patch_all(sample_config, self.adapter):
+            label_cmd.handle_delete(args, fmt="json")
+
+        data = json.loads(capsys.readouterr().out)
+        assert data["result"] == "deleted"
+        assert data["name"] == "bug"
+        assert data["message"]
+
     def test_whitespace_only_name_raises_config_error(self, sample_config):
         args = make_args(name="   ")
         with _patch_all(sample_config, self.adapter):

--- a/tests/test_commands/test_milestone.py
+++ b/tests/test_commands/test_milestone.py
@@ -225,6 +225,16 @@ class TestHandleDelete:
         assert "5" in out
         assert "Deleted" in out
 
+    def test_delete_json_format(self, sample_config, capsys):
+        args = make_args(number=5)
+        with _patch_all(sample_config, self.adapter):
+            milestone_cmd.handle_delete(args, fmt="json")
+
+        data = json.loads(capsys.readouterr().out)
+        assert data["result"] == "deleted"
+        assert data["number"] == 5
+        assert data["message"]
+
 
 class TestHandleView:
     def setup_method(self):

--- a/tests/test_commands/test_notification.py
+++ b/tests/test_commands/test_notification.py
@@ -70,6 +70,28 @@ class TestHandleRead:
             notif_cmd.handle_read(args, fmt="table")
         adapter.mark_all_notifications_read.assert_called_once()
 
+    def test_read_single_json_format(self, capsys):
+        """fmt="json" のとき構造化 JSON が出力される。"""
+        with patch_adapter("gfo.commands.notification"):
+            args = make_args(id="1", mark_all=False)
+            notif_cmd.handle_read(args, fmt="json")
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["result"] == "marked_read"
+        assert data["id"] == "1"
+        assert data["message"]
+
+    def test_read_all_json_format(self, capsys):
+        """--all + fmt="json" のとき構造化 JSON が出力される。"""
+        with patch_adapter("gfo.commands.notification"):
+            args = make_args(id=None, mark_all=True)
+            notif_cmd.handle_read(args, fmt="json")
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["result"] == "marked_read"
+        assert data["all"] is True
+        assert data["message"]
+
     def test_error_both_id_and_all(self):
         with patch_adapter("gfo.commands.notification"):
             args = make_args(id="1", mark_all=True)

--- a/tests/test_commands/test_org.py
+++ b/tests/test_commands/test_org.py
@@ -262,6 +262,17 @@ class TestHandleDelete:
         out = capsys.readouterr().out
         assert "Aborted" in out
 
+    def test_delete_json_format(self, capsys):
+        """fmt="json" で構造化された成功 JSON が出力される。"""
+        with patch_adapter("gfo.commands.org") as adapter:
+            args = make_args(name="my-org", yes=True)
+            org_cmd.handle_delete(args, fmt="json")
+        adapter.delete_organization.assert_called_once_with("my-org")
+        data = json.loads(capsys.readouterr().out)
+        assert data["result"] == "deleted"
+        assert data["name"] == "my-org"
+        assert data["message"]
+
     def test_error_propagation(self):
         with patch_adapter("gfo.commands.org") as adapter:
             adapter.delete_organization.side_effect = HttpError(403, "Forbidden")

--- a/tests/test_commands/test_package.py
+++ b/tests/test_commands/test_package.py
@@ -117,6 +117,19 @@ class TestHandleDelete:
         out = capsys.readouterr().out
         assert "Aborted" in out
 
+    def test_delete_json_format(self, capsys):
+        """fmt="json" で構造化された成功 JSON が出力される。"""
+        with patch_adapter("gfo.commands.package") as adapter:
+            args = make_args(package_type="npm", name="test-pkg", version="1.0.0", yes=True)
+            package_cmd.handle_delete(args, fmt="json")
+        adapter.delete_package.assert_called_once_with("npm", "test-pkg", "1.0.0")
+        data = json.loads(capsys.readouterr().out)
+        assert data["result"] == "deleted"
+        assert data["package_type"] == "npm"
+        assert data["name"] == "test-pkg"
+        assert data["version"] == "1.0.0"
+        assert data["message"]
+
     def test_delete_success_message(self, capsys):
         """削除成功メッセージの出力内容検証。"""
         with patch_adapter("gfo.commands.package"):

--- a/tests/test_commands/test_pr.py
+++ b/tests/test_commands/test_pr.py
@@ -485,6 +485,20 @@ class TestHandleMerge:
             1, method="merge", title="Title only", message=None
         )
 
+    def test_json_output_with_delete_branch(self, sample_config, mock_adapter, capsys):
+        """fmt=json + --delete-branch では単一の構造化 JSON を出力する。"""
+        args = make_args(number=1, merge=False, squash=False, rebase=False, delete_branch=True)
+        with _patch_all(sample_config, mock_adapter):
+            pr_cmd.handle_merge(args, fmt="json")
+
+        out = capsys.readouterr().out
+        assert len(out.strip().splitlines()) == 1
+        data = json.loads(out)
+        assert data["result"] == "merged"
+        assert data["number"] == 1
+        assert data["deleted_branch"] == "feature/test"
+        assert data["message"]
+
 
 class TestHandleClose:
     def test_calls_close_pull_request(self, sample_config, mock_adapter):
@@ -493,6 +507,17 @@ class TestHandleClose:
             pr_cmd.handle_close(args, fmt="table")
 
         mock_adapter.close_pull_request.assert_called_once_with(1)
+
+    def test_json_output(self, sample_config, mock_adapter, capsys):
+        """fmt=json では構造化された成功 JSON を出力する。"""
+        args = make_args(number=42)
+        with _patch_all(sample_config, mock_adapter):
+            pr_cmd.handle_close(args, fmt="json")
+
+        data = json.loads(capsys.readouterr().out)
+        assert data["result"] == "closed"
+        assert data["number"] == 42
+        assert data["message"]
 
 
 class TestHandleReopen:
@@ -1206,6 +1231,27 @@ class TestHandleCreateDryRun:
         mock_adapter.create_pull_request.assert_not_called()
         out = capsys.readouterr().out
         assert "My PR" in out
+
+    def test_dry_run_json_structured_output(self, sample_config, mock_adapter, capsys):
+        """--dry-run + fmt=json では単一の構造化 JSON を出力する。"""
+        args = make_args(
+            head="feature/test",
+            base="main",
+            title="My PR",
+            body="Detailed description",
+            draft=True,
+            dry_run=True,
+        )
+        with _patch_all(sample_config, mock_adapter):
+            pr_cmd.handle_create(args, fmt="json")
+        mock_adapter.create_pull_request.assert_not_called()
+        data = json.loads(capsys.readouterr().out)
+        assert data["result"] == "dry_run"
+        assert data["title"] == "My PR"
+        assert data["head"] == "feature/test"
+        assert data["base"] == "main"
+        assert data["draft"] is True
+        assert data["body"] == "Detailed description"
 
 
 class TestHandleCreateWeb:

--- a/tests/test_commands/test_release.py
+++ b/tests/test_commands/test_release.py
@@ -460,6 +460,18 @@ class TestHandleDelete:
         assert "v1.0.0" in out
         assert "Deleted" in out
 
+    def test_delete_json_format(self, sample_config, capsys):
+        """fmt="json" で構造化 JSON（result / tag / message）が出力される。"""
+        args = make_args(tag="v1.0.0")
+        with _patch_all(sample_config, self.adapter):
+            release_cmd.handle_delete(args, fmt="json")
+
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["result"] == "deleted"
+        assert data["tag"] == "v1.0.0"
+        assert data["message"]
+
     def test_empty_tag_raises_config_error(self, sample_config):
         args = make_args(tag="")
         with _patch_all(sample_config, self.adapter):
@@ -809,6 +821,37 @@ class TestHandleAsset:
             release_cmd.handle_asset(args, fmt="table")
 
         self.adapter.delete_release_asset.assert_called_once_with(tag="v1.0.0", asset_id="1")
+
+    def test_asset_delete_json_format(self, sample_config, capsys):
+        """fmt="json" で構造化 JSON（result / asset_id / message）が出力される。"""
+        args = make_args(asset_action="delete", tag="v1.0.0", asset_id="1")
+        with _patch_all(sample_config, self.adapter):
+            release_cmd.handle_asset(args, fmt="json")
+
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["result"] == "deleted"
+        assert data["asset_id"] == "1"
+        assert data["message"]
+
+    def test_asset_download_by_id_json_format(self, sample_config, capsys):
+        """fmt="json" で構造化 JSON（result / path / message）が出力される。"""
+        self.adapter.download_release_asset.return_value = "/tmp/app.zip"
+        args = make_args(
+            asset_action="download",
+            tag="v1.0.0",
+            asset_id="1",
+            pattern=None,
+            dir=".",
+        )
+        with _patch_all(sample_config, self.adapter):
+            release_cmd.handle_asset(args, fmt="json")
+
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["result"] == "downloaded"
+        assert data["path"] == "/tmp/app.zip"
+        assert data["message"]
 
     def test_no_action_raises(self, sample_config):
         args = make_args(asset_action=None)

--- a/tests/test_commands/test_repo.py
+++ b/tests/test_commands/test_repo.py
@@ -896,6 +896,32 @@ class TestHandleDelete:
         assert "Deleted repository" in out
         assert "my-org/my-repo" in out
 
+    def test_delete_json_format(self, sample_config, mock_adapter, capsys):
+        """fmt="json" で構造化された成功 JSON が出力される。"""
+        args = make_args(yes=True)
+        mock_adapter.owner = "my-org"
+        mock_adapter.repo = "my-repo"
+        with _patch_all(sample_config, mock_adapter):
+            repo_cmd.handle_delete(args, fmt="json")
+
+        data = json.loads(capsys.readouterr().out)
+        assert data["result"] == "deleted"
+        assert data["repository"] == "my-org/my-repo"
+        assert data["message"]
+
+    def test_delete_aborted_json_format(self, sample_config, mock_adapter, capsys):
+        """fmt="json" で確認を拒否すると result="aborted" の JSON が出力される。"""
+        args = make_args(yes=False)
+        mock_adapter.owner = "my-org"
+        mock_adapter.repo = "my-repo"
+        with _patch_all(sample_config, mock_adapter), patch("builtins.input", return_value="n"):
+            repo_cmd.handle_delete(args, fmt="json")
+
+        mock_adapter.delete_repository.assert_not_called()
+        data = json.loads(capsys.readouterr().out)
+        assert data["result"] == "aborted"
+        assert data["message"]
+
 
 class TestParseRepoArg:
     def test_valid_format(self):

--- a/tests/test_commands/test_secret.py
+++ b/tests/test_commands/test_secret.py
@@ -115,6 +115,17 @@ class TestHandleDelete:
             secret_cmd.handle_delete(args, fmt="table")
         adapter.delete_secret.assert_called_once_with("MY_SECRET", scope=None)
 
+    def test_json_format(self, capsys):
+        """fmt="json" のとき構造化 JSON が出力される。"""
+        with patch_adapter("gfo.commands.secret"):
+            args = make_args(name="MY_SECRET")
+            secret_cmd.handle_delete(args, fmt="json")
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["result"] == "deleted"
+        assert data["name"] == "MY_SECRET"
+        assert data["message"]
+
     def test_error_propagation(self):
         with patch_adapter("gfo.commands.secret") as adapter:
             adapter.delete_secret.side_effect = HttpError(404, "Not found")

--- a/tests/test_commands/test_ssh_key.py
+++ b/tests/test_commands/test_ssh_key.py
@@ -102,6 +102,17 @@ class TestHandleDelete:
         assert "Deleted" in out
         assert "1" in out
 
+    def test_json_format(self, capsys):
+        """fmt="json" のとき構造化 JSON が出力される。"""
+        with patch_adapter("gfo.commands.ssh_key"):
+            args = make_args(id=1)
+            ssh_key_cmd.handle_delete(args, fmt="json")
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["result"] == "deleted"
+        assert data["id"] == 1
+        assert data["message"]
+
     def test_calls_delete_ssh_key_string_id(self):
         with patch_adapter("gfo.commands.ssh_key") as adapter:
             args = make_args(id="abc-123")

--- a/tests/test_commands/test_tag.py
+++ b/tests/test_commands/test_tag.py
@@ -174,3 +174,14 @@ class TestHandleDeleteSuccessMessage:
             tag_cmd.handle_delete(args, fmt="table")
         out = capsys.readouterr().out
         assert "v1.0.0" in out
+
+    def test_delete_json_format(self, capsys):
+        """fmt="json" で構造化 JSON（result / tag / message）が出力される。"""
+        with patch_adapter("gfo.commands.tag"):
+            args = make_args(name="v1.0.0")
+            tag_cmd.handle_delete(args, fmt="json")
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["result"] == "deleted"
+        assert data["tag"] == "v1.0.0"
+        assert data["message"]

--- a/tests/test_commands/test_tag_protect.py
+++ b/tests/test_commands/test_tag_protect.py
@@ -140,6 +140,17 @@ class TestHandleDelete:
             tp_cmd.handle_delete(args, fmt="table")
         adapter.delete_tag_protection.assert_called_once_with("v*")
 
+    def test_delete_json_format(self, capsys):
+        """fmt="json" で構造化 JSON（result / id / message）が出力される。"""
+        with patch_adapter("gfo.commands.tag_protect"):
+            args = make_args(id=1)
+            tp_cmd.handle_delete(args, fmt="json")
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["result"] == "deleted"
+        assert data["id"] == 1
+        assert data["message"]
+
     def test_error_propagation(self):
         with patch_adapter("gfo.commands.tag_protect") as adapter:
             adapter.delete_tag_protection.side_effect = HttpError(404, "Not found")

--- a/tests/test_commands/test_variable.py
+++ b/tests/test_commands/test_variable.py
@@ -105,6 +105,17 @@ class TestHandleDelete:
             variable_cmd.handle_delete(args, fmt="table")
         adapter.delete_variable.assert_called_once_with("MY_VAR", scope=None)
 
+    def test_json_format(self, capsys):
+        """fmt="json" のとき構造化 JSON が出力される。"""
+        with patch_adapter("gfo.commands.variable"):
+            args = make_args(name="MY_VAR")
+            variable_cmd.handle_delete(args, fmt="json")
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["result"] == "deleted"
+        assert data["name"] == "MY_VAR"
+        assert data["message"]
+
     def test_error_propagation(self):
         with patch_adapter("gfo.commands.variable") as adapter:
             adapter.delete_variable.side_effect = GfoError("not found")

--- a/tests/test_commands/test_webhook.py
+++ b/tests/test_commands/test_webhook.py
@@ -45,6 +45,17 @@ class TestHandleDelete:
             webhook_cmd.handle_delete(args, fmt="table")
         adapter.delete_webhook.assert_called_once_with(hook_id=1)
 
+    def test_json_format(self, capsys):
+        """fmt="json" のとき構造化 JSON が出力される。"""
+        with patch_adapter("gfo.commands.webhook"):
+            args = make_args(id=42)
+            webhook_cmd.handle_delete(args, fmt="json")
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["result"] == "deleted"
+        assert data["id"] == 42
+        assert data["message"]
+
 
 class TestHandleTest:
     def test_calls_test_webhook(self):
@@ -58,6 +69,17 @@ class TestHandleTest:
             args = make_args(id=42)
             webhook_cmd.handle_test(args, fmt="table")
         adapter.test_webhook.assert_called_once_with(hook_id=42)
+
+    def test_json_format(self, capsys):
+        """fmt="json" のとき構造化 JSON が出力される。"""
+        with patch_adapter("gfo.commands.webhook"):
+            args = make_args(id=42)
+            webhook_cmd.handle_test(args, fmt="json")
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["result"] == "tested"
+        assert data["id"] == 42
+        assert data["message"]
 
 
 class TestHandleEdit:

--- a/tests/test_commands/test_wiki.py
+++ b/tests/test_commands/test_wiki.py
@@ -117,6 +117,17 @@ class TestHandleDelete:
             wiki_cmd.handle_delete(args, fmt="table")
         adapter.delete_wiki_page.assert_called_once_with("1")
 
+    def test_delete_json_format(self, capsys):
+        """fmt="json" で構造化 JSON（result / id / message）が出力される。"""
+        with patch_adapter("gfo.commands.wiki"):
+            args = make_args(id="1")
+            wiki_cmd.handle_delete(args, fmt="json")
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["result"] == "deleted"
+        assert data["id"] == "1"
+        assert data["message"]
+
     def test_error_propagation(self):
         with patch_adapter("gfo.commands.wiki") as adapter:
             adapter.delete_wiki_page.side_effect = HttpError(403, "Forbidden")

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -18,6 +18,7 @@ from gfo.output import (
     format_plain,
     format_table,
     output,
+    output_result,
 )
 
 
@@ -306,6 +307,49 @@ class TestOutput:
         captured = capsys.readouterr()
         parsed = json.loads(captured.out)
         assert parsed[0]["number"] == 1
+
+
+class TestOutputResult:
+    def test_table_prints_message_plain(self, capsys):
+        output_result("Deleted repository 'o/r'.", result="deleted", fmt="table", repository="o/r")
+        assert capsys.readouterr().out == "Deleted repository 'o/r'.\n"
+
+    def test_plain_prints_message_plain(self, capsys):
+        output_result("Deleted repository 'o/r'.", result="deleted", fmt="plain", repository="o/r")
+        assert capsys.readouterr().out == "Deleted repository 'o/r'.\n"
+
+    def test_json_outputs_structured(self, capsys):
+        output_result("Deleted repository 'o/r'.", result="deleted", fmt="json", repository="o/r")
+        data = json.loads(capsys.readouterr().out)
+        assert data == {
+            "result": "deleted",
+            "repository": "o/r",
+            "message": "Deleted repository 'o/r'.",
+        }
+
+    def test_json_key_order_result_first(self, capsys):
+        """result が先頭、message が末尾に来る。"""
+        output_result("msg", result="closed", fmt="json", number=7)
+        keys = list(json.loads(capsys.readouterr().out).keys())
+        assert keys == ["result", "number", "message"]
+
+    def test_json_non_ascii_not_escaped(self, capsys):
+        output_result("ラベル 'バグ' を削除しました。", result="deleted", fmt="json", name="バグ")
+        out = capsys.readouterr().out
+        assert "バグ" in out
+        assert json.loads(out)["name"] == "バグ"
+
+    def test_jq_forces_json(self, capsys):
+        """jq 指定時は fmt が table でも JSON になり jq が適用される。"""
+        with patch("gfo.output.apply_jq_filter", return_value='"deleted"') as mock_jq:
+            output_result("msg", result="deleted", fmt="table", jq=".result")
+        mock_jq.assert_called_once()
+        assert capsys.readouterr().out.strip() == '"deleted"'
+
+    def test_json_no_extra_fields(self, capsys):
+        output_result("Aborted.", result="aborted", fmt="json")
+        data = json.loads(capsys.readouterr().out)
+        assert data == {"result": "aborted", "message": "Aborted."}
 
 
 class TestFormatErrorJson:


### PR DESCRIPTION
## 概要

Closes #63

create / delete / close 等の mutation 系コマンドは成功メッセージを平文 `print(_(...))` で出していたため、`--format json` / 非 TTY の auto-JSON でも平文が返り、エラー側（`format_error_json`）と機械可読性が非対称だった。

## 変更内容

### 共通ヘルパー `output_result()`（output.py）
- table / plain: 従来どおり message を平文出力（**既存の表示は不変**）
- json: `{"result": <動詞>, <対象フィールド>, "message": <ローカライズ済みメッセージ>}`
- `--jq`: `output()` と同じく fmt を json に強制して適用

### 移行（commands/ 26 モジュール・82 箇所）
- 動詞は snake_case 過去形で統一: `deleted` / `closed` / `reopened` / `locked` / `subscribed` / `pinned` / `merged` / `archived` / `starred` / `transferred` / `downloaded` / `saved`（auth）/ `initialized`（init）等
- 対象フィールドはリソースに応じて `number` / `repository` / `name` / `id` / `path` / `branch` / `tag` 等
- 確認プロンプト拒否の `Aborted.` も `{"result": "aborted"}` で構造化
- **pr merge**: JSON では 1 オブジェクトに統合（`--delete-branch` 時は `deleted_branch` フィールド。table は従来どおり 2 行。メッセージ出力がブランチ削除の後になる点のみ挙動変更）
- **pr create --dry-run**: JSON では `result="dry_run"` + `title`/`head`/`base`/`draft`/`body`
- **ci watch** のタイムアウト診断は stderr へ移動（直後に `output(pipeline)` が出す JSON stdout を汚染しないため）
- メッセージ文字列は既存 msgid をそのまま使用 — **`.po` 変更なし・table/plain の表示は 1 文字も変わらない**

### 対象外（意図的に平文のまま）
対話プロンプト・stderr 警告・データ出力（`pr diff` / `auth token` / `file get` 等）・リスト空メッセージ

### docs
`docs/commands.ja.md` のグローバルオプション節に mutation JSON 出力の説明と例を追加

## テスト・検証

- `output_result` 単体テスト 7 件（キー順・非 ASCII・jq 強制・フィールドなし）
- 全 26 モジュールに json モードのハンドラテストを追加（repo は aborted 経路も）
- AST 検査で全 82 呼び出しが `fmt`/`jq`/`result` を渡していることを機械的に確認
- 実 CLI E2E（scratch リポジトリの `gfo init --non-interactive`）: `--format json` / `--jq .result` / table / パイプ auto-JSON の 4 経路を確認
- 全 3888 件 pass、ruff / mypy / bandit green

🤖 Generated with [Claude Code](https://claude.com/claude-code)