### PR TITLE
fix(gitlab): repo mirror add の --auth-token をミラー URL に配線する

### DIFF
--- a/src/gfo/adapter/gitlab.py
+++ b/src/gfo/adapter/gitlab.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import base64
 from collections.abc import Iterable, Iterator
 from typing import TYPE_CHECKING, Any, ClassVar
-from urllib.parse import quote
+from urllib.parse import quote, urlparse, urlunparse
 
 import requests
 
@@ -16,7 +16,7 @@ from gfo.i18n import _
 if TYPE_CHECKING:
     from gfo.http import HttpClient
 
-from .base import GitServiceAdapter, _wrap_conversion_error
+from .base import GitServiceAdapter, _mask_token_in_exception, _wrap_conversion_error
 from .models import (
     Branch,
     BranchProtection,
@@ -2482,6 +2482,24 @@ class GitLabAdapter(GitServiceAdapter):
             for m in results
         ]
 
+    @staticmethod
+    def _embed_mirror_credentials(url: str, auth_token: str) -> str:
+        """auth_token をミラー先 URL の userinfo に埋め込む。
+
+        GitLab の remote mirrors API は認証情報を URL に含める仕様
+        （POST パラメータに password 相当がない）。userinfo 未指定なら
+        `oauth2:<token>@`、ユーザー名のみ指定済みなら token をパスワードとして
+        補完する。パスワード込み・非 http(s) URL はそのまま返す。
+        """
+        parsed = urlparse(url)
+        if parsed.scheme not in ("http", "https") or parsed.password:
+            return url
+        username = quote(parsed.username, safe="") if parsed.username else "oauth2"
+        host = parsed.hostname or ""
+        port = f":{parsed.port}" if parsed.port else ""
+        netloc = f"{username}:{quote(auth_token, safe='')}@{host}{port}"
+        return urlunparse(parsed._replace(netloc=netloc))
+
     def create_push_mirror(
         self,
         remote_address: str,
@@ -2490,12 +2508,21 @@ class GitLabAdapter(GitServiceAdapter):
         sync_on_commit: bool = True,
         auth_token: str | None = None,
     ) -> PushMirror:
+        url = remote_address
+        if auth_token:
+            url = self._embed_mirror_credentials(remote_address, auth_token)
         payload: dict[str, Any] = {
-            "url": remote_address,
+            "url": url,
             "enabled": True,
             "only_protected_branches": False,
         }
