### PR TITLE
feat(i18n): auth / config / detect / http のエラーメッセージを i18n 化する

### DIFF
--- a/.claude/rules/01-exceptions.md
+++ b/.claude/rules/01-exceptions.md
@@ -55,3 +55,18 @@ def _to_pull_request(data: dict) -> PullRequest:
 
 `ValueError` や `IndexError` 等の追加例外も捕捉する必要があるケースだけ
 手書きの try/except を残す (デコレータでは捕捉しないため)。
+
+## エラーメッセージの i18n（必須）
+
+ユーザー向け例外（`GfoError` / `ConfigError` / `AuthError` / `DetectionError` /
+`HttpError` 系）に渡すメッセージは必ず `_()` を通し、`.po` に ja 訳を追加する:
+
+```python
+raise ConfigError(_("No tokens configured for host: {host}").format(host=host))
+```
+
+- f-string を直接渡さない（msgid はリテラルである必要がある。`_("...").format(...)` を使う）
+- `tests/test_i18n_lint.py` が `src/gfo/*.py`（トップレベル）を AST 検査で強制する。
+  adapter/ と commands/ は未対応箇所が残るため対象外（issue #83 で追跡）
+- 内部契約エラー（`ValueError` 等、上表参照）と `NotSupportedError` /
+  `UnsupportedServiceError`（識別子を受け取り内部で i18n 済みテンプレートに埋め込む）は対象外

--- a/src/gfo/auth.py
+++ b/src/gfo/auth.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from gfo._context import cli_account
 from gfo.config import get_config_dir, get_credentials_path
 from gfo.exceptions import AuthError, ConfigError, GitCommandError
