### PR TITLE
feat(i18n): adapter / commands のエラーメッセージを i18n 化する

### DIFF
--- a/.claude/rules/01-exceptions.md
+++ b/.claude/rules/01-exceptions.md
@@ -66,7 +66,7 @@ raise ConfigError(_("No tokens configured for host: {host}").format(host=host))
 ```
 
 - f-string を直接渡さない（msgid はリテラルである必要がある。`_("...").format(...)` を使う）
-- `tests/test_i18n_lint.py` が `src/gfo/*.py`（トップレベル）を AST 検査で強制する。
-  adapter/ と commands/ は未対応箇所が残るため対象外（issue #83 で追跡）
+- `tests/test_i18n_lint.py` が `src/gfo/` 配下全モジュールを AST 検査で強制し、
+  あわせて全 `_()` msgid が `gfo.po` に登録されていること（未訳の混入なし）も検査する
 - 内部契約エラー（`ValueError` 等、上表参照）と `NotSupportedError` /
   `UnsupportedServiceError`（識別子を受け取り内部で i18n 済みテンプレートに埋め込む）は対象外

--- a/src/gfo/adapter/_helpers.py
+++ b/src/gfo/adapter/_helpers.py
@@ -11,6 +11,7 @@ from collections.abc import Callable
 from typing import TypeVar
 
 from gfo.exceptions import GfoError
+from gfo.i18n import _
 
 _F = TypeVar("_F", bound=Callable[..., object])
 
@@ -29,7 +30,9 @@ def _wrap_conversion_error(func: _F) -> _F:
         try:
             return func(*args, **kwargs)
         except (KeyError, TypeError, AttributeError) as e:
-            raise GfoError(f"Unexpected API response: missing field {e}") from e
+            raise GfoError(
+                _("Unexpected API response: missing field {error}").format(error=e)
+            ) from e
 
     return wrapper  # type: ignore[return-value]
 

--- a/src/gfo/adapter/azure_devops.py
+++ b/src/gfo/adapter/azure_devops.py
@@ -12,6 +12,7 @@ import requests
 
 from gfo.exceptions import GfoError, NotFoundError, NotSupportedError
 from gfo.http import paginate_top_skip
+from gfo.i18n import _
 
 if TYPE_CHECKING:
     from gfo.http import HttpClient
@@ -249,18 +250,26 @@ class AzureDevOpsAdapter(GitServiceAdapter):
         }
         if method not in strategy_map:
             raise GfoError(
-                f"Unsupported merge method '{method}'. Use one of: {', '.join(strategy_map)}."
+                _("Unsupported merge method '{method}'. Use one of: {allowed}.").format(
+                    method=method, allowed=", ".join(strategy_map)
+                )
             )
         strategy = strategy_map[method]
         pr_resp = self._client.get(f"{self._git_path()}/pullrequests/{number}")
         pr_data = pr_resp.json()
         if not isinstance(pr_data, dict):
-            raise GfoError(f"Unexpected API response from pullrequests endpoint: {type(pr_data)}")
+            raise GfoError(
+                _("Unexpected API response from {endpoint} endpoint: {error}").format(
+                    endpoint="pullrequests", error=type(pr_data)
+                )
+            )
         last_merge_commit = pr_data.get("lastMergeSourceCommit")
         if not last_merge_commit:
             raise GfoError(
-                f"Cannot merge pull request #{number}: lastMergeSourceCommit not found. "
-                "The pull request may have no commits or may be in an invalid state."
+                _(
+                    "Cannot merge pull request #{number}: lastMergeSourceCommit not found. "
+                    "The pull request may have no commits or may be in an invalid state."
+                ).format(number=number)
             )
         completion_options: dict[str, Any] = {"mergeStrategy": strategy}
         if title is not None or message is not None:
@@ -335,7 +344,9 @@ class AzureDevOpsAdapter(GitServiceAdapter):
         ).json()
         if not isinstance(iters, dict):
             raise GfoError(
-                f"Unexpected Azure DevOps PR iterations response type: {type(iters).__name__}"
+                _("Unexpected Azure DevOps PR iterations response type: {type}").format(
+                    type=type(iters).__name__
+                )
             )
         iterations = iters.get("value", [])
         if not iterations:
@@ -346,7 +357,9 @@ class AzureDevOpsAdapter(GitServiceAdapter):
         ).json()
         if not isinstance(resp, dict):
             raise GfoError(
-                f"Unexpected Azure DevOps PR changes response type: {type(resp).__name__}"
+                _("Unexpected Azure DevOps PR changes response type: {type}").format(
+                    type=type(resp).__name__
+                )
             )
         out: list[PullRequestFile] = []
         for entry in resp.get("changeEntries", []):
@@ -386,7 +399,9 @@ class AzureDevOpsAdapter(GitServiceAdapter):
         ).json()
         if not isinstance(resp, dict):
             raise GfoError(
-                f"Unexpected Azure DevOps reviewers response type: {type(resp).__name__}"
+                _("Unexpected Azure DevOps reviewers response type: {type}").format(
+                    type=type(resp).__name__
+                )
             )
         return [r.get("displayName", "") for r in resp.get("value", [])]
 
@@ -475,11 +490,19 @@ class AzureDevOpsAdapter(GitServiceAdapter):
         )
         wiql_body = wiql_resp.json()
         if not isinstance(wiql_body, dict):
-            raise GfoError(f"Unexpected API response from WIQL endpoint: {type(wiql_body)}")
+            raise GfoError(
+                _("Unexpected API response from {endpoint} endpoint: {error}").format(
+                    endpoint="WIQL", error=type(wiql_body)
+                )
+            )
         try:
             ids = [wi["id"] for wi in wiql_body.get("workItems", [])]
         except (KeyError, TypeError) as e:
-            raise GfoError(f"Unexpected API response from WIQL endpoint: {e}") from e
+            raise GfoError(
+                _("Unexpected API response from {endpoint} endpoint: {error}").format(
+                    endpoint="WIQL", error=e
+                )
+            ) from e
         if not ids:
             return []
 
@@ -497,7 +520,9 @@ class AzureDevOpsAdapter(GitServiceAdapter):
             batch_body = resp.json()
             if not isinstance(batch_body, dict):
                 raise GfoError(
-                    f"Unexpected API response from workitems endpoint: {type(batch_body)}"
+                    _("Unexpected API response from {endpoint} endpoint: {error}").format(
+                        endpoint="workitems", error=type(batch_body)
+                    )
                 )
             for item in batch_body.get("value", []):
                 results.append(self._to_issue(item))
@@ -636,7 +661,9 @@ class AzureDevOpsAdapter(GitServiceAdapter):
         try:
             repo_id = resp.json()["id"]
         except (KeyError, TypeError) as e:
-            raise GfoError(f"Unexpected API response: missing field {e}") from e
+            raise GfoError(
+                _("Unexpected API response: missing field {error}").format(error=e)
+            ) from e
         self._client.delete(f"/git/repositories/{repo_id}")
 
     def update_repository(
@@ -1108,7 +1135,7 @@ class AzureDevOpsAdapter(GitServiceAdapter):
         )
         items = resp.json().get("value", [])
         if not items:
-            raise GfoError(f"Branch '{name}' not found after creation")
+            raise GfoError(_("Branch '{name}' not found after creation").format(name=name))
         return self._to_branch(items[0])
 
     def delete_branch(self, *, name: str) -> None:
@@ -1220,7 +1247,7 @@ class AzureDevOpsAdapter(GitServiceAdapter):
             # objectId は blob SHA
             sha = data.get("objectId") or ""
         except (KeyError, TypeError, AttributeError) as e:
-            raise GfoError(f"Unexpected API response: {e}") from e
+            raise GfoError(_("Unexpected API response: {error}").format(error=e)) from e
         return content, sha
 
     def create_or_update_file(
@@ -1580,11 +1607,11 @@ class AzureDevOpsAdapter(GitServiceAdapter):
         )
         wiql_body = wiql_resp.json()
         if not isinstance(wiql_body, dict):
-            raise GfoError(f"Unexpected API response: {type(wiql_body)}")
+            raise GfoError(_("Unexpected API response: {error}").format(error=type(wiql_body)))
         try:
             ids = [wi["id"] for wi in wiql_body.get("workItems", [])]
         except (KeyError, TypeError) as e:
-            raise GfoError(f"Unexpected API response: {e}") from e
+            raise GfoError(_("Unexpected API response: {error}").format(error=e)) from e
         if not ids:
             return []
         ids_str = ",".join(str(x) for x in ids[: limit if limit > 0 else None])
@@ -1594,7 +1621,7 @@ class AzureDevOpsAdapter(GitServiceAdapter):
         )
         batch_body = resp.json()
         if not isinstance(batch_body, dict):
-            raise GfoError(f"Unexpected API response: {type(batch_body)}")
+            raise GfoError(_("Unexpected API response: {error}").format(error=type(batch_body)))
         return [self._to_issue(item) for item in batch_body.get("value", [])]
 
     def _search_api_url(self) -> str:

--- a/src/gfo/adapter/backlog.py
+++ b/src/gfo/adapter/backlog.py
@@ -6,6 +6,7 @@ import urllib.parse
 from typing import TYPE_CHECKING, Any
 
 from gfo.exceptions import GfoError, NotFoundError, NotSupportedError
+from gfo.i18n import _
 
 if TYPE_CHECKING:
     from gfo.http import HttpClient
@@ -57,7 +58,11 @@ class BacklogAdapter(GitServiceAdapter):
             try:
                 self._project_id = resp.json()["id"]
             except (KeyError, TypeError) as e:
-                raise GfoError(f"Unexpected API response from project endpoint: {e}") from e
+                raise GfoError(
+                    _("Unexpected API response from {endpoint} endpoint: {error}").format(
+                        endpoint="project", error=e
+                    )
+                ) from e
         return self._project_id
 
     def _resolve_merged_status_id(self) -> int | None:
@@ -67,7 +72,11 @@ class BacklogAdapter(GitServiceAdapter):
         resp = self._client.get(f"/projects/{self._project_key}/statuses")
         statuses = resp.json()
         if not isinstance(statuses, list):
-            raise GfoError(f"Unexpected API response from statuses endpoint: {type(statuses)}")
+            raise GfoError(
+                _("Unexpected API response from {endpoint} endpoint: {error}").format(
+                    endpoint="statuses", error=type(statuses)
+                )
+            )
         for status in statuses:
             try:
                 if "merged" in status["name"].lower():
@@ -136,7 +145,9 @@ class BacklogAdapter(GitServiceAdapter):
                 updated_at=data.get("updated"),
             )
         except (KeyError, TypeError, ValueError, AttributeError) as e:
-            raise GfoError(f"Unexpected API response: missing field {e}") from e
+            raise GfoError(
+                _("Unexpected API response: missing field {error}").format(error=e)
+            ) from e
 
     @staticmethod
     @_wrap_conversion_error
@@ -309,18 +320,28 @@ class BacklogAdapter(GitServiceAdapter):
             resp = self._client.get(f"/projects/{self._project_key}/issueTypes")
             types = resp.json()
             if not isinstance(types, list):
-                raise GfoError(f"Unexpected API response from issueTypes endpoint: {type(types)}")
+                raise GfoError(
+                    _("Unexpected API response from {endpoint} endpoint: {error}").format(
+                        endpoint="issueTypes", error=type(types)
+                    )
+                )
             try:
                 issue_type = types[0]["id"] if types else None
             except (KeyError, TypeError) as e:
-                raise GfoError(f"Unexpected API response from issueTypes endpoint: {e}") from e
+                raise GfoError(
+                    _("Unexpected API response from {endpoint} endpoint: {error}").format(
+                        endpoint="issueTypes", error=e
+                    )
+                ) from e
 
         if priority is None:
             resp = self._client.get("/priorities")
             priorities = resp.json()
             if not isinstance(priorities, list):
                 raise GfoError(
-                    f"Unexpected API response from priorities endpoint: {type(priorities)}"
+                    _("Unexpected API response from {endpoint} endpoint: {error}").format(
+                        endpoint="priorities", error=type(priorities)
+                    )
                 )
             try:
                 # "中" (Normal) を優先、なければ先頭
@@ -333,16 +354,22 @@ class BacklogAdapter(GitServiceAdapter):
                     priorities[0]["id"] if priorities else None,
                 )
             except (KeyError, TypeError) as e:
-                raise GfoError(f"Unexpected API response from priorities endpoint: {e}") from e
+                raise GfoError(
+                    _("Unexpected API response from {endpoint} endpoint: {error}").format(
+                        endpoint="priorities", error=e
+                    )
+                ) from e
 
         if issue_type is None:
             raise GfoError(
-                "Cannot create issue: no issue types found for project "
-                f"'{self._project_key}'. Configure issue types in Backlog."
+                _(
+                    "Cannot create issue: no issue types found for project "
+                    "'{project}'. Configure issue types in Backlog."
+                ).format(project=self._project_key)
             )
         if priority is None:
             raise GfoError(
-                "Cannot create issue: no priorities found. Configure priorities in Backlog."
+                _("Cannot create issue: no priorities found. Configure priorities in Backlog.")
             )
 
         payload: dict[str, Any] = {
@@ -781,7 +808,7 @@ class BacklogAdapter(GitServiceAdapter):
                     u["userId"] for u in users[: limit if limit > 0 else None] if u.get("userId")
                 ]
             except (KeyError, TypeError) as e:
-                raise GfoError(f"Unexpected API response: {e}") from e
+                raise GfoError(_("Unexpected API response: {error}").format(error=e)) from e
         return []
 
     def add_collaborator(self, *, username: str, permission: str = "write") -> None:

--- a/src/gfo/adapter/base.py
+++ b/src/gfo/adapter/base.py
@@ -62,6 +62,7 @@ from gfo.adapter.models import (
     Workflow,
 )
 from gfo.exceptions import GfoError, NotSupportedError
+from gfo.i18n import _
 
 if TYPE_CHECKING:
     from gfo.http import HttpClient
@@ -531,7 +532,7 @@ class GitServiceAdapter(ABC):
         for ms in self.list_milestones():
             if ms.title == title:
                 return ms.number
-        raise GfoError(f"Milestone not found: {title}")
+        raise GfoError(_("Milestone not found: {title}").format(title=title))
 
     # --- Comment ---
     @abstractmethod
@@ -764,7 +765,7 @@ class GitServiceAdapter(ABC):
         for key in ("login", "username", "nickname", "userId"):
             if key in user and user[key]:
                 return str(user[key])
-        raise GfoError("Cannot determine username from current user response")
+        raise GfoError(_("Cannot determine username from current user response"))
 
     # --- Search ---
     def search_repositories(self, query: str, *, limit: int = 30) -> list[Repository]:

--- a/src/gfo/adapter/bitbucket.py
+++ b/src/gfo/adapter/bitbucket.py
@@ -10,6 +10,7 @@ import requests
 
 from gfo.exceptions import GfoError, NotFoundError, NotSupportedError
 from gfo.http import paginate_response_body
+from gfo.i18n import _
 
 from .base import GitServiceAdapter, _wrap_conversion_error
 from .models import (
@@ -578,7 +579,9 @@ class BitbucketAdapter(GitServiceAdapter):
                 created_at=data.get("created_on") or "",
             )
         except (KeyError, TypeError, AttributeError, IndexError) as e:
-            raise GfoError(f"Unexpected API response: missing field {e}") from e
+            raise GfoError(
+                _("Unexpected API response: missing field {error}").format(error=e)
+            ) from e
 
     # --- Comment ---
 
@@ -698,7 +701,9 @@ class BitbucketAdapter(GitServiceAdapter):
         try:
             commit_hash = data["source"]["commit"]["hash"]
         except (KeyError, TypeError) as e:
-            raise GfoError(f"Unexpected API response: missing field {e}") from e
+            raise GfoError(
+                _("Unexpected API response: missing field {error}").format(error=e)
+            ) from e
 
         statuses = paginate_response_body(
             self._client,
@@ -724,7 +729,9 @@ class BitbucketAdapter(GitServiceAdapter):
                     )
                 )
             except (KeyError, TypeError, AttributeError) as e:
-                raise GfoError(f"Unexpected API response: missing field {e}") from e
+                raise GfoError(
+                    _("Unexpected API response: missing field {error}").format(error=e)
+                ) from e
         return results
 
     def list_pull_request_files(self, number: int) -> list[PullRequestFile]:
@@ -757,7 +764,9 @@ class BitbucketAdapter(GitServiceAdapter):
                     )
                 )
             except (KeyError, TypeError, AttributeError) as e:
-                raise GfoError(f"Unexpected API response: missing field {e}") from e
+                raise GfoError(
+                    _("Unexpected API response: missing field {error}").format(error=e)
+                ) from e
         return files
 
     def list_pull_request_commits(self, number: int) -> list[PullRequestCommit]:
@@ -783,7 +792,9 @@ class BitbucketAdapter(GitServiceAdapter):
                     )
                 )
             except (KeyError, TypeError, AttributeError) as e:
-                raise GfoError(f"Unexpected API response: missing field {e}") from e
+                raise GfoError(
+                    _("Unexpected API response: missing field {error}").format(error=e)
+                ) from e
         return commits
 
     def list_requested_reviewers(self, number: int) -> list[str]:
@@ -1064,7 +1075,7 @@ class BitbucketAdapter(GitServiceAdapter):
                 if (r.get("user") or {}).get("nickname")
             ]
         except (KeyError, TypeError, AttributeError) as e:
-            raise GfoError(f"Unexpected API response: {e}") from e
+            raise GfoError(_("Unexpected API response: {error}").format(error=e)) from e
 
     def add_collaborator(self, *, username: str, permission: str = "write") -> None:
         raise NotSupportedError(self.service_name, "collaborator add (use Bitbucket web interface)")
@@ -1379,7 +1390,7 @@ class BitbucketAdapter(GitServiceAdapter):
                 if (r.get("user") or {}).get("nickname")
             ]
         except (KeyError, TypeError, AttributeError) as e:
-            raise GfoError(f"Unexpected API response: {e}") from e
+            raise GfoError(_("Unexpected API response: {error}").format(error=e)) from e
 
     def list_org_repos(self, name: str, *, limit: int = 30) -> list[Repository]:
         results = paginate_response_body(

--- a/src/gfo/adapter/gitbucket.py
+++ b/src/gfo/adapter/gitbucket.py
@@ -14,6 +14,7 @@ from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from gfo.exceptions import GfoError, NotFoundError, NotSupportedError
+from gfo.i18n import _
 
 if TYPE_CHECKING:
     import requests
@@ -58,9 +59,11 @@ class GitBucketAdapter(GitHubAdapter):
             try:
                 data = json.loads(data)
             except (json.JSONDecodeError, ValueError) as e:
-                raise GfoError(f"GitBucket: failed to parse response JSON: {e}") from e
+                raise GfoError(
+                    _("GitBucket: failed to parse response JSON: {error}").format(error=e)
+                ) from e
         if not isinstance(data, dict):
-            raise GfoError(f"GitBucket: unexpected response type: {type(data)}")
+            raise GfoError(_("GitBucket: unexpected response type: {type}").format(type=type(data)))
         return data
 
     def _web_base_url(self) -> str:
@@ -174,7 +177,9 @@ class GitBucketAdapter(GitHubAdapter):
                 created_at=data.get("created_at") or "",
             )
         except (KeyError, TypeError) as e:
-            raise GfoError(f"Unexpected API response: missing field {e}") from e
+            raise GfoError(
+                _("Unexpected API response: missing field {error}").format(error=e)
+            ) from e
 
     def delete_repository(self) -> None:
         """GitBucket は DELETE /repos API 未実装のため非対応。"""

--- a/src/gfo/adapter/gitea.py
+++ b/src/gfo/adapter/gitea.py
@@ -11,6 +11,7 @@ import requests
 
 from gfo.exceptions import GfoError, NotFoundError, NotSupportedError
 from gfo.http import paginate_link_header
+from gfo.i18n import _
 
 if TYPE_CHECKING:
     from gfo.http import HttpClient
@@ -180,7 +181,7 @@ class GiteaAdapter(GitHubLikeAdapter, GitServiceAdapter):
             if name in name_to_id:
                 ids.append(name_to_id[name])
             else:
-                raise GfoError(f"Label not found: {name}")
+                raise GfoError(_("Label not found: {name}").format(name=name))
         return ids
 
     def _invalidate_label_cache(self) -> None:
@@ -647,7 +648,7 @@ class GiteaAdapter(GitHubLikeAdapter, GitServiceAdapter):
         asset_name = os.path.basename(data.get("name") or f"asset-{asset_id}")
         output_path = os.path.join(output_dir, asset_name)
         if not Path(output_path).resolve().is_relative_to(Path(output_dir).resolve()):
-            raise GfoError(f"Invalid asset name: {asset_name}")
+            raise GfoError(_("Invalid asset name: {name}").format(name=asset_name))
         url = (
             data.get("browser_download_url")
             or f"{self._client.base_url}{self._repos_path()}/releases/{release_id}/assets/{asset_id}"
@@ -1119,7 +1120,7 @@ class GiteaAdapter(GitHubLikeAdapter, GitServiceAdapter):
             content = base64.b64decode(data["content"]).decode("utf-8")
             sha = data["sha"]
         except (KeyError, TypeError) as e:
-            raise GfoError(f"Unexpected API response: {e}") from e
+            raise GfoError(_("Unexpected API response: {error}").format(error=e)) from e
         return content, sha
 
     def create_or_update_file(
@@ -1272,7 +1273,7 @@ class GiteaAdapter(GitHubLikeAdapter, GitServiceAdapter):
         try:
             return [r["login"] for r in results]
         except (KeyError, TypeError) as e:
-            raise GfoError(f"Unexpected API response: {e}") from e
+            raise GfoError(_("Unexpected API response: {error}").format(error=e)) from e
 
     def add_collaborator(self, *, username: str, permission: str = "write") -> None:
         self._client.put(
@@ -1310,7 +1311,9 @@ class GiteaAdapter(GitHubLikeAdapter, GitServiceAdapter):
     ) -> Pipeline:
 
         if not workflow:
-            raise GfoError("Gitea requires --workflow to trigger a pipeline.")
+            raise GfoError(
+                _("{service} requires --workflow to trigger a pipeline.").format(service="Gitea")
+            )
         payload: dict[str, Any] = {"ref": ref}
         if inputs:
             payload["inputs"] = inputs
@@ -1401,7 +1404,7 @@ class GiteaAdapter(GitHubLikeAdapter, GitServiceAdapter):
         name = os.path.basename(data.get("name", f"artifact-{artifact_id}"))
         output_path = os.path.join(output_dir, f"{name}.zip")
         if not Path(output_path).resolve().is_relative_to(Path(output_dir).resolve()):
-            raise GfoError(f"Invalid artifact name: {name}")
+            raise GfoError(_("Invalid artifact name: {name}").format(name=name))
         url = f"{self._client.base_url}{self._repos_path()}/actions/artifacts/{artifact_id}/zip"
         self._client.download_file(url, output_path)
         return output_path
@@ -1416,7 +1419,7 @@ class GiteaAdapter(GitHubLikeAdapter, GitServiceAdapter):
         safe_run = os.path.basename(str(run_id))
         output_path = os.path.join(output_dir, f"logs-{safe_run}.zip")
         if not Path(output_path).resolve().is_relative_to(Path(output_dir).resolve()):
-            raise GfoError(f"Invalid run_id: {run_id}")
+            raise GfoError(_("Invalid run_id: {run_id}").format(run_id=run_id))
         url = f"{self._client.base_url}{self._repos_path()}/actions/runs/{run_id}/logs"
         self._client.download_file(url, output_path)
         return output_path
@@ -1646,7 +1649,7 @@ class GiteaAdapter(GitHubLikeAdapter, GitServiceAdapter):
         try:
             return [r["login"] for r in results]
         except (KeyError, TypeError) as e:
-            raise GfoError(f"Unexpected API response: {e}") from e
+            raise GfoError(_("Unexpected API response: {error}").format(error=e)) from e
 
     def list_org_repos(self, name: str, *, limit: int = 30) -> list[Repository]:
         results = paginate_link_header(
@@ -1673,7 +1676,9 @@ class GiteaAdapter(GitHubLikeAdapter, GitServiceAdapter):
                 url=url,
             )
         except (KeyError, TypeError) as e:
-            raise GfoError(f"Unexpected API response: missing field {e}") from e
+            raise GfoError(
+                _("Unexpected API response: missing field {error}").format(error=e)
+            ) from e
 
     def create_organization(
         self, name: str, *, display_name: str | None = None, description: str | None = None

--- a/src/gfo/adapter/github.py
+++ b/src/gfo/adapter/github.py
@@ -11,6 +11,7 @@ import requests
 
 from gfo.exceptions import GfoError, HttpError, NotFoundError
 from gfo.http import paginate_link_header
+from gfo.i18n import _
 
 from .base import GitServiceAdapter, _mask_token_in_exception, _wrap_conversion_error
 from .github_like import GitHubLikeAdapter
@@ -634,7 +635,7 @@ class GitHubAdapter(GitHubLikeAdapter, GitServiceAdapter):
         asset_name = os.path.basename(meta_resp.json().get("name", f"asset-{asset_id}"))
         output_path = os.path.join(output_dir, asset_name)
         if not Path(output_path).resolve().is_relative_to(Path(output_dir).resolve()):
-            raise GfoError(f"Invalid asset name: {asset_name}")
+            raise GfoError(_("Invalid asset name: {name}").format(name=asset_name))
         url = f"{self._client.base_url}{self._repos_path()}/releases/assets/{asset_id}"
         self._client.download_file(url, output_path, headers={"Accept": "application/octet-stream"})
         return output_path
@@ -1086,7 +1087,7 @@ class GitHubAdapter(GitHubLikeAdapter, GitServiceAdapter):
             if t.get("name") == name:
                 return self._to_tag(t)
 
-        raise GfoError(f"Tag '{name}' not found after creation")
+        raise GfoError(_("Tag '{name}' not found after creation").format(name=name))
 
     def delete_tag(self, *, name: str) -> None:
         self._client.delete(f"{self._repos_path()}/git/refs/tags/{quote(name, safe='')}")
@@ -1138,7 +1139,7 @@ class GitHubAdapter(GitHubLikeAdapter, GitServiceAdapter):
             content = base64.b64decode(data["content"]).decode("utf-8")
             sha = data["sha"]
         except (KeyError, TypeError) as e:
-            raise GfoError(f"Unexpected API response: {e}") from e
+            raise GfoError(_("Unexpected API response: {error}").format(error=e)) from e
         return content, sha
 
     def create_or_update_file(
@@ -1277,7 +1278,7 @@ class GitHubAdapter(GitHubLikeAdapter, GitServiceAdapter):
         try:
             return [r["login"] for r in results]
         except (KeyError, TypeError) as e:
-            raise GfoError(f"Unexpected API response: {e}") from e
+            raise GfoError(_("Unexpected API response: {error}").format(error=e)) from e
 
     def add_collaborator(self, *, username: str, permission: str = "write") -> None:
         self._client.put(
@@ -1334,7 +1335,9 @@ class GitHubAdapter(GitHubLikeAdapter, GitServiceAdapter):
     ) -> Pipeline:
 
         if not workflow:
-            raise GfoError("GitHub requires --workflow to trigger a pipeline.")
+            raise GfoError(
+                _("{service} requires --workflow to trigger a pipeline.").format(service="GitHub")
+            )
         payload: dict[str, Any] = {"ref": ref}
         if inputs:
             payload["inputs"] = inputs
@@ -1447,7 +1450,7 @@ class GitHubAdapter(GitHubLikeAdapter, GitServiceAdapter):
         name = os.path.basename(data.get("name", f"artifact-{artifact_id}"))
         output_path = os.path.join(output_dir, f"{name}.zip")
         if not Path(output_path).resolve().is_relative_to(Path(output_dir).resolve()):
-            raise GfoError(f"Invalid artifact name: {name}")
+            raise GfoError(_("Invalid artifact name: {name}").format(name=name))
         url = f"{self._client.base_url}{self._repos_path()}/actions/artifacts/{artifact_id}/zip"
         self._client.download_file(url, output_path)
         return output_path
@@ -1464,7 +1467,11 @@ class GitHubAdapter(GitHubLikeAdapter, GitServiceAdapter):
             safe_job = os.path.basename(str(job_id))
             output_path = os.path.join(output_dir, f"logs-{safe_run}-job-{safe_job}.txt")
             if not Path(output_path).resolve().is_relative_to(Path(output_dir).resolve()):
-                raise GfoError(f"Invalid run_id/job_id: {run_id}/{job_id}")
+                raise GfoError(
+                    _("Invalid run_id/job_id: {run_id}/{job_id}").format(
+                        run_id=run_id, job_id=job_id
+                    )
+                )
             resp = self._client.get(
                 f"{self._repos_path()}/actions/jobs/{job_id}/logs",
                 headers={"Accept": "application/vnd.github.v3+json"},
@@ -1475,7 +1482,7 @@ class GitHubAdapter(GitHubLikeAdapter, GitServiceAdapter):
             safe_run = os.path.basename(str(run_id))
             output_path = os.path.join(output_dir, f"logs-{safe_run}.zip")
             if not Path(output_path).resolve().is_relative_to(Path(output_dir).resolve()):
-                raise GfoError(f"Invalid run_id: {run_id}")
+                raise GfoError(_("Invalid run_id: {run_id}").format(run_id=run_id))
             url = f"{self._client.base_url}{self._repos_path()}/actions/runs/{run_id}/logs"
             self._client.download_file(url, output_path)
         return output_path
@@ -1597,7 +1604,7 @@ class GitHubAdapter(GitHubLikeAdapter, GitServiceAdapter):
             from nacl import encoding, public
         except ImportError as e:
             raise GfoError(
-                "PyNaCl is required for GitHub Secret encryption: pip install PyNaCl"
+                _("PyNaCl is required for GitHub Secret encryption: pip install PyNaCl")
             ) from e
         key = public.PublicKey(public_key.encode(), encoding.Base64Encoder)
         sealed_box = public.SealedBox(key)
@@ -1828,7 +1835,7 @@ class GitHubAdapter(GitHubLikeAdapter, GitServiceAdapter):
         try:
             return [r["login"] for r in results]
         except (KeyError, TypeError) as e:
-            raise GfoError(f"Unexpected API response: {e}") from e
+            raise GfoError(_("Unexpected API response: {error}").format(error=e)) from e
 
     def list_org_repos(self, name: str, *, limit: int = 30) -> list[Repository]:
         results = paginate_link_header(

--- a/src/gfo/adapter/gitlab.py
+++ b/src/gfo/adapter/gitlab.py
@@ -11,6 +11,7 @@ import requests
 
 from gfo.exceptions import GfoError, NotFoundError, NotSupportedError
 from gfo.http import paginate_page_param
+from gfo.i18n import _
 
 if TYPE_CHECKING:
     from gfo.http import HttpClient
@@ -246,7 +247,7 @@ class GitLabAdapter(GitServiceAdapter):
         resp = self._client.get(f"{self._project_path()}/milestones", params={"title": title})
         milestones = resp.json()
         if not milestones:
-            raise GfoError(f"Milestone not found: {title}")
+            raise GfoError(_("Milestone not found: {title}").format(title=title))
         return int(milestones[0]["id"])
 
     def get_pull_request(self, number: int) -> PullRequest:
@@ -263,7 +264,11 @@ class GitLabAdapter(GitServiceAdapter):
     ) -> None:
         allowed_methods = {"merge", "squash", "rebase"}
         if method not in allowed_methods:
-            raise GfoError(f"method must be one of {sorted(allowed_methods)}, got {method!r}")
+            raise GfoError(
+                _("method must be one of {allowed}, got {method!r}").format(
+                    allowed=sorted(allowed_methods), method=method
+                )
+            )
         if method == "rebase":
             # GitLab rebase は /merge ではなく専用の /rebase エンドポイントを使用
             self._client.put(
@@ -772,7 +777,7 @@ class GitLabAdapter(GitServiceAdapter):
         asset_name = os.path.basename(data.get("name") or f"asset-{asset_id}")
         output_path = os.path.join(output_dir, asset_name)
         if not Path(output_path).resolve().is_relative_to(Path(output_dir).resolve()):
-            raise GfoError(f"Invalid asset name: {asset_name}")
+            raise GfoError(_("Invalid asset name: {name}").format(name=asset_name))
         self._client.download_file(url, output_path)
         return output_path
 
@@ -1249,7 +1254,9 @@ class GitLabAdapter(GitServiceAdapter):
             else:
                 unresolved.append(name)
         if unresolved:
-            raise GfoError(f"GitLab user(s) not found: {', '.join(unresolved)}")
+            raise GfoError(
+                _("GitLab user(s) not found: {users}").format(users=", ".join(unresolved))
+            )
         return ids
 
     def request_reviewers(self, number: int, reviewers: list[str]) -> None:
@@ -1498,7 +1505,7 @@ class GitLabAdapter(GitServiceAdapter):
             content = base64.b64decode(data["content"]).decode("utf-8")
             sha = data.get("blob_id") or data.get("commit_id") or ""
         except (KeyError, TypeError) as e:
-            raise GfoError(f"Unexpected API response: {e}") from e
+            raise GfoError(_("Unexpected API response: {error}").format(error=e)) from e
         return content, sha
 
     def create_or_update_file(
@@ -1657,14 +1664,14 @@ class GitLabAdapter(GitServiceAdapter):
         try:
             return [r["username"] for r in results]
         except (KeyError, TypeError) as e:
-            raise GfoError(f"Unexpected API response: {e}") from e
+            raise GfoError(_("Unexpected API response: {error}").format(error=e)) from e
 
     def add_collaborator(self, *, username: str, permission: str = "write") -> None:
         # GitLab ではまずユーザー ID を取得する
         resp = self._client.get("/users", params={"username": username})
         users = resp.json()
         if not users:
-            raise GfoError(f"User '{username}' not found")
+            raise GfoError(_("User '{username}' not found").format(username=username))
         user_id = users[0]["id"]
         access_level_map = {"read": 20, "write": 30, "admin": 40}
         access_level = access_level_map.get(permission, 30)
@@ -1677,7 +1684,7 @@ class GitLabAdapter(GitServiceAdapter):
         resp = self._client.get("/users", params={"username": username})
         users = resp.json()
         if not users:
-            raise GfoError(f"User '{username}' not found")
+            raise GfoError(_("User '{username}' not found").format(username=username))
         user_id = users[0]["id"]
         self._client.delete(f"{self._project_path()}/members/{user_id}")
 
@@ -1903,7 +1910,7 @@ class GitLabAdapter(GitServiceAdapter):
         try:
             return [r["username"] for r in results]
         except (KeyError, TypeError) as e:
-            raise GfoError(f"Unexpected API response: {e}") from e
+            raise GfoError(_("Unexpected API response: {error}").format(error=e)) from e
 
     def list_org_repos(self, name: str, *, limit: int = 30) -> list[Repository]:
         results = paginate_page_param(

--- a/src/gfo/adapter/registry.py
+++ b/src/gfo/adapter/registry.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from gfo.adapter.base import GitServiceAdapter
 from gfo.config import ProjectConfig
 from gfo.exceptions import ConfigError, UnsupportedServiceError
+from gfo.i18n import _
 
 if TYPE_CHECKING:
     from gfo.http import HttpClient
@@ -41,8 +42,10 @@ def create_http_client(service_type: str, api_url: str, token: str) -> HttpClien
     elif service_type == "bitbucket":
         if ":" not in token:
             raise ConfigError(
-                "Bitbucket token must be in 'email:api-token' format. "
-                "Run 'gfo auth login --host bitbucket.org' to reconfigure."
+                _(
+                    "Bitbucket token must be in 'email:api-token' format. "
+                    "Run 'gfo auth login --host bitbucket.org' to reconfigure."
+                )
             )
         user, pw = token.split(":", 1)
         return HttpClient(api_url, basic_auth=(user, pw))
@@ -85,7 +88,7 @@ def create_adapter(config: ProjectConfig) -> GitServiceAdapter:
         # build_default_api_url 経由ではない api_url 設定パスを通っても None 漏れを防ぐ。
         if not config.organization or not config.project_key:
             raise ConfigError(
-                "Azure DevOps requires both organization and project. Run 'gfo init'."
+                _("Azure DevOps requires both organization and project. Run 'gfo init'.")
             )
         kwargs["organization"] = config.organization
         kwargs["project_key"] = config.project_key

--- a/src/gfo/commands/schema.py
+++ b/src/gfo/commands/schema.py
@@ -53,6 +53,7 @@ from gfo.adapter.base import (
     Workflow,
 )
 from gfo.exceptions import ConfigError
+from gfo.i18n import _
 from gfo.output import apply_jq_filter
 
 logger = logging.getLogger(__name__)
@@ -433,7 +434,11 @@ def _get_subcommand_parser(
             if subcommand in action.choices:
                 parser: argparse.ArgumentParser = action.choices[subcommand]
                 return parser
-    raise ConfigError(f"Unknown subcommand: {command} {subcommand}")
+    raise ConfigError(
+        _("Unknown subcommand: {command} {subcommand}").format(
+            command=command, subcommand=subcommand
+        )
+    )
 
 
 def _build_output_schema(key: tuple[str, str | None]) -> Any:
@@ -548,7 +553,7 @@ def handle_schema(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
         return
 
     if len(target) > 2:
-        raise ConfigError(f"Too many arguments: {' '.join(target)}")
+        raise ConfigError(_("Too many arguments: {args}").format(args=" ".join(target)))
 
     command = target[0]
     subcommand = target[1] if len(target) > 1 else None
@@ -557,17 +562,21 @@ def handle_schema(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
         # 単一コマンドスキーマ
         key = (command, subcommand)
         if key not in _DISPATCH:
-            raise ConfigError(f"Unknown command: {command} {subcommand}")
+            raise ConfigError(
+                _("Unknown command: {command} {subcommand}").format(
+                    command=command, subcommand=subcommand
+                )
+            )
         schema = _build_command_schema(key, subparser_map)
         json_str = json.dumps(schema, indent=2, ensure_ascii=False)
         _print_json(json_str, jq)
     else:
         # コマンドグループ — 該当 command 配下の全サブコマンド
         if command not in subparser_map:
-            raise ConfigError(f"Unknown command: {command}")
+            raise ConfigError(_("Unknown command: {command}").format(command=command))
         group_keys = [k for k in _DISPATCH if k[0] == command]
         if not group_keys:
-            raise ConfigError(f"Unknown command: {command}")
+            raise ConfigError(_("Unknown command: {command}").format(command=command))
         # サブコマンドなしのコマンド（browse 等）
         if len(group_keys) == 1 and group_keys[0][1] is None:
             schema = _build_command_schema(group_keys[0], subparser_map)

--- a/src/gfo/locale/ja/LC_MESSAGES/gfo.po
+++ b/src/gfo/locale/ja/LC_MESSAGES/gfo.po
@@ -20,8 +20,6 @@ msgstr ""
 msgid "Git Forge Operator v{version} — manage GitHub, GitLab, Bitbucket, and 6 more forges from a unified CLI"
 msgstr "Git Forge Operator v{version} — GitHub, GitLab, Bitbucket 他6サービスを統一 CLI で操作"
 
-msgid "Setup:\n  init             Initialize config (auto-detects from remote URL)\n  auth             Manage authentication tokens\n  completion       Generate shell completion script\n  config           Manage configuration\n\nWorkflow:\n  pr               Pull requests (list, create, merge, review)\n  issue            Issues (list, create, close, comment)\n  issue-template   List issue templates\n  ci               CI pipelines (list, view, trigger, logs)\n  status           Commit statuses (list, create)\n  notification     Notifications (list, read)\n\nRepository:\n  repo             Repositories (list, create, clone, edit, delete)\n  branch           Branches (list, create, delete)\n  tag              Tags (list, create, delete)\n  file             Repository files (get, put, delete)\n  release          Releases (list, create, edit, delete)\n  label            Labels (list, create, edit, clone)\n  milestone        Milestones (list, create, edit, close)\n  wiki             Wiki pages (list, create, edit, delete)\n\nSecurity:\n  collaborator     Collaborators (list, add, remove)\n  deploy-key       Deploy keys (list, create, delete)\n  ssh-key          SSH keys (list, create, delete)\n  gpg-key          GPG keys (list, create, delete)\n  secret           Secrets (list, set, delete)\n  variable         Variables (list, set, get, delete)\n  branch-protect   Branch protection rules (list, set, remove)\n  tag-protect      Tag protection rules (list, create, delete)\n\nOther:\n  user             User commands (whoami)\n  search           Search (repos, issues, prs, commits, code)\n  org              Organizations (list, create, members)\n  package          Packages (list, view, delete)\n  browse           Open repository in browser\n  api              Send raw API requests (e.g. gfo api GET /repos/o/r)\n  batch            Batch PR operations (create multiple PRs)\n  schema           Show JSON Schema for commands\n\nGetting started:\n  gfo auth login                  Register authentication token\n  gfo init                        Initialize config (auto-detects from remote URL)\n\nExamples:\n  gfo pr list                     List pull requests\n  gfo issue create -t 'Bug'       Create an issue\n  gfo pr list -R github.com/o/r   List PRs of another repo (no init required)\n  gfo pr list --format json       Output as JSON\n\nSupported forges:\n  GitHub, GitLab, Gitea, Forgejo, Bitbucket,\n  Azure DevOps, Gogs, GitBucket, Backlog\n\nEnvironment variables (checked after 'gfo auth login' tokens):\n  GITHUB_TOKEN      GitHub          GITEA_TOKEN       Gitea/Forgejo/Gogs\n  GITLAB_TOKEN      GitLab          GITBUCKET_TOKEN   GitBucket\n  BITBUCKET_TOKEN   Bitbucket       BACKLOG_API_KEY   Backlog\n  AZURE_DEVOPS_PAT  Azure DevOps    GFO_TOKEN         Fallback (any service)\n\nRun 'gfo <command> -h' for details on each command."
-msgstr "セットアップ:\n  init             設定を初期化（remote URL から自動検出）\n  auth             認証トークンを管理\n  completion       シェル補完スクリプトを生成\n  config           設定を管理\n\nワークフロー:\n  pr               プルリクエスト（list, create, merge, review）\n  issue            Issue（list, create, close, comment）\n  issue-template   Issue テンプレートの一覧\n  ci               CI パイプライン（list, view, trigger, logs）\n  status           コミットステータス（list, create）\n  notification     通知（list, read）\n\nリポジトリ:\n  repo             リポジトリ（list, create, clone, edit, delete）\n  branch           ブランチ（list, create, delete）\n  tag              タグ（list, create, delete）\n  file             リポジトリのファイル（get, put, delete）\n  release          リリース（list, create, edit, delete）\n  label            ラベル（list, create, edit, clone）\n  milestone        マイルストーン（list, create, edit, close）\n  wiki             Wiki ページ（list, create, edit, delete）\n\nセキュリティ:\n  collaborator     コラボレーター（list, add, remove）\n  deploy-key       デプロイキー（list, create, delete）\n  ssh-key          SSH 鍵（list, create, delete）\n  gpg-key          GPG 鍵（list, create, delete）\n  secret           シークレット（list, set, delete）\n  variable         変数（list, set, get, delete）\n  branch-protect   ブランチ保護ルール（list, set, remove）\n  tag-protect      タグ保護ルール（list, create, delete）\n\nその他:\n  user             ユーザーコマンド（whoami）\n  search           検索（repos, issues, prs, commits, code）\n  org              組織（list, create, members）\n  package          パッケージ（list, view, delete）\n  browse           リポジトリをブラウザで開く\n  api              未加工の API リクエスト（例: gfo api GET /repos/o/r）\n  batch            PR のバッチ操作（複数 PR の一括作成）\n  schema           コマンドの JSON Schema を表示\n\nはじめに:\n  gfo auth login                  認証トークンを登録\n  gfo init                        設定を初期化（remote URL から自動検出）\n\n使用例:\n  gfo pr list                     PR の一覧\n  gfo issue create -t 'Bug'       Issue を作成\n  gfo pr list -R github.com/o/r   別リポジトリの PR を表示（init 不要）\n  gfo pr list --format json       JSON で出力\n\n対応サービス:\n  GitHub, GitLab, Gitea, Forgejo, Bitbucket,\n  Azure DevOps, Gogs, GitBucket, Backlog\n\n環境変数（'gfo auth login' のトークンが優先）:\n  GITHUB_TOKEN      GitHub          GITEA_TOKEN       Gitea/Forgejo/Gogs\n  GITLAB_TOKEN      GitLab          GITBUCKET_TOKEN   GitBucket\n  BITBUCKET_TOKEN   Bitbucket       BACKLOG_API_KEY   Backlog\n  AZURE_DEVOPS_PAT  Azure DevOps    GFO_TOKEN         フォールバック（全サービス）\n\n詳細は 'gfo <command> -h' を参照してください。"
 
 msgid "Show help and exit"
 msgstr "ヘルプを表示して終了"
@@ -2219,3 +2217,194 @@ msgstr "api_url は https:// で始まる必要があります（指定値: {val
 
 msgid "Warning: GFO_INSECURE is set; TLS verification is disabled for self-hosted hosts. Cloud-hosted services (github.com, gitlab.com, bitbucket.org, dev.azure.com, *.backlog.com/jp, *.visualstudio.com) still enforce TLS verification."
 msgstr "警告: GFO_INSECURE が設定されているため、セルフホスト先の TLS 検証が無効化されています。クラウドサービス（github.com, gitlab.com, bitbucket.org, dev.azure.com, *.backlog.com/jp, *.visualstudio.com）では引き続き TLS 検証が強制されます。"
+
+# --- adapter / commands / 既存未訳分の i18n 化 (issue #83) ---
+
+msgid "  No results found."
+msgstr "  結果が見つかりません。"
+
+msgid "--delete-branch cannot be combined with --auto/--disable-auto (the branch would be deleted before the merge completes)."
+msgstr "--delete-branch は --auto/--disable-auto と併用できません（マージ完了前にブランチが削除されてしまうため）。"
+
+msgid "--internal requires an organization. Use 'org/name' format for the repository name."
+msgstr "--internal には組織が必要です。リポジトリ名は 'org/name' 形式で指定してください。"
+
+msgid "--notes and --notes-file are mutually exclusive."
+msgstr "--notes と --notes-file は同時に指定できません。"
+
+msgid "Aborted by user."
+msgstr "ユーザーにより中断されました。"
+
+msgid "Are you sure you want to delete organization '{name}'? This action cannot be undone. [y/N]: "
+msgstr "組織 '{name}' を削除してもよいですか？この操作は取り消せません。 [y/N]: "
+
+msgid "Are you sure you want to transfer repository '{repo_name}' to '{new_owner}'? [y/N]: "
+msgstr "リポジトリ '{repo_name}' を '{new_owner}' に移管してもよいですか？ [y/N]: "
+
+msgid "Authentication token (DEPRECATED, will be removed in a future release; insecure because the token is visible in the process list. Use --token-stdin or --token-file instead)"
+msgstr "認証トークン（非推奨。将来のリリースで削除されます。プロセス一覧にトークンが見えるため安全ではありません。--token-stdin または --token-file を使用してください）"
+
+msgid "Azure DevOps requires both organization and project. Run 'gfo init'."
+msgstr "Azure DevOps には組織とプロジェクトの両方が必要です。'gfo init' を実行してください。"
+
+msgid "Bitbucket token must be in 'email:api-token' format. Run 'gfo auth login --host bitbucket.org' to reconfigure."
+msgstr "Bitbucket のトークンは 'email:api-token' 形式である必要があります。'gfo auth login --host bitbucket.org' で再設定してください。"
+
+msgid "Branch '{name}' not found after creation"
+msgstr "作成後にブランチ '{name}' が見つかりません"
+
+msgid "Cannot create issue: no issue types found for project '{project}'. Configure issue types in Backlog."
+msgstr "Issue を作成できません: プロジェクト '{project}' に Issue 種別がありません。Backlog で Issue 種別を設定してください。"
+
+msgid "Cannot create issue: no priorities found. Configure priorities in Backlog."
+msgstr "Issue を作成できません: 優先度が見つかりません。Backlog で優先度を設定してください。"
+
+msgid "Cannot determine username from current user response"
+msgstr "現在のユーザー情報からユーザー名を特定できません"
+
+msgid "Cannot merge pull request #{number}: lastMergeSourceCommit not found. The pull request may have no commits or may be in an invalid state."
+msgstr "PR #{number} をマージできません: lastMergeSourceCommit が見つかりません。PR にコミットがないか、不正な状態の可能性があります。"
+
+msgid "Cannot read token file {path}: {error}"
+msgstr "トークンファイル {path} を読み込めません: {error}"
+
+msgid "Empty token in file {path}"
+msgstr "ファイル {path} のトークンが空です"
+
+msgid "Empty token received from stdin"
+msgstr "stdin から受け取ったトークンが空です"
+
+msgid "GitBucket: failed to parse response JSON: {error}"
+msgstr "GitBucket: レスポンス JSON の解析に失敗しました: {error}"
+
+msgid "GitBucket: unexpected response type: {type}"
+msgstr "GitBucket: 予期しないレスポンス型: {type}"
+
+msgid "GitLab user(s) not found: {users}"
+msgstr "GitLab ユーザーが見つかりません: {users}"
+
+msgid "Header '{key}' cannot be set via --header (managed by gfo). Use gfo auth / config options instead."
+msgstr "ヘッダー '{key}' は --header では設定できません（gfo が管理します）。gfo auth / config のオプションを使用してください。"
+
+msgid "Header '{key}' contains control characters; refused."
+msgstr "ヘッダー '{key}' に制御文字が含まれているため拒否しました。"
+
+msgid "Invalid artifact name: {name}"
+msgstr "不正なアーティファクト名: {name}"
+
+msgid "Invalid asset name: {name}"
+msgstr "不正なアセット名: {name}"
+
+msgid "Invalid duration format: '{s}'. Use format like '1h30m', '45m', or '3600'."
+msgstr "不正な期間形式: '{s}'。'1h30m'、'45m'、'3600' のような形式で指定してください。"
+
+msgid "Invalid header: empty key in '{h}'."
+msgstr "不正なヘッダー: '{h}' のキーが空です。"
+
+msgid "Invalid name format '{name}'. Expected 'org/repo' with non-empty org and repo."
+msgstr "不正な名前形式 '{name}'。org と repo が空でない 'org/repo' 形式で指定してください。"
+
+msgid "Invalid run_id/job_id: {run_id}/{job_id}"
+msgstr "不正な run_id/job_id: {run_id}/{job_id}"
+
+msgid "Invalid run_id: {run_id}"
+msgstr "不正な run_id: {run_id}"
+
+msgid "Invalid service spec format: {spec}. Expected 'service:host:owner/repo'."
+msgstr "不正なサービス指定形式: {spec}。'service:host:owner/repo' 形式で指定してください。"
+
+msgid "Invalid service spec format: {spec}. Expected 'service:owner/repo' or 'service:host:owner/repo'."
+msgstr "不正なサービス指定形式: {spec}。'service:owner/repo' または 'service:host:owner/repo' 形式で指定してください。"
+
+msgid "Label not found: {name}"
+msgstr "ラベルが見つかりません: {name}"
+
+msgid "Milestone not found: {title}"
+msgstr "マイルストーンが見つかりません: {title}"
+
+msgid "PATH contains control characters; refused."
+msgstr "PATH に制御文字が含まれているため拒否しました。"
+
+msgid "PATH must be a relative path starting with '/' (e.g. '/repos/owner/repo'). Absolute URLs are not allowed."
+msgstr "PATH は '/' で始まる相対パスである必要があります（例: '/repos/owner/repo'）。絶対 URL は使用できません。"
+
+msgid "PyNaCl is required for GitHub Secret encryption: pip install PyNaCl"
+msgstr "GitHub Secret の暗号化には PyNaCl が必要です: pip install PyNaCl"
+
+msgid "Read token from file (path)"
+msgstr "ファイルからトークンを読み込む（パス）"
+
+msgid "Read token from stdin (recommended for scripts)"
+msgstr "stdin からトークンを読み込む（スクリプトでの利用を推奨）"
+
+msgid "Repository name or org/name"
+msgstr "リポジトリ名または org/name"
+
+msgid "Self-hosted service '{service_type}' requires a host: '{service_type}:host:owner/repo'."
+msgstr "セルフホスト型サービス '{service_type}' にはホストが必要です: '{service_type}:host:owner/repo'。"
+
+msgid "Tag '{name}' not found after creation"
+msgstr "作成後にタグ '{name}' が見つかりません"
+
+msgid "Token file {path} is readable by other users (mode {mode}). Run 'chmod 600 {path}' to restrict access."
+msgstr "トークンファイル {path} は他のユーザーから読み取り可能です（mode {mode}）。'chmod 600 {path}' でアクセスを制限してください。"
+
+msgid "Too many arguments: {args}"
+msgstr "引数が多すぎます: {args}"
+
+msgid "Unexpected API response from {endpoint} endpoint: {error}"
+msgstr "{endpoint} エンドポイントからの予期しない API レスポンス: {error}"
+
+msgid "Unexpected API response: missing field {error}"
+msgstr "予期しない API レスポンス: フィールド {error} がありません"
+
+msgid "Unexpected API response: {error}"
+msgstr "予期しない API レスポンス: {error}"
+
+msgid "Unexpected Azure DevOps PR changes response type: {type}"
+msgstr "Azure DevOps PR changes の予期しないレスポンス型: {type}"
+
+msgid "Unexpected Azure DevOps PR iterations response type: {type}"
+msgstr "Azure DevOps PR iterations の予期しないレスポンス型: {type}"
+
+msgid "Unexpected Azure DevOps reviewers response type: {type}"
+msgstr "Azure DevOps reviewers の予期しないレスポンス型: {type}"
+
+msgid "Unknown command: {command}"
+msgstr "未知のコマンド: {command}"
+
+msgid "Unknown command: {command} {subcommand}"
+msgstr "未知のコマンド: {command} {subcommand}"
+
+msgid "Unknown subcommand: {command} {subcommand}"
+msgstr "未知のサブコマンド: {command} {subcommand}"
+
+msgid "Unsupported merge method '{method}'. Use one of: {allowed}."
+msgstr "未対応のマージ方式 '{method}'。次のいずれかを使用してください: {allowed}。"
+
+msgid "User '{username}' not found"
+msgstr "ユーザー '{username}' が見つかりません"
+
+msgid "Warning: --token is deprecated and will be removed in a future release. Passing tokens via --token is insecure (visible in process list). Use --token-stdin or --token-file instead."
+msgstr "警告: --token は非推奨で、将来のリリースで削除されます。--token でのトークン指定は安全ではありません（プロセス一覧に見えます）。--token-stdin または --token-file を使用してください。"
+
+msgid "jq filter timed out after 60 seconds."
+msgstr "jq フィルタが 60 秒でタイムアウトしました。"
+
+msgid "method must be one of {allowed}, got {method!r}"
+msgstr "method は {allowed} のいずれかである必要があります（指定値: {method!r}）"
+
+msgid "path contains control characters; refused."
+msgstr "path に制御文字が含まれているため拒否しました。"
+
+msgid "path must not be empty."
+msgstr "path は空にできません。"
+
+msgid "path must not contain '..' segments."
+msgstr "path に '..' セグメントを含めることはできません。"
+
+msgid "{service} requires --workflow to trigger a pipeline."
+msgstr "{service} でパイプラインをトリガーするには --workflow が必要です。"
+
+msgid "Setup:\n  init             Initialize config (auto-detects from remote URL)\n  auth             Manage authentication tokens\n  completion       Generate shell completion script\n  config           Manage configuration\n\nWorkflow:\n  pr               Pull requests (list, create, merge, review)\n  issue            Issues (list, create, close, comment)\n  issue-template   List issue templates\n  ci               CI pipelines (list, view, trigger, logs)\n  status           Commit statuses (list, create)\n  notification     Notifications (list, read)\n\nRepository:\n  repo             Repositories (list, create, clone, edit, delete)\n  branch           Branches (list, create, delete)\n  tag              Tags (list, create, delete)\n  file             Repository files (get, put, delete)\n  release          Releases (list, create, edit, delete)\n  label            Labels (list, create, edit, clone)\n  milestone        Milestones (list, create, edit, close)\n  wiki             Wiki pages (list, create, edit, delete)\n\nSecurity:\n  collaborator     Collaborators (list, add, remove)\n  deploy-key       Deploy keys (list, view, create, delete)\n  ssh-key          SSH keys (list, view, create, delete)\n  gpg-key          GPG keys (list, view, create, delete)\n  secret           Secrets (list, set, delete)\n  variable         Variables (list, set, get, delete)\n  branch-protect   Branch protection rules (list, set, remove)\n  tag-protect      Tag protection rules (list, create, delete)\n\nOther:\n  user             User commands (whoami)\n  search           Search (repos, issues, prs, commits, code)\n  org              Organizations (list, view, members, repos, create, edit, delete)\n  package          Packages (list, view, delete)\n  browse           Open repository in browser\n  api              Send raw API requests (e.g. gfo api GET /repos/o/r)\n  batch            Batch PR operations (create multiple PRs)\n  schema           Show JSON Schema for commands\n\nGetting started:\n  gfo auth login                  Register authentication token\n  gfo init                        Initialize config (auto-detects from remote URL)\n\nExamples:\n  gfo pr list                     List pull requests\n  gfo issue create -t 'Bug'       Create an issue\n  gfo pr list -R github.com/o/r   List PRs of another repo (no init required)\n  gfo pr list --format json       Output as JSON\n\nSupported forges:\n  GitHub, GitLab, Gitea, Forgejo, Bitbucket,\n  Azure DevOps, Gogs, GitBucket, Backlog\n\nEnvironment variables (checked after 'gfo auth login' tokens):\n  GITHUB_TOKEN      GitHub          GITEA_TOKEN       Gitea/Forgejo/Gogs\n  GITLAB_TOKEN      GitLab          GITBUCKET_TOKEN   GitBucket\n  BITBUCKET_TOKEN   Bitbucket       BACKLOG_API_KEY   Backlog\n  AZURE_DEVOPS_PAT  Azure DevOps    GFO_TOKEN         Fallback (any service)\n\nBehavior variables:\n  GFO_NO_AUTO_JSON  Disable auto JSON output when stdout is not a TTY\n  GFO_RETRY_AFTER_MAX  Max seconds to honor a 429 Retry-After (default 300)\n\nRun 'gfo <command> -h' for details on each command."
+msgstr "セットアップ:\n  init             設定を初期化（remote URL から自動検出）\n  auth             認証トークンを管理\n  completion       シェル補完スクリプトを生成\n  config           設定を管理\n\nワークフロー:\n  pr               プルリクエスト（list, create, merge, review）\n  issue            Issue（list, create, close, comment）\n  issue-template   Issue テンプレートの一覧\n  ci               CI パイプライン（list, view, trigger, logs）\n  status           コミットステータス（list, create）\n  notification     通知（list, read）\n\nリポジトリ:\n  repo             リポジトリ（list, create, clone, edit, delete）\n  branch           ブランチ（list, create, delete）\n  tag              タグ（list, create, delete）\n  file             リポジトリのファイル（get, put, delete）\n  release          リリース（list, create, edit, delete）\n  label            ラベル（list, create, edit, clone）\n  milestone        マイルストーン（list, create, edit, close）\n  wiki             Wiki ページ（list, create, edit, delete）\n\nセキュリティ:\n  collaborator     コラボレーター（list, add, remove）\n  deploy-key       デプロイキー（list, view, create, delete）\n  ssh-key          SSH 鍵（list, view, create, delete）\n  gpg-key          GPG 鍵（list, view, create, delete）\n  secret           シークレット（list, set, delete）\n  variable         変数（list, set, get, delete）\n  branch-protect   ブランチ保護ルール（list, set, remove）\n  tag-protect      タグ保護ルール（list, create, delete）\n\nその他:\n  user             ユーザーコマンド（whoami）\n  search           検索（repos, issues, prs, commits, code）\n  org              組織（list, view, members, repos, create, edit, delete）\n  package          パッケージ（list, view, delete）\n  browse           リポジトリをブラウザで開く\n  api              未加工の API リクエスト（例: gfo api GET /repos/o/r）\n  batch            PR のバッチ操作（複数 PR の一括作成）\n  schema           コマンドの JSON Schema を表示\n\nはじめに:\n  gfo auth login                  認証トークンを登録\n  gfo init                        設定を初期化（remote URL から自動検出）\n\n使用例:\n  gfo pr list                     PR の一覧\n  gfo issue create -t 'Bug'       Issue を作成\n  gfo pr list -R github.com/o/r   別リポジトリの PR を表示（init 不要）\n  gfo pr list --format json       JSON で出力\n\n対応サービス:\n  GitHub, GitLab, Gitea, Forgejo, Bitbucket,\n  Azure DevOps, Gogs, GitBucket, Backlog\n\n環境変数（'gfo auth login' のトークンが優先）:\n  GITHUB_TOKEN      GitHub          GITEA_TOKEN       Gitea/Forgejo/Gogs\n  GITLAB_TOKEN      GitLab          GITBUCKET_TOKEN   GitBucket\n  BITBUCKET_TOKEN   Bitbucket       BACKLOG_API_KEY   Backlog\n  AZURE_DEVOPS_PAT  Azure DevOps    GFO_TOKEN         フォールバック（全サービス）\n\n動作設定の環境変数:\n  GFO_NO_AUTO_JSON  stdout が TTY でないときの自動 JSON 出力を無効化\n  GFO_RETRY_AFTER_MAX  429 の Retry-After を尊重する最大秒数（既定 300）\n\n詳細は 'gfo <command> -h' を参照してください。"

--- a/tests/test_i18n_lint.py
+++ b/tests/test_i18n_lint.py
@@ -4,8 +4,7 @@
 文字列リテラルを直接 message に渡す raise を検出する。正しい形は
 `raise ConfigError(_("No tokens configured for host: {host}").format(host=host))`。
 
-対象は src/gfo 直下のトップレベルモジュールのみ。adapter/ と commands/ には
-未対応箇所が残っているため対象外（issue #83 で追跡）。
+対象は src/gfo 配下の全モジュール（adapter/ と commands/ を含む）。
 `ValueError` 等の内部契約エラーは対象外（rules 01 参照）。
 """
 
@@ -30,7 +29,7 @@ _USER_FACING_EXCEPTIONS = {
     "ValidationError",
 }
 
-_MODULES = sorted(_SRC_DIR.glob("*.py"))
+_MODULES = sorted(_SRC_DIR.rglob("*.py"))
 
 
 def _exception_name(func: ast.expr) -> str | None:
@@ -71,11 +70,65 @@ def _iter_violations(path: Path) -> list[int]:
     return violations
 
 
-@pytest.mark.parametrize("path", _MODULES, ids=lambda p: p.name)
+@pytest.mark.parametrize("path", _MODULES, ids=lambda p: str(p.relative_to(_SRC_DIR)))
 def test_user_facing_error_messages_are_translated(path: Path):
     violations = _iter_violations(path)
     assert not violations, (
-        f"{path.name}:{violations} — user-facing exception raised with a string literal "
+        f"{path.relative_to(_SRC_DIR)}:{violations} — user-facing exception raised with a string literal "
         "that does not go through _(). Wrap the message in _() and add a ja translation "
         "to gfo.po (see .claude/rules/01-exceptions.md)."
+    )
+
+
+# ── .po カバレッジ検査 ──
+
+_PO_PATH = _SRC_DIR / "locale" / "ja" / "LC_MESSAGES" / "gfo.po"
+
+
+def _parse_po_msgids(po_path: Path) -> set[str]:
+    """PO ファイルから msgid の集合を返す（hatch_build.py と同じ単純パーサ）。"""
+    msgids: set[str] = set()
+    lines = po_path.read_text(encoding="utf-8").splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i].strip()
+        if line.startswith("msgid "):
+            msgid = ast.literal_eval(line[6:])
+            i += 1
+            while i < len(lines) and lines[i].strip().startswith('"'):
+                msgid += ast.literal_eval(lines[i].strip())
+                i += 1
+            msgids.add(msgid)
+        else:
+            i += 1
+    return msgids
+
+
+def _collect_source_msgids(path: Path) -> set[str]:
+    """モジュール内の _() 呼び出しの文字列リテラル msgid を収集する。"""
+    msgids: set[str] = set()
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "_"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and isinstance(node.args[0].value, str)
+        ):
+            msgids.add(node.args[0].value)
+    return msgids
+
+
+def test_all_msgids_have_ja_translation():
+    """src/gfo 配下の全 _() msgid が gfo.po に登録されている（未訳の混入防止）。"""
+    po_msgids = _parse_po_msgids(_PO_PATH)
+    missing: dict[str, list[str]] = {}
+    for path in _MODULES:
+        for msgid in _collect_source_msgids(path):
+            if msgid not in po_msgids:
+                missing.setdefault(str(path.relative_to(_SRC_DIR)), []).append(msgid)
+    assert not missing, (
+        f"msgids missing from gfo.po: {missing} — add a ja translation entry for each."
     )


### PR DESCRIPTION
Closes #83

## 変更内容

#67（PR #84）の続き。adapter/ 全 11 ファイルと `commands/schema.py` に残っていた `_()` を通らないユーザー向けエラーメッセージ **72 箇所**を `_("...").format(...)` に変換した。

- 類似メッセージは msgid をパラメータ化して集約（`"Unexpected API response from {endpoint} endpoint: {error}"`、`"{service} requires --workflow to trigger a pipeline."` 等）。**C ロケールでの出力文字列は従来と同一**
- `tests/test_i18n_lint.py` の AST 検査を `src/gfo/` 配下**全モジュール**に拡大。grep ベースの列挙では見えなかった複数行 raise 12 箇所（azure_devops / backlog / github / registry）も検出して修正
- **`.po` カバレッジ検査を新設**（`test_all_msgids_have_ja_translation`）: 全 `_()` msgid が `gfo.po` に登録されていることを強制。未訳メッセージの混入を今後 CI で防ぐ
- カバレッジ検査で発見した**既存の未訳 msgid** にも ja 訳を追加: api / batch / auth_cmd / org / repo / pr のエラー・ヘルプ文言、および更新で orphan 化していた `--help` epilog（deploy-key 等の view 追加・Behavior variables 節を反映して差し替え）。追加エントリは計 63 件
- `.claude/rules/01-exceptions.md` の i18n 規約を「全モジュール + .po カバレッジ検査」に更新

## 動作確認（実 CLI・hermetic XDG_CONFIG_HOME）

```
$ LANGUAGE=ja gfo schema nosuchcmd
未知のコマンド: nosuchcmd

$ LANGUAGE=ja gfo --help   # 末尾（更新された epilog 訳）
動作設定の環境変数:
  GFO_NO_AUTO_JSON  stdout が TTY でないときの自動 JSON 出力を無効化
  GFO_RETRY_AFTER_MAX  429 の Retry-After を尊重する最大秒数（既定 300）

$ LANGUAGE=C gfo schema nosuchcmd
Unknown command: nosuchcmd
```

## テスト

- i18n lint: 65 モジュール AST 検査 + .po カバレッジ検査 = 66 件 pass
- 全 3971 件 pass、ruff / ruff format / mypy（linux + win32）/ bandit green

🤖 Generated with [Claude Code](https://claude.com/claude-code)