### PR TITLE
feat(http): 汎用 4xx エラーの JSON body を構造化する

### DIFF
--- a/.claude/rules/01-exceptions.md
+++ b/.claude/rules/01-exceptions.md
@@ -18,6 +18,7 @@ GfoError
 │   ├── AuthenticationError # 401/403
 │   ├── NotFoundError       # 404
 │   ├── RateLimitError      # 429
+│   ├── ValidationError     # 400/422（JSON body パース済み details 付き）
 │   └── ServerError         # 5xx
 ├── NetworkError            # ConnectionError/Timeout/SSLError
 ├── NotSupportedError       # サービスが非対応の操作

--- a/src/gfo/exceptions.py
+++ b/src/gfo/exceptions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from enum import IntEnum
+from typing import Any
 
 from gfo.i18n import _
 
@@ -89,9 +90,12 @@ class AuthError(GfoError):
 class HttpError(GfoError):
     """HTTP リクエストのエラー（基底）。"""
 
-    def __init__(self, status_code: int, message: str, url: str = ""):
+    def __init__(self, status_code: int, message: str, url: str = "", details: Any = None):
         self.status_code = status_code
         self.url = url
+        # エラーレスポンスの JSON body をパースした構造化詳細。
+        # --format json 出力時に details フィールドとして載せる（人間可読 message と対）。
+        self.details = details
         super().__init__(
             _("HTTP {status_code}: {message}").format(status_code=status_code, message=message)
         )
@@ -138,6 +142,21 @@ class RateLimitError(HttpError):
         super().__init__(429, msg, url)
         if retry_after:
             self.hint = _("Retry after {retry_after}s.").format(retry_after=retry_after)
+
+
+class ValidationError(HttpError):
+    """400/422 リクエスト内容のバリデーションエラー。
+
+    サービスがフィールド別のエラーを JSON body で返すケース（GitHub の 422 等）。
+    パース済み body は details に載る。
+    """
+
+    error_code = "validation_error"
+    exit_code = ExitCode.GENERAL
+
+    def __init__(self, status_code: int, message: str, url: str = "", details: Any = None):
+        super().__init__(status_code, message, url, details)
+        self.hint = _("Check the request parameters for invalid or missing values.")
 
 
 class ServerError(HttpError):
@@ -228,8 +247,8 @@ def lookup_http_exception(status_code: int) -> type[HttpError] | None:
 
     - 401 / 403 / 404 のような単純な status → exception 対応はテーブル参照。
     - 5xx は range で一括 `ServerError` にマップする。