+from gfo.i18n import _
 
 _SERVICE_ENV_MAP: dict[str, str] = {
     "github": "GITHUB_TOKEN",
@@ -60,8 +61,13 @@ def resolve_token(host: str, service_type: str) -> str:
         if account_name not in host_accounts:
             raise AuthError(
                 host,
-                f"Account '{account_name}' not found for host: {host}. "
-                f"Available accounts: {', '.join(k for k in host_accounts if k != '_default')}",
+                _(
+                    "Account '{account}' not found for host: {host}. Available accounts: {accounts}"
+                ).format(
+                    account=account_name,
+                    host=host,
+                    accounts=", ".join(k for k in host_accounts if k != "_default"),
+                ),
             )
 
     # 2. サービス別環境変数
@@ -83,9 +89,9 @@ def resolve_token(host: str, service_type: str) -> str:
 def save_token(host: str, token: str, account: str = "default") -> None:
     """credentials.toml にトークンを保存する。"""
     if account == "_default":
-        raise ConfigError("'_default' is a reserved key and cannot be used as an account name.")
+        raise ConfigError(_("'_default' is a reserved key and cannot be used as an account name."))
     if not token.strip():
-        raise AuthError(host, "Token must not be empty.")
+        raise AuthError(host, _("Token must not be empty."))
     host = host.lower()
     config_dir = get_config_dir()
     config_dir.mkdir(parents=True, exist_ok=True)
@@ -106,14 +112,16 @@ def save_token(host: str, token: str, account: str = "default") -> None:
 def switch_account(host: str, account: str) -> None:
     """アクティブアカウントを切り替える。"""
     if account == "_default":
-        raise ConfigError("'_default' is a reserved key and cannot be used as an account name.")
+        raise ConfigError(_("'_default' is a reserved key and cannot be used as an account name."))
     host = host.lower()
     tokens = load_tokens()
     host_accounts = tokens.get(host)
     if not host_accounts:
-        raise ConfigError(f"No tokens configured for host: {host}")
+        raise ConfigError(_("No tokens configured for host: {host}").format(host=host))
     if account not in host_accounts:
-        raise ConfigError(f"Account '{account}' not found for host: {host}")
+        raise ConfigError(
+            _("Account '{account}' not found for host: {host}").format(account=account, host=host)
+        )
     host_accounts["_default"] = account
     tokens[host] = host_accounts
 
@@ -133,18 +141,22 @@ def list_accounts(host: str) -> list[str]:
 def remove_token(host: str, account: str | None = None) -> None:
     """トークンを削除する。account 指定時はそのアカウントのみ、None 時はホスト全体を削除。"""
     if account == "_default":
-        raise ConfigError("'_default' is a reserved key and cannot be used as an account name.")
+        raise ConfigError(_("'_default' is a reserved key and cannot be used as an account name."))
     host = host.lower()
     tokens = load_tokens()
     if host not in tokens:
-        raise ConfigError(f"No tokens configured for host: {host}")
+        raise ConfigError(_("No tokens configured for host: {host}").format(host=host))
 
     if account is None:
         del tokens[host]
     else:
         host_accounts = tokens[host]
         if account not in host_accounts:
-            raise ConfigError(f"Account '{account}' not found for host: {host}")
+            raise ConfigError(
+                _("Account '{account}' not found for host: {host}").format(
+                    account=account, host=host
+                )
+            )
         del host_accounts[account]
         # _default が削除されたアカウントを指していた場合、残りの最初のアカウントに切り替え
         if host_accounts.get("_default") == account:
@@ -170,11 +182,15 @@ def load_tokens() -> dict[str, dict[str, str]]:
             try:
                 data = tomllib.load(f)
             except tomllib.TOMLDecodeError as e:
-                raise ConfigError(f"Failed to parse credentials file {path}: {e}") from e
+                raise ConfigError(
+                    _("Failed to parse credentials file {path}: {error}").format(path=path, error=e)
+                ) from e
     except FileNotFoundError:
         return {}
     except OSError as e:
-        raise ConfigError(f"Failed to read credentials file {path}: {e}") from e
+        raise ConfigError(
+            _("Failed to read credentials file {path}: {error}").format(path=path, error=e)
+        ) from e
     tokens = data.get("tokens", {})
     old_format_hosts = [str(k) for k, v in tokens.items() if isinstance(v, str)]
     if old_format_hosts:
@@ -331,7 +347,9 @@ def _write_credentials_toml(path: Path, tokens: dict[str, dict[str, str]]) -> No
                 os.unlink(tmp_path)
             raise
     except OSError as e:
-        raise ConfigError(f"Failed to write credentials file {path}: {e}") from e
+        raise ConfigError(
+            _("Failed to write credentials file {path}: {error}").format(path=path, error=e)
+        ) from e
 
 
 def _resolve_account_name(host: str, host_accounts: dict[str, str]) -> str:

--- a/src/gfo/config.py
+++ b/src/gfo/config.py
@@ -57,12 +57,14 @@ def validate_api_url(value: str) -> None:
         ).lower() in ("1", "true", "yes"):
             return
         raise ConfigError(
-            f"api_url must use https:// (got: {value}). "
-            "For localhost development use http://localhost/..., "
-            "or set GFO_ALLOW_INSECURE_HTTP=1 to bypass (insecure, "
-            "ignored on cloud hosts)."
+            _(
+                "api_url must use https:// (got: {value}). "
+                "For localhost development use http://localhost/..., "
+                "or set GFO_ALLOW_INSECURE_HTTP=1 to bypass (insecure, "
+                "ignored on cloud hosts)."
+            ).format(value=value)
         )
-    raise ConfigError(f"api_url must use http:// or https:// (got: {value})")
+    raise ConfigError(_("api_url must use http:// or https:// (got: {value})").format(value=value))
 
 
 # ── パス ──
@@ -105,9 +107,13 @@ def load_user_config() -> dict[str, Any]:
             try:
                 return tomllib.load(f)
             except tomllib.TOMLDecodeError as e:
-                raise ConfigError(f"Failed to parse config file {path}: {e}") from e
+                raise ConfigError(
+                    _("Failed to parse config file {path}: {error}").format(path=path, error=e)
+                ) from e
     except OSError as e:
-        raise ConfigError(f"Failed to read config file {path}: {e}") from e
+        raise ConfigError(
+            _("Failed to read config file {path}: {error}").format(path=path, error=e)
+        ) from e
 
 
 def get_default_output_format() -> str:
@@ -185,7 +191,9 @@ def _parse_key_parts(key: str) -> list[str]:
             except ValueError:
                 # 閉じ引用符がない不正入力は ConfigError に変換する
                 # （素の ValueError だと CLI で "Unexpected error" 扱いになる）
-                raise ConfigError(f"Invalid quoted key: missing closing quote in {key!r}") from None
+                raise ConfigError(
+                    _("Invalid quoted key: missing closing quote in {key!r}").format(key=key)
+                ) from None
             parts.append(key[i + 1 : end])
             i = end + 1
             # 直後のドットをスキップ
@@ -228,10 +236,12 @@ def set_config_value(key: str, value: str) -> None:
     引用符記法に対応: ``hosts."gitlab.example.com".type``
     """
     if not key:
-        raise ConfigError("Key must not be empty.")
+        raise ConfigError(_("Key must not be empty."))
     parts = _parse_key_parts(key)
     if len(parts) < 2:
-        raise ConfigError(f"Key must have at least two parts (e.g. defaults.output), got: {key}")
+        raise ConfigError(
+            _("Key must have at least two parts (e.g. defaults.output), got: {key}").format(key=key)
+        )
 
     # api_url を設定するキーの場合、平文 http:// を拒否する（PAT 漏えい防止）。
     if parts[-1] == "api_url":
@@ -246,7 +256,9 @@ def set_config_value(key: str, value: str) -> None:
             current[part] = {}
         child = current[part]
         if not isinstance(child, dict):
-            raise ConfigError(f"Cannot set '{key}': '{part}' is not a table.")
+            raise ConfigError(
+                _("Cannot set '{key}': '{part}' is not a table.").format(key=key, part=part)
+            )
         current = child
     current[parts[-1]] = value
 
@@ -256,10 +268,12 @@ def set_config_value(key: str, value: str) -> None:
 def unset_config_value(key: str) -> bool:
     """ドット区切りキーで config.toml の値を削除する。削除できたら True。"""
     if not key:
-        raise ConfigError("Key must not be empty.")
+        raise ConfigError(_("Key must not be empty."))
     parts = _parse_key_parts(key)
     if len(parts) < 2:
-        raise ConfigError(f"Key must have at least two parts (e.g. defaults.output), got: {key}")
+        raise ConfigError(
+            _("Key must have at least two parts (e.g. defaults.output), got: {key}").format(key=key)
+        )
 
     cfg = load_user_config()
 
@@ -397,11 +411,11 @@ def resolve_project_config(cwd: str | None = None) -> ProjectConfig:
         "or use '--repo HOST/OWNER/REPO' to specify directly."
     )
     if not saved_type:
-        err = ConfigError("Could not resolve service type.")
+        err = ConfigError(_("Could not resolve service type."))
         err.hint = _init_hint
         raise err
     if not saved_host:
-        err = ConfigError("Could not resolve host.")
+        err = ConfigError(_("Could not resolve host."))
         err.hint = _init_hint
         raise err
 
@@ -467,7 +481,10 @@ def build_clone_url(
     """サービス種別・ホスト・owner/name から clone 用 HTTPS URL を構築する。"""
     if not owner or not name:
         raise ConfigError(
-            f"Invalid repo format. Both owner and name must be non-empty, got owner={owner!r}, name={name!r}."
+            _(
+                "Invalid repo format. Both owner and name must be non-empty, "
+                "got owner={owner!r}, name={name!r}."
+            ).format(owner=owner, name=name)
         )
     if service_type in ("github", "bitbucket"):
         return f"https://{host}/{owner}/{name}.git"
@@ -499,10 +516,12 @@ def build_default_api_url(
     if service_type == "azure-devops":
         if not organization:
             raise ConfigError(
-                "Azure DevOps requires an organization. Run 'gfo init' first to configure."
+                _("Azure DevOps requires an organization. Run 'gfo init' first to configure.")
             )
         if not project:
-            raise ConfigError("Azure DevOps requires a project. Run 'gfo init' first to configure.")
+            raise ConfigError(
+                _("Azure DevOps requires a project. Run 'gfo init' first to configure.")
+            )
         return f"https://{host}/{organization}/{project}/_apis"
     if service_type in ("gitea", "forgejo", "gogs"):
         return f"https://{host}/api/v1"
@@ -510,4 +529,4 @@ def build_default_api_url(
         return f"https://{host}/api/v3"
     if service_type == "backlog":
         return f"https://{host}/api/v2"
-    raise ConfigError(f"Unknown service type: {service_type}")
+    raise ConfigError(_("Unknown service type: {service_type}").format(service_type=service_type))

--- a/src/gfo/detect.py
+++ b/src/gfo/detect.py
@@ -13,6 +13,7 @@ import requests
 
 from gfo.exceptions import DetectionError, GitCommandError
 from gfo.git_util import _mask_credentials, get_remote_url, git_config_get
+from gfo.i18n import _
 
 
 def normalize_host(value: str) -> str:
@@ -107,7 +108,7 @@ def _parse_url(remote_url: str) -> tuple[str, str]:
         m = pattern.match(remote_url)
         if m:
             return m.group("host"), m.group("path")
-    raise DetectionError(f"Cannot parse URL: {_mask_credentials(remote_url)}")
+    raise DetectionError(_("Cannot parse URL: {url}").format(url=_mask_credentials(remote_url)))
 
 
 def detect_from_url(remote_url: str) -> DetectResult:
@@ -153,7 +154,9 @@ def detect_from_url(remote_url: str) -> DetectResult:
                 repo=m.group("repo"),
                 project=m.group("owner"),
             )
-        raise DetectionError(f"Cannot parse Backlog path: {_mask_credentials(path)}")
+        raise DetectionError(
+            _("Cannot parse Backlog path: {path}").format(path=_mask_credentials(path))
+        )
 
     # 既知ホストテーブル照合
     service_type = _KNOWN_HOSTS.get(host.lower())
@@ -178,7 +181,9 @@ def detect_from_url(remote_url: str) -> DetectResult:
                 organization=org,
                 project=m.group("project"),
             )
-        raise DetectionError(f"Cannot parse Azure DevOps path: {_mask_credentials(path)}")
+        raise DetectionError(
+            _("Cannot parse Azure DevOps path: {path}").format(path=_mask_credentials(path))
+        )
 
     # 既知ホスト + 汎用パス
     if service_type is not None:
@@ -190,7 +195,7 @@ def detect_from_url(remote_url: str) -> DetectResult:
                 owner=m.group("owner"),
                 repo=m.group("repo"),
             )
-        raise DetectionError(f"Cannot parse path: {_mask_credentials(path)}")
+        raise DetectionError(_("Cannot parse path: {path}").format(path=_mask_credentials(path)))
 
     # 未知ホスト → service_type=None
     m = _GENERIC_PATH_RE.match(path)
@@ -201,7 +206,7 @@ def detect_from_url(remote_url: str) -> DetectResult:
             owner=m.group("owner"),
             repo=m.group("repo"),
         )
-    raise DetectionError(f"Cannot parse path: {_mask_credentials(path)}")
+    raise DetectionError(_("Cannot parse path: {path}").format(path=_mask_credentials(path)))
 
 
 # ── API プローブ ──
@@ -319,7 +324,6 @@ def probe_unknown_host(host: str, scheme: str = "https") -> str | None:
 def _parse_repo_option(value: str) -> DetectResult:
     """--repo オプションの値をパースして DetectResult を返す。"""
     from gfo.exceptions import ConfigError
-    from gfo.i18n import _
 
     if not value or not value.strip():
         raise ConfigError(_("--repo value must not be empty. Use URL or HOST/OWNER/REPO format."))
@@ -426,6 +430,6 @@ def detect_service(cwd: str | None = None) -> DetectResult:
 
     # 5. 全失敗
     if result.service_type is None:
-        raise DetectionError(f"Unknown host: {result.host}")
+        raise DetectionError(_("Unknown host: {host}").format(host=result.host))
 
     return result

--- a/src/gfo/http.py
+++ b/src/gfo/http.py
@@ -426,7 +426,9 @@ class HttpClient:
                     except OSError:
                         pass
                     raise gfo.exceptions.GfoError(
-                        f"Download exceeded GFO_MAX_DOWNLOAD_BYTES ({max_bytes} bytes); aborted."
+                        _(
+                            "Download exceeded GFO_MAX_DOWNLOAD_BYTES ({max_bytes} bytes); aborted."
+                        ).format(max_bytes=max_bytes)
                     )
                 f.write(chunk)
 

--- a/src/gfo/locale/ja/LC_MESSAGES/gfo.po
+++ b/src/gfo/locale/ja/LC_MESSAGES/gfo.po
@@ -2130,3 +2130,92 @@ msgstr "タグは空にできません。"
 
 msgid "tag must not be empty. Specify a tag or use --latest."
 msgstr "タグは空にできません。タグを指定するか --latest を使用してください。"
+
+# --- auth.py / config.py / detect.py / http.py エラーメッセージ i18n 化 (issue #67) ---
+
+msgid "'_default' is a reserved key and cannot be used as an account name."
+msgstr "'_default' は予約キーのため、アカウント名として使用できません。"
+
+msgid "Account '{account}' not found for host: {host}"
+msgstr "ホスト {host} にアカウント '{account}' が見つかりません"
+
+msgid "Account '{account}' not found for host: {host}. Available accounts: {accounts}"
+msgstr "ホスト {host} にアカウント '{account}' が見つかりません。利用可能なアカウント: {accounts}"
+
+msgid "Azure DevOps requires a project. Run 'gfo init' first to configure."
+msgstr "Azure DevOps にはプロジェクトが必要です。先に 'gfo init' を実行して設定してください。"
+
+msgid "Azure DevOps requires an organization. Run 'gfo init' first to configure."
+msgstr "Azure DevOps には組織が必要です。先に 'gfo init' を実行して設定してください。"
+
+msgid "Cannot parse Azure DevOps path: {path}"
+msgstr "Azure DevOps のパスを解析できません: {path}"
+
+msgid "Cannot parse Backlog path: {path}"
+msgstr "Backlog のパスを解析できません: {path}"
+
+msgid "Cannot parse URL: {url}"
+msgstr "URL を解析できません: {url}"
+
+msgid "Cannot parse path: {path}"
+msgstr "パスを解析できません: {path}"
+
+msgid "Cannot set '{key}': '{part}' is not a table."
+msgstr "'{key}' を設定できません: '{part}' はテーブルではありません。"
+
+msgid "Could not resolve host."
+msgstr "ホストを解決できませんでした。"
+
+msgid "Could not resolve service type."
+msgstr "サービス種別を解決できませんでした。"
+
+msgid "Download exceeded GFO_MAX_DOWNLOAD_BYTES ({max_bytes} bytes); aborted."
+msgstr "ダウンロードが GFO_MAX_DOWNLOAD_BYTES（{max_bytes} バイト）を超えたため中断しました。"
+
+msgid "Failed to parse config file {path}: {error}"
+msgstr "設定ファイル {path} の解析に失敗しました: {error}"
+
+msgid "Failed to parse credentials file {path}: {error}"
+msgstr "認証情報ファイル {path} の解析に失敗しました: {error}"
+
+msgid "Failed to read config file {path}: {error}"
+msgstr "設定ファイル {path} の読み込みに失敗しました: {error}"
+
+msgid "Failed to read credentials file {path}: {error}"
+msgstr "認証情報ファイル {path} の読み込みに失敗しました: {error}"
+
+msgid "Failed to write credentials file {path}: {error}"
+msgstr "認証情報ファイル {path} の書き込みに失敗しました: {error}"
+
+msgid "Invalid quoted key: missing closing quote in {key!r}"
+msgstr "不正な引用符付きキー: {key!r} に閉じ引用符がありません"
+
+msgid "Invalid repo format. Both owner and name must be non-empty, got owner={owner!r}, name={name!r}."
+msgstr "リポジトリ形式が不正です。owner と name は両方必須です（owner={owner!r}, name={name!r}）。"
+
+msgid "Key must have at least two parts (e.g. defaults.output), got: {key}"
+msgstr "キーは 2 つ以上のパーツが必要です（例: defaults.output）: {key}"
+
+msgid "Key must not be empty."
+msgstr "キーは空にできません。"
+
+msgid "No tokens configured for host: {host}"
+msgstr "ホスト {host} にトークンが設定されていません"
+
+msgid "Token must not be empty."
+msgstr "トークンは空にできません。"
+
+msgid "Unknown host: {host}"
+msgstr "未知のホスト: {host}"
+
+msgid "Unknown service type: {service_type}"
+msgstr "未知のサービス種別: {service_type}"
+
+msgid "api_url must use http:// or https:// (got: {value})"
+msgstr "api_url は http:// または https:// で始まる必要があります（指定値: {value}）"
+
+msgid "api_url must use https:// (got: {value}). For localhost development use http://localhost/..., or set GFO_ALLOW_INSECURE_HTTP=1 to bypass (insecure, ignored on cloud hosts)."
+msgstr "api_url は https:// で始まる必要があります（指定値: {value}）。localhost での開発には http://localhost/... を使用するか、GFO_ALLOW_INSECURE_HTTP=1 でバイパスできます（安全ではありません。クラウドホストでは無視されます）。"
+
+msgid "Warning: GFO_INSECURE is set; TLS verification is disabled for self-hosted hosts. Cloud-hosted services (github.com, gitlab.com, bitbucket.org, dev.azure.com, *.backlog.com/jp, *.visualstudio.com) still enforce TLS verification."
+msgstr "警告: GFO_INSECURE が設定されているため、セルフホスト先の TLS 検証が無効化されています。クラウドサービス（github.com, gitlab.com, bitbucket.org, dev.azure.com, *.backlog.com/jp, *.visualstudio.com）では引き続き TLS 検証が強制されます。"

--- a/tests/test_i18n_lint.py
+++ b/tests/test_i18n_lint.py
@@ -1,0 +1,81 @@
+"""ユーザー向けエラーメッセージが _() を通っているかの静的検査（AST ベース）。
+
+`raise GfoError("literal")` / `raise ConfigError(f"...")` のような、翻訳を通らない
+文字列リテラルを直接 message に渡す raise を検出する。正しい形は
+`raise ConfigError(_("No tokens configured for host: {host}").format(host=host))`。
+
+対象は src/gfo 直下のトップレベルモジュールのみ。adapter/ と commands/ には
+未対応箇所が残っているため対象外（issue #83 で追跡）。
+`ValueError` 等の内部契約エラーは対象外（rules 01 参照）。
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_SRC_DIR = Path(__file__).parent.parent / "src" / "gfo"
+
+# 文字列 message をコンストラクタに直接受け取るユーザー向け例外。
+# NotSupportedError / UnsupportedServiceError は識別子（service 名等）を受け取り
+# 内部で i18n 済みテンプレートに埋め込むため対象外。
+_USER_FACING_EXCEPTIONS = {
+    "GfoError",
+    "ConfigError",
+    "AuthError",
+    "DetectionError",
+    "HttpError",
+    "ValidationError",
+}
+
+_MODULES = sorted(_SRC_DIR.glob("*.py"))
+
+
+def _exception_name(func: ast.expr) -> str | None:
+    """raise 対象の Call から例外クラス名を取り出す（Name / Attribute 両対応）。"""
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _is_untranslated_literal(arg: ast.expr) -> bool:
+    """引数が _() を通らない文字列リテラル（f-string / .format() 込み）かを判定する。"""
+    if isinstance(arg, ast.Constant):
+        return isinstance(arg.value, str)
+    if isinstance(arg, ast.JoinedStr):  # f-string
+        return True
+    # "literal {x}".format(...) — _( "..." ).format(...) は func.value が Call なので False
+    if (
+        isinstance(arg, ast.Call)
+        and isinstance(arg.func, ast.Attribute)
+        and arg.func.attr == "format"
+    ):
+        return _is_untranslated_literal(arg.func.value)
+    return False
+
+
+def _iter_violations(path: Path) -> list[int]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    violations: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Raise) or not isinstance(node.exc, ast.Call):
+            continue
+        if _exception_name(node.exc.func) not in _USER_FACING_EXCEPTIONS:
+            continue
+        if any(_is_untranslated_literal(arg) for arg in node.exc.args):
+            violations.append(node.lineno)
+    return violations
+
+
+@pytest.mark.parametrize("path", _MODULES, ids=lambda p: p.name)
+def test_user_facing_error_messages_are_translated(path: Path):
+    violations = _iter_violations(path)
+    assert not violations, (
+        f"{path.name}:{violations} — user-facing exception raised with a string literal "
+        "that does not go through _(). Wrap the message in _() and add a ja translation "
+        "to gfo.po (see .claude/rules/01-exceptions.md)."
+    )