-        resp = self._client.post(f"{self._project_path()}/remote_mirrors", json=payload)
+        # auth_token は URL に embed されるため、サーバー応答エラー本文や
+        # ネットワーク例外メッセージに漏れないようマスクする
+        try:
+            resp = self._client.post(f"{self._project_path()}/remote_mirrors", json=payload)
+        except Exception as e:
+            _mask_token_in_exception(e, auth_token)
+            raise
         m = resp.json()
         return PushMirror(
             id=m["id"],

--- a/tests/test_adapters/test_gitlab.py
+++ b/tests/test_adapters/test_gitlab.py
@@ -3803,6 +3803,93 @@ class TestMigrateRepositoryTokenMask:
         assert "***" in str(exc_info.value)
 
 
+class TestCreatePushMirrorAuthToken:
+    """create_push_mirror の auth_token は URL の userinfo に埋め込まれる（GitLab API 仕様）。"""
+
+    MIRROR_URL = f"{BASE}/projects/test-owner%2Ftest-repo/remote_mirrors"
+    MIRROR_RESP = {
+        "id": 101486,
+        "enabled": True,
+        "url": "https://*****:*****@github.com/o/r.git",
+        "created_at": "2026-01-01T00:00:00Z",
+        "last_successful_update_at": None,
+        "last_error": None,
+    }
+
+    @responses.activate
+    def test_auth_token_embedded_as_oauth2(self, gitlab_adapter):
+        responses.add(responses.POST, self.MIRROR_URL, json=self.MIRROR_RESP, status=201)
+        mirror = gitlab_adapter.create_push_mirror("https://github.com/o/r.git", auth_token="tok")
+        import json as _json
+
+        body = _json.loads(responses.calls[0].request.body)
+        assert body["url"] == "https://oauth2:tok@github.com/o/r.git"
+        # レスポンス側の URL は GitLab がマスク済みの値をそのまま返す
+        assert mirror.remote_address == "https://*****:*****@github.com/o/r.git"
+
+    @responses.activate
+    def test_auth_token_fills_password_when_username_present(self, gitlab_adapter):
+        responses.add(responses.POST, self.MIRROR_URL, json=self.MIRROR_RESP, status=201)
+        gitlab_adapter.create_push_mirror("https://user@github.com/o/r.git", auth_token="tok")
+        import json as _json
+
+        body = _json.loads(responses.calls[0].request.body)
+        assert body["url"] == "https://user:tok@github.com/o/r.git"
+
+    @responses.activate
+    def test_url_with_password_kept_as_is(self, gitlab_adapter):
+        responses.add(responses.POST, self.MIRROR_URL, json=self.MIRROR_RESP, status=201)
+        gitlab_adapter.create_push_mirror("https://user:pass@github.com/o/r.git", auth_token="tok")
+        import json as _json
+
+        body = _json.loads(responses.calls[0].request.body)
+        assert body["url"] == "https://user:pass@github.com/o/r.git"
+
+    @responses.activate
+    def test_non_http_url_kept_as_is(self, gitlab_adapter):
+        responses.add(responses.POST, self.MIRROR_URL, json=self.MIRROR_RESP, status=201)
+        gitlab_adapter.create_push_mirror("ssh://git@github.com/o/r.git", auth_token="tok")
+        import json as _json
+
+        body = _json.loads(responses.calls[0].request.body)
+        assert body["url"] == "ssh://git@github.com/o/r.git"
+
+    @responses.activate
+    def test_no_auth_token_url_unchanged(self, gitlab_adapter):
+        responses.add(responses.POST, self.MIRROR_URL, json=self.MIRROR_RESP, status=201)
+        gitlab_adapter.create_push_mirror("https://github.com/o/r.git")
+        import json as _json
+
+        body = _json.loads(responses.calls[0].request.body)
+        assert body["url"] == "https://github.com/o/r.git"
+
+    @responses.activate
+    def test_token_masked_on_error(self, gitlab_adapter):
+        """エラー応答本文経由でも auth_token が例外メッセージに漏れない。"""
+        from gfo.exceptions import GfoError
+
+        responses.add(
+            responses.POST,
+            self.MIRROR_URL,
+            json={
+                "message": "url is invalid: https://oauth2:super-secret-token@github.com/o/r.git"
+            },
+            status=400,
+        )
+        with pytest.raises(GfoError) as exc_info:
+            gitlab_adapter.create_push_mirror(
+                "https://github.com/o/r.git", auth_token="super-secret-token"
+            )
+        assert "super-secret-token" not in str(exc_info.value)
+        assert "***" in str(exc_info.value)
+
+    def test_special_chars_in_token_are_quoted(self):
+        from gfo.adapter.gitlab import GitLabAdapter
+
+        url = GitLabAdapter._embed_mirror_credentials("https://github.com/o/r.git", "t@k/en:1")
+        assert url == "https://oauth2:t%40k%2Fen%3A1@github.com/o/r.git"
+
+
 class TestUpdateOrganization:
     def test_update_display_name(self, mock_responses, gitlab_adapter):
         mock_responses.add(


### PR DESCRIPTION
Closes #86

## 変更内容

GitLab の `create_push_mirror`（`src/gfo/adapter/gitlab.py`）は `auth_token` 引数を受け取るだけで payload に使用しておらず、`gfo repo mirror add --auth-token` が黙って無視されていた（前セッションからの持ち越し。Gitea 系は `remote_password` で配線済み）。

GitLab の remote mirrors API（`POST /projects/:id/remote_mirrors`）は認証情報を URL に埋め込む仕様のため、`_embed_mirror_credentials` で `url` の userinfo に埋め込む:

- userinfo なし → `oauth2:<token>@`（既存の `migrate_repository` の `import_url` と同じ流儀）
- ユーザー名のみ指定済み → token をパスワードとして補完（token は URL エンコード）
- パスワード込み / 非 http(s) URL → そのまま

トークンが URL に載るため、gitea 実装と同様に `_mask_token_in_exception` でエラー応答・ネットワーク例外からのトークン漏えいをマスクする。レスポンスの `url` は GitLab 側でマスク済みの値（`https://*****:*****@...`）をそのまま返す。

## テスト

`TestCreatePushMirrorAuthToken` を追加（7 件）: oauth2 埋め込み / ユーザー名補完 / パスワード込み・ssh URL の非変更 / token なし非変更 / エラー時のトークンマスク / 特殊文字の URL エンコード。

全 3978 件 pass、ruff / mypy（linux + win32）green。

※ 実 GitLab での動作は未確認（コードパス上の確認 + HTTP モック）。統合テストは `tests/integration` の対象範囲で別途実行可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)