-    - 429 や汎用 4xx などコンストラクタに追加引数が必要なケースは `None` を返し、
-      呼び出し側で個別に組み立てる。
+    - 429 / 400 / 422 / 汎用 4xx などコンストラクタに追加引数（retry_after,
+      body, details 等）が必要なケースは `None` を返し、呼び出し側で個別に組み立てる。
     """
     cls = _SIMPLE_HTTP_EXCEPTIONS.get(status_code)
     if cls is not None:

--- a/src/gfo/http.py
+++ b/src/gfo/http.py
@@ -41,6 +41,105 @@ _MAX_RETRY_AFTER = _max_retry_after_seconds()
 _MAX_ERROR_BODY_CHARS = 4096
 
 
+def _truncate_error_body(body: str) -> str:
+    """エラーレスポンス body を _MAX_ERROR_BODY_CHARS 文字に切り詰める。"""
+    if len(body) > _MAX_ERROR_BODY_CHARS:
+        return (
+            body[:_MAX_ERROR_BODY_CHARS]
+            + f"... [truncated {len(body) - _MAX_ERROR_BODY_CHARS} chars]"
+        )
+    return body
+
+
+def _flatten_message_value(msg: Any) -> str | None:
+    """エラー JSON の message フィールド値を 1 行の文字列に平坦化する。
+
+    GitLab は message に {"name": ["has already been taken"]} のような
+    dict / list を返すことがあるため、文字列以外もフィールド名付きで展開する。
+    """
+    if isinstance(msg, str):
+        return msg.strip() or None
+    if isinstance(msg, list):
+        parts = [str(x) for x in msg if x]
+        return "; ".join(parts) or None
+    if isinstance(msg, dict):
+        parts = []
+        for key, val in msg.items():
+            val_str = "; ".join(str(x) for x in val) if isinstance(val, list) else str(val)
+            parts.append(f"{key}: {val_str}")
+        return ", ".join(parts) or None
+    return None
+
+
+def _summarize_error_item(item: Any) -> str | None:
+    """errors 配列の 1 要素を人間可読な文字列に要約する。
+
+    Backlog は {"message": ...}、GitHub は message を持たない場合
+    {"resource": ..., "field": ..., "code": ...} の形式で返す。
+    """
+    if isinstance(item, str):
+        return item.strip() or None
+    if not isinstance(item, dict):
+        return None
+    msg = _flatten_message_value(item.get("message"))
+    if msg:
+        return msg
+    label = ".".join(str(item[k]) for k in ("resource", "field") if item.get(k))
+    code = item.get("code")
+    if label and code:
+        return f"{label}: {code}"
+    return label or (str(code) if code else None)
+
+
+def _extract_error_message(data: dict[str, Any]) -> str | None:
+    """エラーレスポンスの JSON dict から主要メッセージを抽出する。
+
+    サービスごとの代表的な形式:
+    - GitHub / Gitea 系 / Azure DevOps: {"message": str, "errors": [...]}
+    - GitLab: {"message": str | dict | list} または {"error": str}
+    - Bitbucket: {"error": {"message": str, "fields": {...}}}
+    - Backlog: {"errors": [{"message": str}, ...]}
+    """
+    main = _flatten_message_value(data.get("message"))
+    if not main:
+        err = data.get("error")
+        if isinstance(err, str):
+            main = err.strip() or None
+        elif isinstance(err, dict):
+            main = _flatten_message_value(err.get("message"))
+    errors = data.get("errors")
+    detail = None
+    if isinstance(errors, list):
+        summaries = [s for s in (_summarize_error_item(e) for e in errors) if s]
+        if summaries:
+            detail = "; ".join(summaries)
+    if main and detail:
+        return f"{main} ({detail})"
+    return main or detail
+
+
+def _summarize_error_body(response: requests.Response) -> tuple[str, dict[str, Any] | None]:
+    """エラーレスポンス body から (人間可読メッセージ, 構造化詳細) を抽出する。
+
+    JSON dict の body は主要メッセージを抽出し、パース結果を details として返す。
+    非 JSON・非 dict・巨大 body（_MAX_ERROR_BODY_CHARS 超）は従来どおり
+    切り詰めた raw テキストを message にし、details は付けない。
+    """
+    text = response.text
+    data: Any = None
+    if len(text) <= _MAX_ERROR_BODY_CHARS:
+        try:
+            data = response.json()
+        except ValueError:
+            data = None
+    if not isinstance(data, dict):
+        return _truncate_error_body(text), None
+    message = _extract_error_message(data)
+    if message is None:
+        return _truncate_error_body(text), data
+    return message, data
+
+
 def _max_download_bytes() -> int:
     """GFO_MAX_DOWNLOAD_BYTES の値を返す。未設定なら 5 GiB。0 は無制限。
 
@@ -475,14 +574,12 @@ class HttpClient:
             raise gfo.exceptions.AuthenticationError(code, url)
         if cls is gfo.exceptions.ServerError:
             raise gfo.exceptions.ServerError(code, url)
-        # その他 (汎用 4xx 等) は HttpError として body 付きで送出。
-        body = response.text
-        if len(body) > _MAX_ERROR_BODY_CHARS:
-            body = (
-                body[:_MAX_ERROR_BODY_CHARS]
-                + f"... [truncated {len(body) - _MAX_ERROR_BODY_CHARS} chars]"
-            )
-        raise gfo.exceptions.HttpError(code, body, url)
+        # その他 (汎用 4xx 等) は body を解析し、人間可読 message + 構造化 details で送出。
+        # 400/422 はバリデーションエラーとして専用の error_code / hint を付ける。
+        message, details = _summarize_error_body(response)
+        if code in (400, 422):
+            raise gfo.exceptions.ValidationError(code, message, url, details=details)
+        raise gfo.exceptions.HttpError(code, message, url, details=details)
 
     @staticmethod
     def _parse_retry_after(value: str | None, default: int = 60) -> int:

--- a/src/gfo/locale/ja/LC_MESSAGES/gfo.po
+++ b/src/gfo/locale/ja/LC_MESSAGES/gfo.po
@@ -1486,6 +1486,9 @@ msgid "Cannot parse --repo value: {value}. Use URL or HOST/OWNER/REPO format."
 msgstr "--repo の値を解析できません: {value}。URL または HOST/OWNER/REPO 形式で指定してください。"
 
 