### PR DESCRIPTION
Closes #67

## 変更内容

認証・設定・URL 検出まわりのエラーメッセージが `_()` を通らない英語 f-string 直書きになっており、日本語ロケールでも英語のまま出力されて日本語メッセージと混在していた。

- `auth.py` / `config.py` / `detect.py` / `http.py` のユーザー向け例外メッセージ 28 msgid を `_("...").format(...)` に変換し、`.po` に ja 訳を追加
- 既存の未訳 msgid（GFO_INSECURE 起動時警告）にも ja 訳を追加（.po カバレッジ検査で発見）
- **機械チェックの導入**: `tests/test_i18n_lint.py` を新設。`src/gfo/*.py` トップレベルモジュールを AST 検査し、ユーザー向け例外（`GfoError` / `ConfigError` / `AuthError` / `DetectionError` / `HttpError` 系）に `_()` を通らない文字列リテラル・f-string・`"...".format()` を渡す raise を fail させる
- `.claude/rules/01-exceptions.md` に「ユーザー向けメッセージは必ず `_()` を通す」規約を明記
- adapter/（約 55 箇所）と `commands/schema.py`（5 箇所）は残対応として #83 を起票して追跡

`http.py` の `ValueError`（ページネーションの `limit` 検査等）は内部契約エラーのため対象外（rules 01 の既存方針どおり）。

## 動作確認（実 CLI・hermetic XDG_CONFIG_HOME）

```
$ LANGUAGE=ja gfo config set badkey x
キーは 2 つ以上のパーツが必要です（例: defaults.output）: badkey

$ LANGUAGE=ja gfo auth logout --host nosuch.example.com
ホスト nosuch.example.com にトークンが設定されていません

$ LANGUAGE=C gfo config set badkey x
Key must have at least two parts (e.g. defaults.output), got: badkey
```

※ dev 環境の stale な `.mo`（gitignored）が原因で最初は英語のままだった。`hatch_build.py` の `_parse_po` / `_generate_mo` で再生成して確認。リリース物はビルド時に自動生成されるため影響なし。

## テスト

- `tests/test_i18n_lint.py`（12 モジュール分の AST 検査）を追加
- 全 3917 件 pass、ruff / ruff format / mypy（linux + win32）/ bandit green
- `.po` は全 msgid のカバレッジ・重複なしをスクリプトで検査済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)