+msgid "Check the request parameters for invalid or missing values."
+msgstr "リクエストパラメータに不正な値や不足がないか確認してください。"
+
 msgid "Check your network connection and try again."
 msgstr "ネットワーク接続を確認して再試行してください。"
 

--- a/src/gfo/output.py
+++ b/src/gfo/output.py
@@ -8,7 +8,7 @@ import subprocess  # nosec B404 - jq is a fixed, well-known command
 import unicodedata
 from typing import Any
 
-from gfo.exceptions import GfoError
+from gfo.exceptions import GfoError, HttpError
 from gfo.i18n import _
 
 
@@ -84,6 +84,11 @@ def format_error_json(err: GfoError) -> str:
         "message": str(err),
         "exit_code": int(err.exit_code),
     }
+    if isinstance(err, HttpError):
+        d["status_code"] = err.status_code
+        # エラーレスポンスの JSON body をパースした構造化詳細（4xx バリデーション等）
+        if err.details is not None:
+            d["details"] = err.details
     if hasattr(err, "hint") and err.hint:
         d["hint"] = err.hint
     return json.dumps(d, ensure_ascii=False)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -17,6 +17,7 @@ from gfo.exceptions import (
     RateLimitError,
     ServerError,
     UnsupportedServiceError,
+    ValidationError,
 )
 
 
@@ -140,6 +141,31 @@ class TestServerError:
         assert isinstance(err, GfoError)
 
 
+class TestValidationError:
+    def test_attributes(self):
+        details = {
+            "message": "Validation Failed",
+            "errors": [{"resource": "Issue", "field": "title", "code": "missing_field"}],
+        }
+        err = ValidationError(422, "Validation Failed", "https://api.github.com", details=details)
+        assert err.status_code == 422
+        assert err.url == "https://api.github.com"
+        assert err.error_code == "validation_error"
+        assert err.exit_code == ExitCode.GENERAL
+        assert err.details == details
+        assert err.hint
+        assert "Validation Failed" in str(err)
+
+    def test_default_details_none(self):
+        err = ValidationError(400, "Bad Request")
+        assert err.details is None
+
+    def test_inherits_http_error(self):
+        err = ValidationError(422, "Validation Failed")
+        assert isinstance(err, HttpError)
+        assert isinstance(err, GfoError)
+
+
 class TestNetworkError:
     def test_message(self):
         err = NetworkError("Connection refused")
@@ -186,6 +212,7 @@ class TestErrorCode:
             (NotFoundError(), "not_found"),
             (RateLimitError(), "rate_limited"),
             (ServerError(500), "server_error"),
+            (ValidationError(422, "x"), "validation_error"),
             (NetworkError("x"), "network_error"),
             (NotSupportedError("S", "op"), "not_supported"),
             (UnsupportedServiceError("x"), "unsupported_service"),
@@ -210,6 +237,7 @@ class TestExitCode:
             (NotFoundError(), ExitCode.NOT_FOUND),
             (RateLimitError(), ExitCode.RATE_LIMIT),
             (ServerError(500), ExitCode.GENERAL),
+            (ValidationError(422, "x"), ExitCode.GENERAL),
             (NetworkError("x"), ExitCode.NETWORK),
             (NotSupportedError("S", "op"), ExitCode.NOT_SUPPORTED),
             (UnsupportedServiceError("x"), ExitCode.GENERAL),
@@ -272,6 +300,10 @@ class TestHint:
 
     def test_server_error_hint(self):
         assert ServerError(500).hint == "Please try again later."
+
+    def test_validation_error_hint(self):
+        err = ValidationError(422, "Validation Failed")
+        assert err.hint == "Check the request parameters for invalid or missing values."
 
 
 class TestCatchByBaseClass:

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -12,6 +12,7 @@ from gfo.exceptions import (
     NotFoundError,
     RateLimitError,
     ServerError,
+    ValidationError,
 )
 from gfo.http import (
     HttpClient,
@@ -339,6 +340,110 @@ class TestErrorBodyTruncation:
         m = re.search(r"\[truncated (\d+) chars\]", msg)
         assert m is not None
         assert int(m.group(1)) == extra
+
+
+class TestStructuredErrorBody:
+    """汎用 4xx の JSON エラーボディは message 抽出 + details 構造化される。"""
+
+    @responses.activate
+    def test_github_422_validation_error(self):
+        """GitHub 形式の 422 は ValidationError になり、errors 配列が message に要約される。"""
+        body = {
+            "message": "Validation Failed",
+            "errors": [{"resource": "Issue", "field": "title", "code": "missing_field"}],
+            "documentation_url": "https://docs.github.com/rest",
+        }
+        responses.add(responses.POST, f"{BASE}/repos/o/r/issues", json=body, status=422)
+        c = HttpClient(BASE)
+        with pytest.raises(ValidationError) as exc_info:
+            c.post("/repos/o/r/issues")
+        err = exc_info.value
+        assert str(err) == "HTTP 422: Validation Failed (Issue.title: missing_field)"
+        assert err.error_code == "validation_error"
+        assert err.details == body
+        assert err.hint
+
+    @responses.activate
+    def test_gitlab_400_message_dict(self):
+        """GitLab 形式の message dict はフィールド名付きで平坦化される。"""
+        body = {"message": {"name": ["has already been taken"]}}
+        responses.add(responses.POST, f"{BASE}/projects", json=body, status=400)
+        c = HttpClient(BASE)
+        with pytest.raises(ValidationError) as exc_info:
+            c.post("/projects")
+        assert "name: has already been taken" in str(exc_info.value)
+        assert exc_info.value.details == body
+
+    @responses.activate
+    def test_bitbucket_error_object(self):
+        """Bitbucket 形式の {"error": {"message": ...}} から message を抽出する。"""
+        body = {"error": {"message": "Repository already exists.", "fields": {"name": ["taken"]}}}
+        responses.add(responses.POST, f"{BASE}/repositories/w", json=body, status=400)
+        c = HttpClient(BASE)
+        with pytest.raises(ValidationError) as exc_info:
+            c.post("/repositories/w")
+        assert "Repository already exists." in str(exc_info.value)
+        assert exc_info.value.details == body
+
+    @responses.activate
+    def test_backlog_errors_list(self):
+        """Backlog 形式の errors 配列から message を抽出する。"""
+        body = {"errors": [{"message": "No project.", "code": 6, "moreInfo": ""}]}
+        responses.add(responses.GET, f"{BASE}/projects/X", json=body, status=400)
+        c = HttpClient(BASE)
+        with pytest.raises(ValidationError) as exc_info:
+            c.get("/projects/X")
+        assert "No project." in str(exc_info.value)
+        assert exc_info.value.details == body
+
+    @responses.activate
+    def test_409_is_generic_http_error_with_details(self):
+        """400/422 以外の汎用 4xx は HttpError のまま details だけ構造化される。"""
+        body = {"message": "Reference already exists"}
+        responses.add(responses.POST, f"{BASE}/repos/o/r/git/refs", json=body, status=409)
+        c = HttpClient(BASE)
+        with pytest.raises(HttpError) as exc_info:
+            c.post("/repos/o/r/git/refs")
+        err = exc_info.value
+        assert not isinstance(err, ValidationError)
+        assert str(err) == "HTTP 409: Reference already exists"
+        assert err.error_code == "general_error"
+        assert err.details == body
+
+    @responses.activate
+    def test_non_json_body_falls_back_to_raw_text(self):
+        """非 JSON body は従来どおり raw テキストが message になり details は付かない。"""
+        responses.add(responses.GET, f"{BASE}/items", body="<html>conflict</html>", status=409)
+        c = HttpClient(BASE)
+        with pytest.raises(HttpError) as exc_info:
+            c.get("/items")
+        assert "<html>conflict</html>" in str(exc_info.value)
+        assert exc_info.value.details is None
+
+    @responses.activate
+    def test_unrecognized_json_keys_fall_back_to_raw_text(self):
+        """message / error / errors を持たない JSON dict は raw テキストに fallback するが
+        details にはパース結果を載せる。"""
+        body = {"reason": "unknown shape"}
+        responses.add(responses.GET, f"{BASE}/items", json=body, status=422)
+        c = HttpClient(BASE)
+        with pytest.raises(ValidationError) as exc_info:
+            c.get("/items")
+        assert "unknown shape" in str(exc_info.value)
+        assert exc_info.value.details == body
+
+    @responses.activate
+    def test_huge_json_body_is_not_parsed(self):
+        """_MAX_ERROR_BODY_CHARS 超の body はパースせず切り詰めのみ（JSON 出力の肥大防止）。"""
+        from gfo.http import _MAX_ERROR_BODY_CHARS
+
+        body = {"message": "X" * (_MAX_ERROR_BODY_CHARS * 2)}
+        responses.add(responses.GET, f"{BASE}/items", json=body, status=422)
+        c = HttpClient(BASE)
+        with pytest.raises(ValidationError) as exc_info:
+            c.get("/items")
+        assert "truncated" in str(exc_info.value)
+        assert exc_info.value.details is None
 
 
 class TestDownloadFileCrossOrigin:

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -9,7 +9,14 @@ from unittest.mock import patch
 
 import pytest
 
-from gfo.exceptions import AuthError, GfoError, NotSupportedError, RateLimitError
+from gfo.exceptions import (
+    AuthError,
+    GfoError,
+    HttpError,
+    NotSupportedError,
+    RateLimitError,
+    ValidationError,
+)
 from gfo.output import (
     _display_width,
     apply_jq_filter,
@@ -400,6 +407,30 @@ class TestFormatErrorJson:
         err = GfoError("日本語エラー")
         raw = format_error_json(err)
         assert "日本語エラー" in raw
+
+    def test_http_error_includes_status_code(self):
+        err = HttpError(409, "Conflict")
+        result = json.loads(format_error_json(err))
+        assert result["status_code"] == 409
+        # details なしの HttpError には details フィールドを付けない
+        assert "details" not in result
+
+    def test_validation_error_includes_details(self):
+        details = {
+            "message": "Validation Failed",
+            "errors": [{"resource": "Issue", "field": "title", "code": "missing_field"}],
+        }
+        err = ValidationError(422, "Validation Failed", details=details)
+        result = json.loads(format_error_json(err))
+        assert result["error"] == "validation_error"
+        assert result["status_code"] == 422
+        assert result["details"] == details
+        assert result["hint"]
+
+    def test_non_http_error_has_no_status_code(self):
+        err = GfoError("plain")
+        result = json.loads(format_error_json(err))
+        assert "status_code" not in result
 
 
 class TestApplyJqFilter:


### PR DESCRIPTION
Closes #68

## 変更内容

401/403/404/429/5xx 以外の汎用 4xx は `response.text` をそのまま message に詰めた `HttpError` になっており、GitHub の 422 等では `HTTP 422: {JSON 文字列}` という可読性の低いメッセージになっていた。

- `_handle_response`（`src/gfo/http.py`）で JSON body をパースし、主要メッセージを抽出して人間可読な 1 行 message にする
  - GitHub / Gitea 系 / Azure DevOps: `message` + `errors` 配列（`resource.field: code` 形式に要約）
  - GitLab: `message`（str / dict / list を平坦化）・`error`
  - Bitbucket: `error.message`
  - Backlog: `errors[].message`
- パース結果を `HttpError.details` に保持し、`--format json` のエラー出力に `details` / `status_code` フィールドを追加（`format_error_json`）
- 400/422 は新設の `ValidationError`（`error_code=validation_error`、hint 付き）として送出
- 非 JSON・巨大 body（`_MAX_ERROR_BODY_CHARS` 超）は従来どおり切り詰めた raw テキストに fallback し `details` は付けない
- 例外ツリーの rules（`.claude/rules/01-exceptions.md`）と ja 訳（`.po`）を同期

アダプター側フックは導入せず、サービス横断の共通形式抽出で対応した（rules 02 の方針に追加変更なし）。

## 動作確認（実サービス）

GitHub の実 422（既存ラベルの重複作成・状態変更なし）で確認:

```
$ gfo label create bug --format json
{"error": "validation_error", "message": "HTTP 422: Validation Failed (Label.name: already_exists)", "exit_code": 1, "status_code": 422, "details": {"message": "Validation Failed", "errors": [{"resource": "Label", "code": "already_exists", "field": "name"}], ...}, "hint": "Check the request parameters for invalid or missing values."}

$ gfo label create bug   # table
HTTP 422: Validation Failed (Label.name: already_exists)
```

## テスト

- `tests/test_http.py`: GitHub 422 / GitLab message dict / Bitbucket error object / Backlog errors 配列 / 409 汎用 / 非 JSON fallback / 未知形式 fallback / 巨大 body 非パース
- `tests/test_exceptions.py`: `ValidationError` の属性・error_code・exit_code・hint
- `tests/test_output.py`: `format_error_json` の `status_code` / `details`
- 全 3905 件 pass、ruff / mypy（linux + win32）/ bandit green

🤖 Generated with [Claude Code](https://claude.com/claude-code)