### PR TITLE
feat(cli): 破壊的操作に確認プロンプトと --yes を統一する

### DIFF
--- a/docs/commands.ja.md
+++ b/docs/commands.ja.md
@@ -13,6 +13,10 @@
 | `--account ACCOUNT` | マルチアカウントのトークン解決に使用するアカウント名（`gfo auth login --account` 参照） | — |
 | `--version` | バージョンを表示して終了 | — |
 
+### 破壊的操作と `--yes`
+
+破壊的なサブコマンド（`delete` / `remove` 系、および `repo archive` / `repo transfer`）は、デフォルトで確認プロンプトを表示します。`--yes` / `-y` でスキップできます。非対話環境（stdin が TTY でない場合 — パイプ・CI・AI agent など）ではプロンプトを表示せず、`--yes` がない限りエラーで失敗します。
+
 ### mutation 系コマンドの JSON 出力
 
 create / delete / close などの mutation 系コマンドの成功メッセージは、`--format json`（および非 TTY 時の auto-JSON）では構造化 JSON になります。`result`（実行結果の動詞）+ 対象を特定するフィールド + `message`（ローカライズ済みメッセージ）の形式です。
@@ -566,7 +570,7 @@ PR のコメントを管理します。
 gfo pr comment list NUMBER [--limit N]
 gfo pr comment create NUMBER --body BODY
 gfo pr comment edit COMMENT_ID --body BODY
-gfo pr comment delete COMMENT_ID
+gfo pr comment delete COMMENT_ID [--yes]
 ```
 
 ```bash
@@ -671,7 +675,7 @@ gfo issue reopen 10
 > GitHub / Gogs は非対応
 
 ```
-gfo issue delete NUMBER
+gfo issue delete NUMBER [--yes]
 ```
 
 ```bash
@@ -805,7 +809,7 @@ Issue のコメントを管理します。
 gfo issue comment list NUMBER [--limit N]
 gfo issue comment create NUMBER --body BODY
 gfo issue comment edit COMMENT_ID --body BODY
-gfo issue comment delete COMMENT_ID
+gfo issue comment delete COMMENT_ID [--yes]
 ```
 
 ```bash
@@ -901,7 +905,7 @@ Issue のタイムトラッキング（作業時間記録）を管理します�
 ```
 gfo issue time list NUMBER
 gfo issue time add NUMBER DURATION
-gfo issue time delete NUMBER ENTRY_ID
+gfo issue time delete NUMBER ENTRY_ID [--yes]
 ```
 
 | 引数 | 説明 |
@@ -1198,7 +1202,7 @@ gfo repo migrate https://github.com/other/repo.git --name my-org/imported --inte
 ```
 gfo repo mirror list
 gfo repo mirror add REMOTE_ADDRESS [--interval INTERVAL]
-gfo repo mirror remove MIRROR_NAME
+gfo repo mirror remove MIRROR_NAME [--yes]
 gfo repo mirror sync
 ```
 
@@ -1324,7 +1328,7 @@ gfo release create v1.0.0 --generate-notes
 ### gfo release delete
 
 ```
-gfo release delete TAG
+gfo release delete TAG [--yes]
 ```
 
 ```bash
@@ -1386,7 +1390,7 @@ gfo release asset list --tag TAG
 gfo release asset upload --tag TAG <file> [--name NAME]
 gfo release asset download --tag TAG [--asset-id ID | --pattern GLOB] [--dir DIR]
 gfo release asset edit --tag TAG <asset_id> [--name NAME]
-gfo release asset delete --tag TAG <asset_id>
+gfo release asset delete --tag TAG <asset_id> [--yes]
 ```
 
 ---
@@ -1419,7 +1423,7 @@ gfo label create enhancement --color 0075ca
 ### gfo label delete
 
 ```
-gfo label delete NAME
+gfo label delete NAME [--yes]
 ```
 
 ```bash
@@ -1493,7 +1497,7 @@ gfo milestone create "v1.0 Release" --due 2024-12-31
 ### gfo milestone delete
 
 ```
-gfo milestone delete NUMBER
+gfo milestone delete NUMBER [--yes]
 ```
 
 ```bash
@@ -1597,7 +1601,7 @@ gfo branch view feature/new-ui
 ### gfo branch delete
 
 ```
-gfo branch delete NAME
+gfo branch delete NAME [--yes]
 ```
 
 ```bash
@@ -1646,7 +1650,7 @@ gfo tag create v1.0.0 --ref main --message "Release v1.0.0"
 ### gfo tag delete
 
 ```
-gfo tag delete NAME
+gfo tag delete NAME [--yes]
 ```
 
 ```bash
@@ -1720,7 +1724,7 @@ cat myfile.py | gfo file put src/myfile.py --message "Update myfile" --branch fe
 ### gfo file delete
 
 ```
-gfo file delete PATH --message MSG [--branch BRANCH]
+gfo file delete PATH --message MSG [--branch BRANCH] [--yes]
 ```
 
 ```bash
@@ -1757,7 +1761,7 @@ gfo webhook create --url https://example.com/hook --event push --secret mysecret
 ### gfo webhook delete
 
 ```
-gfo webhook delete ID
+gfo webhook delete ID [--yes]
 ```
 
 ```bash
@@ -1838,7 +1842,7 @@ gfo deploy-key create --title "Deploy Bot" --key "ssh-ed25519 AAAA..." --read-wr
 ### gfo deploy-key delete
 
 ```
-gfo deploy-key delete ID
+gfo deploy-key delete ID [--yes]
 ```
 
 ```bash
@@ -1877,7 +1881,7 @@ gfo collaborator add bob --permission admin
 ### gfo collaborator remove
 
 ```
-gfo collaborator remove USERNAME
+gfo collaborator remove USERNAME [--yes]
 ```
 
 ```bash
@@ -1928,7 +1932,7 @@ gfo ci cancel 12345678
 パイプライン実行を削除します。
 
 ```
-gfo ci delete ID
+gfo ci delete ID [--yes]
 ```
 
 ```bash
@@ -2144,7 +2148,7 @@ gfo wiki edit 1 --title "New Title"
 ### gfo wiki delete
 
 ```
-gfo wiki delete ID
+gfo wiki delete ID [--yes]
 ```
 
 ```bash
@@ -2239,7 +2243,7 @@ gfo branch-protect set main --require-reviews 2 --no-allow-force-push
 ### gfo branch-protect remove
 
 ```
-gfo branch-protect remove BRANCH
+gfo branch-protect remove BRANCH [--yes]
 ```
 
 ```bash
@@ -2386,7 +2390,7 @@ gfo ssh-key create --title "My Laptop" --key "ssh-ed25519 AAAA..."
 ### gfo ssh-key delete
 
 ```
-gfo ssh-key delete ID
+gfo ssh-key delete ID [--yes]
 ```
 
 ```bash
@@ -2436,7 +2440,7 @@ gfo secret set ORG_TOKEN --value "token" --org my-org
 ### gfo secret delete
 
 ```
-gfo secret delete NAME [--org ORG]
+gfo secret delete NAME [--org ORG] [--yes]
 ```
 
 | オプション | 説明 |
@@ -2492,7 +2496,7 @@ gfo variable get NODE_ENV
 ### gfo variable delete
 
 ```
-gfo variable delete NAME [--org ORG]
+gfo variable delete NAME [--org ORG] [--yes]
 ```
 
 | オプション | 説明 |
@@ -2631,7 +2635,7 @@ gfo gpg-key create --key "-----BEGIN PGP PUBLIC KEY BLOCK-----..."
 ### gfo gpg-key delete
 
 ```
-gfo gpg-key delete ID
+gfo gpg-key delete ID [--yes]
 ```
 
 ```bash
@@ -2750,7 +2754,7 @@ gfo tag-protect create "release-*" --access-level maintainer
 ### gfo tag-protect delete
 
 ```
-gfo tag-protect delete ID
+gfo tag-protect delete ID [--yes]
 ```
 
 ```bash

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -13,6 +13,10 @@ Available for all commands.
 | `--account ACCOUNT` | Account name for multi-account token resolution (see `gfo auth login --account`) | — |
 | `--version` | Show version and exit | — |
 
+### Destructive operations and `--yes`
+
+All destructive subcommands (`delete` / `remove` family, plus `repo archive` and `repo transfer`) show a confirmation prompt by default. Pass `--yes` / `-y` to skip it. In non-interactive contexts (stdin is not a TTY — pipes, CI, AI agents), no prompt is shown: the command fails with an error unless `--yes` is given.
+
 ---
 
 ## gfo init
@@ -552,7 +556,7 @@ Manage PR comments.
 gfo pr comment list NUMBER [--limit N]
 gfo pr comment create NUMBER --body BODY
 gfo pr comment edit COMMENT_ID --body BODY
-gfo pr comment delete COMMENT_ID
+gfo pr comment delete COMMENT_ID [--yes]
 ```
 
 ```bash
@@ -657,7 +661,7 @@ gfo issue reopen 10
 > GitHub / Gogs not supported
 
 ```
-gfo issue delete NUMBER
+gfo issue delete NUMBER [--yes]
 ```
 
 ```bash
@@ -791,7 +795,7 @@ Manage issue comments.
 gfo issue comment list NUMBER [--limit N]
 gfo issue comment create NUMBER --body BODY
 gfo issue comment edit COMMENT_ID --body BODY
-gfo issue comment delete COMMENT_ID
+gfo issue comment delete COMMENT_ID [--yes]
 ```
 
 ```bash
@@ -887,7 +891,7 @@ Manage issue time tracking (work time entries).
 ```
 gfo issue time list NUMBER
 gfo issue time add NUMBER DURATION
-gfo issue time delete NUMBER ENTRY_ID
+gfo issue time delete NUMBER ENTRY_ID [--yes]
 ```
 
 | Argument | Description |
@@ -1184,7 +1188,7 @@ Manage push mirrors.
 ```
 gfo repo mirror list
 gfo repo mirror add REMOTE_ADDRESS [--interval INTERVAL]
-gfo repo mirror remove MIRROR_NAME
+gfo repo mirror remove MIRROR_NAME [--yes]
 gfo repo mirror sync
 ```
 
@@ -1310,7 +1314,7 @@ gfo release create v1.0.0 --generate-notes
 ### gfo release delete
 
 ```
-gfo release delete TAG
+gfo release delete TAG [--yes]
 ```
 
 ```bash
@@ -1372,7 +1376,7 @@ gfo release asset list --tag TAG
 gfo release asset upload --tag TAG <file> [--name NAME]
 gfo release asset download --tag TAG [--asset-id ID | --pattern GLOB] [--dir DIR]
 gfo release asset edit --tag TAG <asset_id> [--name NAME]
-gfo release asset delete --tag TAG <asset_id>
+gfo release asset delete --tag TAG <asset_id> [--yes]
 ```
 
 ---
@@ -1405,7 +1409,7 @@ gfo label create enhancement --color 0075ca
 ### gfo label delete
 
 ```
-gfo label delete NAME
+gfo label delete NAME [--yes]
 ```
 
 ```bash
@@ -1479,7 +1483,7 @@ gfo milestone create "v1.0 Release" --due 2024-12-31
 ### gfo milestone delete
 
 ```
-gfo milestone delete NUMBER
+gfo milestone delete NUMBER [--yes]
 ```
 
 ```bash
@@ -1583,7 +1587,7 @@ gfo branch view feature/new-ui
 ### gfo branch delete
 
 ```
-gfo branch delete NAME
+gfo branch delete NAME [--yes]
 ```
 
 ```bash
@@ -1632,7 +1636,7 @@ gfo tag create v1.0.0 --ref main --message "Release v1.0.0"
 ### gfo tag delete
 
 ```
-gfo tag delete NAME
+gfo tag delete NAME [--yes]
 ```
 
 ```bash
@@ -1706,7 +1710,7 @@ cat myfile.py | gfo file put src/myfile.py --message "Update myfile" --branch fe
 ### gfo file delete
 
 ```
-gfo file delete PATH --message MSG [--branch BRANCH]
+gfo file delete PATH --message MSG [--branch BRANCH] [--yes]
 ```
 
 ```bash
@@ -1743,7 +1747,7 @@ gfo webhook create --url https://example.com/hook --event push --secret mysecret
 ### gfo webhook delete
 
 ```
-gfo webhook delete ID
+gfo webhook delete ID [--yes]
 ```
 
 ```bash
@@ -1824,7 +1828,7 @@ gfo deploy-key create --title "Deploy Bot" --key "ssh-ed25519 AAAA..." --read-wr
 ### gfo deploy-key delete
 
 ```
-gfo deploy-key delete ID
+gfo deploy-key delete ID [--yes]
 ```
 
 ```bash
@@ -1863,7 +1867,7 @@ gfo collaborator add bob --permission admin
 ### gfo collaborator remove
 
 ```
-gfo collaborator remove USERNAME
+gfo collaborator remove USERNAME [--yes]
 ```
 
 ```bash
@@ -1914,7 +1918,7 @@ gfo ci cancel 12345678
 Delete a pipeline run.
 
 ```
-gfo ci delete ID
+gfo ci delete ID [--yes]
 ```
 
 ```bash
@@ -2130,7 +2134,7 @@ gfo wiki edit 1 --title "New Title"
 ### gfo wiki delete
 
 ```
-gfo wiki delete ID
+gfo wiki delete ID [--yes]
 ```
 
 ```bash
@@ -2225,7 +2229,7 @@ gfo branch-protect set main --require-reviews 2 --no-allow-force-push
 ### gfo branch-protect remove
 
 ```
-gfo branch-protect remove BRANCH
+gfo branch-protect remove BRANCH [--yes]
 ```
 
 ```bash
@@ -2372,7 +2376,7 @@ gfo ssh-key create --title "My Laptop" --key "ssh-ed25519 AAAA..."
 ### gfo ssh-key delete
 
 ```
-gfo ssh-key delete ID
+gfo ssh-key delete ID [--yes]
 ```
 
 ```bash
@@ -2422,7 +2426,7 @@ gfo secret set ORG_TOKEN --value "token" --org my-org
 ### gfo secret delete
 
 ```
-gfo secret delete NAME [--org ORG]
+gfo secret delete NAME [--org ORG] [--yes]
 ```
 
 | Option | Description |
@@ -2478,7 +2482,7 @@ gfo variable get NODE_ENV
 ### gfo variable delete
 
 ```
-gfo variable delete NAME [--org ORG]
+gfo variable delete NAME [--org ORG] [--yes]
 ```
 
 | Option | Description |
@@ -2617,7 +2621,7 @@ gfo gpg-key create --key "-----BEGIN PGP PUBLIC KEY BLOCK-----..."
 ### gfo gpg-key delete
 
 ```
-gfo gpg-key delete ID
+gfo gpg-key delete ID [--yes]
 ```
 
 ```bash
@@ -2736,7 +2740,7 @@ gfo tag-protect create "release-*" --access-level maintainer
 ### gfo tag-protect delete
 
 ```
-gfo tag-protect delete ID
+gfo tag-protect delete ID [--yes]
 ```
 
 ```bash

--- a/src/gfo/cli.py
+++ b/src/gfo/cli.py
@@ -467,6 +467,9 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     pr_comment_edit.add_argument("comment_id", type=int, help=_("Comment ID"))
     pr_comment_edit.add_argument("--body", "-b", required=True, help=_("Body"))
     pr_comment_delete = pr_comment_sub.add_parser("delete", help=_("Delete comment"))
+    pr_comment_delete.add_argument(
+        "--yes", "-y", action="store_true", help=_("Skip confirmation prompt")
+    )
     pr_comment_delete.add_argument("comment_id", type=int, help=_("Comment ID"))
 
     # gfo issue → サブサブコマンド
@@ -513,6 +516,9 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     issue_close = issue_sub.add_parser("close", help=_("Close issue"))
     issue_close.add_argument("number", type=int, help=_("Issue number"))
     issue_delete = issue_sub.add_parser("delete", help=_("Delete issue"))
+    issue_delete.add_argument(
+        "--yes", "-y", action="store_true", help=_("Skip confirmation prompt")
+    )
     issue_delete.add_argument("number", type=int, help=_("Issue number"))
     issue_reopen = issue_sub.add_parser("reopen", help=_("Reopen issue"))
     issue_reopen.add_argument("number", type=int, help=_("Issue number"))
@@ -804,6 +810,9 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
         "--web", "-w", action="store_true", help=_("Open in browser after creating")
     )
     release_delete = release_sub.add_parser("delete", help=_("Delete release"))
+    release_delete.add_argument(
+        "--yes", "-y", action="store_true", help=_("Skip confirmation prompt")
+    )
     release_delete.add_argument("tag", help=_("Tag name"))
     release_view = release_sub.add_parser("view", help=_("View release details"))
     release_view.add_argument("tag", nargs="?", help=_("Tag name"))
@@ -853,6 +862,9 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     asset_edit.add_argument("asset_id", help=_("Asset ID"))
     asset_edit.add_argument("--name", help=_("Asset name"))
     asset_delete = release_asset_sub.add_parser("delete", help=_("Delete asset"))
+    asset_delete.add_argument(
+        "--yes", "-y", action="store_true", help=_("Skip confirmation prompt")
+    )
     asset_delete.add_argument("--tag", required=True, help=_("Tag name"))
     asset_delete.add_argument("asset_id", help=_("Asset ID"))
 
@@ -865,6 +877,9 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     label_create.add_argument("--color", "-c", help=_("Color (hex)"))
     label_create.add_argument("--description", "-d", help=_("Description"))
     label_delete = label_sub.add_parser("delete", help=_("Delete label"))
+    label_delete.add_argument(
+        "--yes", "-y", action="store_true", help=_("Skip confirmation prompt")
+    )
     label_delete.add_argument("name", help=_("Label name"))
     label_edit = label_sub.add_parser("edit", help=_("Edit label"))
     label_edit.add_argument("current_name", metavar="NAME", help=_("Label name"))
@@ -884,6 +899,9 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     milestone_create.add_argument("--description", "-d", help=_("Description"))
     milestone_create.add_argument("--due", help=_("Due date"))
     milestone_delete = milestone_sub.add_parser("delete", help=_("Delete milestone"))
+    milestone_delete.add_argument(
+        "--yes", "-y", action="store_true", help=_("Skip confirmation prompt")
+    )
     milestone_delete.add_argument("number", type=int, help=_("Milestone number"))
     milestone_view = milestone_sub.add_parser("view", help=_("View milestone details"))
     milestone_view.add_argument("number", type=int, help=_("Milestone number"))
@@ -951,6 +969,9 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     issue_comment_edit.add_argument("comment_id", type=int, help=_("Comment ID"))
     issue_comment_edit.add_argument("--body", "-b", required=True, help=_("Body"))
     issue_comment_delete = issue_comment_sub.add_parser("delete", help=_("Delete comment"))
+    issue_comment_delete.add_argument(
+        "--yes", "-y", action="store_true", help=_("Skip confirmation prompt")
+    )
     issue_comment_delete.add_argument("comment_id", type=int, help=_("Comment ID"))
 
     # gfo repo fork（既存 repo に追加）
@@ -980,6 +1001,9 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     branch_create.add_argument("name", help=_("Branch name"))
     branch_create.add_argument("--ref", required=True, help=_("Source ref"))
     branch_delete = branch_sub.add_parser("delete", help=_("Delete branch"))
+    branch_delete.add_argument(
+        "--yes", "-y", action="store_true", help=_("Skip confirmation prompt")
+    )
     branch_delete.add_argument("name", help=_("Branch name"))
 
     # gfo tag → サブサブコマンド
@@ -1000,6 +1024,7 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     tag_create.add_argument("--ref", required=True, help=_("Source ref"))
     tag_create.add_argument("--message", "-m", default="", help=_("Tag message"))
     tag_delete = tag_sub.add_parser("delete", help=_("Delete tag"))
+    tag_delete.add_argument("--yes", "-y", action="store_true", help=_("Skip confirmation prompt"))
     tag_delete.add_argument("name", help=_("Tag name"))
 
     # gfo status → サブサブコマンド
@@ -1041,6 +1066,7 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     file_put.add_argument("--message", required=True, help=_("Commit message"))
     file_put.add_argument("--branch", help=_("Target branch"))
     file_delete = file_sub.add_parser("delete", help=_("Delete file"))
+    file_delete.add_argument("--yes", "-y", action="store_true", help=_("Skip confirmation prompt"))
     file_delete.add_argument("path", help=_("File path"))
     file_delete.add_argument("--message", required=True, help=_("Commit message"))
     file_delete.add_argument("--branch", help=_("Target branch"))
@@ -1063,6 +1089,9 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     webhook_create.add_argument("--event", action="append", required=True, help=_("Event type"))
     webhook_create.add_argument("--secret", help=_("Webhook secret"))
     webhook_delete = webhook_sub.add_parser("delete", help=_("Delete webhook"))
+    webhook_delete.add_argument(
+        "--yes", "-y", action="store_true", help=_("Skip confirmation prompt")
+    )
     webhook_delete.add_argument("id", type=int, help=_("Webhook ID"))
     webhook_test = webhook_sub.add_parser("test", help=_("Test webhook"))
     webhook_test.add_argument("id", type=int, help=_("Webhook ID"))
@@ -1101,6 +1130,9 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
         "--read-write", dest="read_write", action="store_true", help=_("Allow write access")
     )
     deploy_key_delete = deploy_key_sub.add_parser("delete", help=_("Delete deploy key"))
+    deploy_key_delete.add_argument(
+        "--yes", "-y", action="store_true", help=_("Skip confirmation prompt")
+    )
     deploy_key_delete.add_argument("id", type=int, help=_("Deploy key ID"))
 
     # gfo collaborator → サブサブコマンド
@@ -1125,6 +1157,9 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
         help=_("Permission level"),
     )
     collab_remove = collab_sub.add_parser("remove", help=_("Remove collaborator"))
+    collab_remove.add_argument(
+        "--yes", "-y", action="store_true", help=_("Skip confirmation prompt")
+    )
     collab_remove.add_argument("username", help=_("Username"))
 
     # gfo ci → サブサブコマンド
@@ -1144,6 +1179,7 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     ci_cancel = ci_sub.add_parser("cancel", help=_("Cancel pipeline"))
     ci_cancel.add_argument("id", help=_("Pipeline ID"))
     ci_delete = ci_sub.add_parser("delete", help=_("Delete pipeline run"))
+    ci_delete.add_argument("--yes", "-y", action="store_true", help=_("Skip confirmation prompt"))
     ci_delete.add_argument("id", help=_("Pipeline ID"))
     ci_trigger = ci_sub.add_parser("trigger", help=_("Trigger pipeline"))
     ci_trigger.add_argument("--ref", required=True, help=_("Git ref"))
@@ -1248,6 +1284,7 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     wiki_edit.add_argument("--title", "-t", help=_("Title"))
     wiki_edit.add_argument("--content", help=_("Content"))
     wiki_delete = wiki_sub.add_parser("delete", help=_("Delete wiki page"))
+    wiki_delete.add_argument("--yes", "-y", action="store_true", help=_("Skip confirmation prompt"))
     wiki_delete.add_argument("id", help=_("Page ID"))
 
     # -- New Phase 5 parsers --
@@ -1302,6 +1339,9 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     issue_time_add.add_argument("number", type=int, help=_("Issue number"))
     issue_time_add.add_argument("duration", help=_("Duration (e.g. 1h30m)"))
     issue_time_delete = issue_time_sub.add_parser("delete", help=_("Delete time entry"))
+    issue_time_delete.add_argument(
+        "--yes", "-y", action="store_true", help=_("Skip confirmation prompt")
+    )
     issue_time_delete.add_argument("number", type=int, help=_("Issue number"))
     issue_time_delete.add_argument("entry_id", help=_("Time entry ID"))
 
@@ -1366,6 +1406,9 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     repo_mirror_add.add_argument("--interval", default="8h", help=_("Sync interval"))
     repo_mirror_add.add_argument("--auth-token", dest="auth_token", help=_("Authentication token"))
     repo_mirror_remove = repo_mirror_sub.add_parser("remove", help=_("Remove push mirror"))
+    repo_mirror_remove.add_argument(
+        "--yes", "-y", action="store_true", help=_("Skip confirmation prompt")
+    )
     repo_mirror_remove.add_argument("mirror_name", help=_("Mirror name"))
     repo_mirror_sub.add_parser("sync", help=_("Sync push mirrors"))
 
@@ -1461,6 +1504,7 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
         help=_("Disallow branch deletion"),
     )
     bp_remove = bp_sub.add_parser("remove", help=_("Remove branch protection rule"))
+    bp_remove.add_argument("--yes", "-y", action="store_true", help=_("Skip confirmation prompt"))
     bp_remove.add_argument("branch", help=_("Branch name"))
 
     # gfo tag-protect → サブサブコマンド
@@ -1484,6 +1528,7 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     tp_edit.add_argument("--pattern", help=_("Tag pattern"))
     tp_edit.add_argument("--access-level", dest="access_level", help=_("Access level"))
     tp_delete = tp_sub.add_parser("delete", help=_("Delete tag protection rule"))
+    tp_delete.add_argument("--yes", "-y", action="store_true", help=_("Skip confirmation prompt"))
     tp_delete.add_argument("id", help=_("Rule ID"))
 
     # gfo notification → サブサブコマンド
@@ -1568,6 +1613,9 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     ssh_key_create.add_argument("--title", "-t", required=True, help=_("Title"))
     ssh_key_create.add_argument("--key", required=True, help=_("Public key"))
     ssh_key_delete = ssh_key_sub.add_parser("delete", help=_("Delete SSH key"))
+    ssh_key_delete.add_argument(
+        "--yes", "-y", action="store_true", help=_("Skip confirmation prompt")
+    )
     ssh_key_delete.add_argument("id", type=int, help=_("SSH key ID"))
 
     # gfo gpg-key → サブサブコマンド
@@ -1588,6 +1636,9 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     gpg_key_create = gpg_key_sub.add_parser("create", help=_("Create GPG key"))
     gpg_key_create.add_argument("--key", required=True, help=_("GPG public key"))
     gpg_key_delete = gpg_key_sub.add_parser("delete", help=_("Delete GPG key"))
+    gpg_key_delete.add_argument(
+        "--yes", "-y", action="store_true", help=_("Skip confirmation prompt")
+    )
     gpg_key_delete.add_argument("id", type=int, help=_("GPG key ID"))
 
     # gfo secret → サブサブコマンド
@@ -1614,6 +1665,9 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     )
     _secret_value_group.add_argument("--file", help=_("File path"))
     secret_delete = secret_sub.add_parser("delete", help=_("Delete secret"))
+    secret_delete.add_argument(
+        "--yes", "-y", action="store_true", help=_("Skip confirmation prompt")
+    )
     secret_delete.add_argument("name", help=_("Secret name"))
     secret_delete.add_argument("--org", help=_("Organization scope"))
 
@@ -1640,6 +1694,9 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     variable_get.add_argument("name", help=_("Variable name"))
     variable_get.add_argument("--org", help=_("Organization scope"))
     variable_delete = variable_sub.add_parser("delete", help=_("Delete variable"))
+    variable_delete.add_argument(
+        "--yes", "-y", action="store_true", help=_("Skip confirmation prompt")
+    )
     variable_delete.add_argument("name", help=_("Variable name"))
     variable_delete.add_argument("--org", help=_("Organization scope"))
 

--- a/src/gfo/commands/__init__.py
+++ b/src/gfo/commands/__init__.py
@@ -1,11 +1,49 @@
 from __future__ import annotations
 
+import argparse
 from dataclasses import dataclass
 
 import gfo.adapter.registry
 import gfo.config
 from gfo.adapter.base import GitServiceAdapter
 from gfo.config import ProjectConfig
+
+
+def _stdin_is_interactive() -> bool:
+    """stdin が対話端末かどうか（テストで差し替えるためのシーム）。"""
+    import sys
+
+    return sys.stdin.isatty()
+
+
+def confirm_action(
+    args: argparse.Namespace, message: str, *, fmt: str, jq: str | None = None
+) -> bool:
+    """破壊的操作の実行前確認ヘルパー。
+
+    - ``--yes`` 指定時は確認せず True を返す。
+    - 非対話環境（stdin が TTY でない）ではプロンプトを出さずに ConfigError を
+      投げる。パイプ・自動化・AI agent からの誤操作を防ぐため、非対話実行では
+      ``--yes`` による明示同意を要求する。
+    - プロンプトへの回答が y/yes 以外なら "Aborted." を出力して False を返す。
+    """
+    from gfo.exceptions import ConfigError
+    from gfo.i18n import _
+    from gfo.output import output_result
+
+    if getattr(args, "yes", False):
+        return True
+    if not _stdin_is_interactive():
+        raise ConfigError(
+            _(
+                "Confirmation required. Re-run with --yes to skip the prompt in non-interactive mode."
+            )
+        )
+    answer = input(message)
+    if answer.strip().lower() not in ("y", "yes"):
+        output_result(_("Aborted."), result="aborted", fmt=fmt, jq=jq)
+        return False
+    return True
 
 
 def get_adapter() -> GitServiceAdapter:

--- a/src/gfo/commands/branch.py
+++ b/src/gfo/commands/branch.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 
-from gfo.commands import get_adapter
+from gfo.commands import confirm_action, get_adapter
 from gfo.i18n import _
 from gfo.output import output, output_result
 
@@ -33,6 +33,13 @@ def handle_create(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
 def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo branch delete <name> のハンドラ。"""
     adapter = get_adapter()
+    if not confirm_action(
+        args,
+        _("Are you sure you want to delete branch '{name}'? [y/N]: ").format(name=args.name),
+        fmt=fmt,
+        jq=jq,
+    ):
+        return
     adapter.delete_branch(name=args.name)
     output_result(
         _("Deleted branch '{name}'.").format(name=args.name),

--- a/src/gfo/commands/branch_protect.py
+++ b/src/gfo/commands/branch_protect.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 
-from gfo.commands import get_adapter
+from gfo.commands import confirm_action, get_adapter
 from gfo.i18n import _
 from gfo.output import output, output_result
 
@@ -45,6 +45,15 @@ def handle_set(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> 
 def handle_remove(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo branch-protect remove <branch> のハンドラ。"""
     adapter = get_adapter()
+    if not confirm_action(
+        args,
+        _("Are you sure you want to remove branch protection for '{branch}'? [y/N]: ").format(
+            branch=args.branch
+        ),
+        fmt=fmt,
+        jq=jq,
+    ):
+        return
     adapter.remove_branch_protection(args.branch)
     output_result(
         _("Removed branch protection for '{branch}'.").format(branch=args.branch),

--- a/src/gfo/commands/ci.py
+++ b/src/gfo/commands/ci.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 
-from gfo.commands import get_adapter
+from gfo.commands import confirm_action, get_adapter
 from gfo.exceptions import ConfigError
 from gfo.i18n import _
 from gfo.output import output, output_result
@@ -40,6 +40,13 @@ def handle_cancel(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
 def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo ci delete <id> のハンドラ。"""
     adapter = get_adapter()
+    if not confirm_action(
+        args,
+        _("Are you sure you want to delete pipeline run '{id}'? [y/N]: ").format(id=args.id),
+        fmt=fmt,
+        jq=jq,
+    ):
+        return
     adapter.delete_pipeline_run(args.id)
     output_result(
         _("Deleted pipeline run '{id}'.").format(id=args.id),

--- a/src/gfo/commands/collaborator.py
+++ b/src/gfo/commands/collaborator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 
-from gfo.commands import get_adapter
+from gfo.commands import confirm_action, get_adapter
 from gfo.i18n import _
 from gfo.output import apply_jq_filter, output_result
 
@@ -41,6 +41,15 @@ def handle_add(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> 
 def handle_remove(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo collaborator remove <username> のハンドラ。"""
     adapter = get_adapter()
+    if not confirm_action(
+        args,
+        _("Are you sure you want to remove collaborator '{username}'? [y/N]: ").format(
+            username=args.username
+        ),
+        fmt=fmt,
+        jq=jq,
+    ):
+        return
     adapter.remove_collaborator(username=args.username)
     output_result(
         _("Removed collaborator '{username}'.").format(username=args.username),

--- a/src/gfo/commands/comment.py
+++ b/src/gfo/commands/comment.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 
-from gfo.commands import get_adapter
+from gfo.commands import confirm_action, get_adapter
 from gfo.exceptions import ConfigError
 from gfo.i18n import _
 from gfo.output import output, output_result
@@ -26,6 +26,15 @@ def _dispatch(args: argparse.Namespace, resource: str, *, fmt: str, jq: str | No
         comment = adapter.update_comment(resource, args.comment_id, body=args.body)
         output(comment, fmt=fmt, jq=jq)
     elif action == "delete":
+        if not confirm_action(
+            args,
+            _("Are you sure you want to delete comment '{comment_id}'? [y/N]: ").format(
+                comment_id=args.comment_id
+            ),
+            fmt=fmt,
+            jq=jq,
+        ):
+            return
         adapter.delete_comment(resource, args.comment_id)
         output_result(
             _("Deleted comment '{comment_id}'.").format(comment_id=args.comment_id),

--- a/src/gfo/commands/deploy_key.py
+++ b/src/gfo/commands/deploy_key.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 
-from gfo.commands import get_adapter
+from gfo.commands import confirm_action, get_adapter
 from gfo.i18n import _
 from gfo.output import output, output_result
 
@@ -37,6 +37,13 @@ def handle_create(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
 def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo deploy-key delete <id> のハンドラ。"""
     adapter = get_adapter()
+    if not confirm_action(
+        args,
+        _("Are you sure you want to delete deploy key '{id}'? [y/N]: ").format(id=args.id),
+        fmt=fmt,
+        jq=jq,
+    ):
+        return
     adapter.delete_deploy_key(key_id=args.id)
     output_result(
         _("Deleted deploy key '{id}'.").format(id=args.id),

--- a/src/gfo/commands/file.py
+++ b/src/gfo/commands/file.py
@@ -6,7 +6,7 @@ import argparse
 import json
 import sys
 
-from gfo.commands import get_adapter
+from gfo.commands import confirm_action, get_adapter
 from gfo.exceptions import ConfigError, NotFoundError
 from gfo.i18n import _
 from gfo.output import apply_jq_filter, output_result
@@ -87,6 +87,13 @@ def handle_put(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> 
 def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo file delete <path> --message TEXT のハンドラ。"""
     _validate_repo_path(args.path)
+    if not confirm_action(
+        args,
+        _("Are you sure you want to delete file '{path}'? [y/N]: ").format(path=args.path),
+        fmt=fmt,
+        jq=jq,
+    ):
+        return
     adapter = get_adapter()
     _content, sha = adapter.get_file_content(args.path, ref=args.branch)
     adapter.delete_file(args.path, sha=sha, message=args.message, branch=args.branch)

--- a/src/gfo/commands/gpg_key.py
+++ b/src/gfo/commands/gpg_key.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 
-from gfo.commands import get_adapter
+from gfo.commands import confirm_action, get_adapter
 from gfo.i18n import _
 from gfo.output import output, output_result
 
@@ -33,6 +33,13 @@ def handle_create(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
 def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo gpg-key delete <id> のハンドラ。"""
     adapter = get_adapter()
+    if not confirm_action(
+        args,
+        _("Are you sure you want to delete GPG key '{id}'? [y/N]: ").format(id=args.id),
+        fmt=fmt,
+        jq=jq,
+    ):
+        return
     adapter.delete_gpg_key(key_id=args.id)
     output_result(
         _("Deleted GPG key '{id}'.").format(id=args.id),

--- a/src/gfo/commands/issue.py
+++ b/src/gfo/commands/issue.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from gfo.commands import (
+    confirm_action,
     create_adapter_from_spec,
     get_adapter,
     get_adapter_with_config,
@@ -147,6 +148,13 @@ def handle_reopen(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
 def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo issue delete <number> のハンドラ。"""
     adapter = get_adapter()
+    if not confirm_action(
+        args,
+        _("Are you sure you want to delete issue #{number}? [y/N]: ").format(number=args.number),
+        fmt=fmt,
+        jq=jq,
+    ):
+        return
     adapter.delete_issue(args.number)
     output_result(
         _("Deleted issue '{number}'.").format(number=args.number),
@@ -364,6 +372,15 @@ def handle_time(args: argparse.Namespace, *, fmt: str, jq: str | None = None) ->
         entry = adapter.add_time_entry(args.number, duration)
         output(entry, fmt=fmt, jq=jq)
     elif action == "delete":
+        if not confirm_action(
+            args,
+            _("Are you sure you want to delete time entry '{entry_id}'? [y/N]: ").format(
+                entry_id=args.entry_id
+            ),
+            fmt=fmt,
+            jq=jq,
+        ):
+            return
         adapter.delete_time_entry(args.number, args.entry_id)
         output_result(
             _("Deleted time entry '{entry_id}'.").format(entry_id=args.entry_id),

--- a/src/gfo/commands/label.py
+++ b/src/gfo/commands/label.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 import re
 
-from gfo.commands import get_adapter
+from gfo.commands import confirm_action, get_adapter
 from gfo.exceptions import ConfigError
 from gfo.i18n import _
 from gfo.output import output, output_result
@@ -47,6 +47,13 @@ def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
     if not name:
         raise ConfigError(_("name must not be empty."))
     adapter = get_adapter()
+    if not confirm_action(
+        args,
+        _("Are you sure you want to delete label '{name}'? [y/N]: ").format(name=name),
+        fmt=fmt,
+        jq=jq,
+    ):
+        return
     adapter.delete_label(name=name)
     output_result(
         _("Deleted label '{name}'.").format(name=name),

--- a/src/gfo/commands/milestone.py
+++ b/src/gfo/commands/milestone.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 
-from gfo.commands import get_adapter, open_in_browser
+from gfo.commands import confirm_action, get_adapter, open_in_browser
 from gfo.exceptions import ConfigError
 from gfo.i18n import _
 from gfo.output import output, output_result
@@ -37,6 +37,15 @@ def handle_create(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
 def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo milestone delete のハンドラ。"""
     adapter = get_adapter()
+    if not confirm_action(
+        args,
+        _("Are you sure you want to delete milestone '{number}'? [y/N]: ").format(
+            number=args.number
+        ),
+        fmt=fmt,
+        jq=jq,
+    ):
+        return
     adapter.delete_milestone(number=args.number)
     output_result(
         _("Deleted milestone '{number}'.").format(number=args.number),

--- a/src/gfo/commands/org.py
+++ b/src/gfo/commands/org.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 
-from gfo.commands import get_adapter
+from gfo.commands import confirm_action, get_adapter
 from gfo.output import apply_jq_filter, output, output_result
 
 
@@ -72,15 +72,15 @@ def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
     from gfo.i18n import _
 
     adapter = get_adapter()
-    if not getattr(args, "yes", False):
-        confirm = input(
-            _(
-                "Are you sure you want to delete organization '{name}'? This action cannot be undone. [y/N]: "
-            ).format(name=args.name)
-        )
-        if confirm.lower() not in ("y", "yes"):
-            output_result(_("Aborted."), result="aborted", fmt=fmt, jq=jq)
-            return
+    if not confirm_action(
+        args,
+        _(
+            "Are you sure you want to delete organization '{name}'? This action cannot be undone. [y/N]: "
+        ).format(name=args.name),
+        fmt=fmt,
+        jq=jq,
+    ):
+        return
     adapter.delete_organization(args.name)
     output_result(
         _("Deleted organization '{name}'.").format(name=args.name),

--- a/src/gfo/commands/package.py
+++ b/src/gfo/commands/package.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 
-from gfo.commands import get_adapter
+from gfo.commands import confirm_action, get_adapter
 from gfo.i18n import _
 from gfo.output import output, output_result
 
@@ -33,15 +33,15 @@ def handle_view(args: argparse.Namespace, *, fmt: str, jq: str | None = None) ->
 def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo package delete のハンドラ。"""
     adapter = get_adapter()
-    if not getattr(args, "yes", False):
-        confirm = input(
-            _("Are you sure you want to delete package '{type}/{name}@{version}'? [y/N]: ").format(
-                type=args.package_type, name=args.name, version=args.version
-            )
-        )
-        if confirm.lower() not in ("y", "yes"):
-            output_result(_("Aborted."), result="aborted", fmt=fmt, jq=jq)
-            return
+    if not confirm_action(
+        args,
+        _("Are you sure you want to delete package '{type}/{name}@{version}'? [y/N]: ").format(
+            type=args.package_type, name=args.name, version=args.version
+        ),
+        fmt=fmt,
+        jq=jq,
+    ):
+        return
     adapter.delete_package(args.package_type, args.name, args.version)
     output_result(
         _("Deleted package '{type}/{name}@{version}'.").format(

--- a/src/gfo/commands/release.py
+++ b/src/gfo/commands/release.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 
-from gfo.commands import get_adapter, open_in_browser, read_file_arg
+from gfo.commands import confirm_action, get_adapter, open_in_browser, read_file_arg
 from gfo.exceptions import ConfigError, GfoError
 from gfo.i18n import _
 from gfo.output import output, output_result
@@ -65,6 +65,13 @@ def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
     if not tag:
         raise ConfigError(_("tag must not be empty. Use 'gfo release delete <tag>'."))
     adapter = get_adapter()
+    if not confirm_action(
+        args,
+        _("Are you sure you want to delete release '{tag}'? [y/N]: ").format(tag=tag),
+        fmt=fmt,
+        jq=jq,
+    ):
+        return
     adapter.delete_release(tag=tag)
     output_result(
         _("Deleted release '{tag}'.").format(tag=tag),
@@ -217,6 +224,15 @@ def _handle_asset_edit(args: argparse.Namespace, *, fmt: str, jq: str | None = N
 
 def _handle_asset_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     adapter = get_adapter()
+    if not confirm_action(
+        args,
+        _("Are you sure you want to delete release asset '{asset_id}'? [y/N]: ").format(
+            asset_id=args.asset_id
+        ),
+        fmt=fmt,
+        jq=jq,
+    ):
+        return
     adapter.delete_release_asset(tag=args.tag, asset_id=args.asset_id)
     output_result(
         _("Deleted asset '{asset_id}'.").format(asset_id=args.asset_id),

--- a/src/gfo/commands/repo.py
+++ b/src/gfo/commands/repo.py
@@ -7,7 +7,7 @@ import sys
 
 from gfo.adapter.registry import create_http_client, get_adapter_class
 from gfo.auth import resolve_token
-from gfo.commands import get_adapter, open_in_browser
+from gfo.commands import confirm_action, get_adapter, open_in_browser
 from gfo.config import (
     build_clone_url,
     build_default_api_url,
@@ -218,15 +218,15 @@ def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
     """gfo repo delete のハンドラ。"""
     adapter = get_adapter()
     repo_name = f"{adapter.owner}/{adapter.repo}"
-    if not getattr(args, "yes", False):
-        confirm = input(
-            _(
-                "Are you sure you want to delete repository '{repo_name}'? This action cannot be undone. [y/N]: "
-            ).format(repo_name=repo_name)
-        )
-        if confirm.lower() not in ("y", "yes"):
-            output_result(_("Aborted."), result="aborted", fmt=fmt, jq=jq)
-            return
+    if not confirm_action(
+        args,
+        _(
+            "Are you sure you want to delete repository '{repo_name}'? This action cannot be undone. [y/N]: "
+        ).format(repo_name=repo_name),
+        fmt=fmt,
+        jq=jq,
+    ):
+        return
     adapter.delete_repository()
     output_result(
         _("Deleted repository '{repo_name}'.").format(repo_name=repo_name),
@@ -276,15 +276,15 @@ def handle_archive(args: argparse.Namespace, *, fmt: str, jq: str | None = None)
     """gfo repo archive のハンドラ。"""
     adapter = get_adapter()
     repo_name = f"{adapter.owner}/{adapter.repo}"
-    if not getattr(args, "yes", False):
-        confirm = input(
-            _("Are you sure you want to archive repository '{repo_name}'? [y/N]: ").format(
-                repo_name=repo_name
-            )
-        )
-        if confirm.lower() not in ("y", "yes"):
-            output_result(_("Aborted."), result="aborted", fmt=fmt, jq=jq)
-            return
+    if not confirm_action(
+        args,
+        _("Are you sure you want to archive repository '{repo_name}'? [y/N]: ").format(
+            repo_name=repo_name
+        ),
+        fmt=fmt,
+        jq=jq,
+    ):
+        return
     adapter.archive_repository()
     output_result(
         _("Archived repository '{repo_name}'.").format(repo_name=repo_name),
@@ -417,6 +417,15 @@ def handle_mirror(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
         )
         output(mirror, fmt=fmt, jq=jq)
     elif action == "remove":
+        if not confirm_action(
+            args,
+            _("Are you sure you want to remove push mirror '{name}'? [y/N]: ").format(
+                name=args.mirror_name
+            ),
+            fmt=fmt,
+            jq=jq,
+        ):
+            return
         adapter.delete_push_mirror(args.mirror_name)
         output_result(
             _("Deleted push mirror '{name}'.").format(name=args.mirror_name),
@@ -434,15 +443,15 @@ def handle_transfer(args: argparse.Namespace, *, fmt: str, jq: str | None = None
     """gfo repo transfer <new_owner> のハンドラ。"""
     adapter = get_adapter()
     repo_name = f"{adapter.owner}/{adapter.repo}"
-    if not getattr(args, "yes", False):
-        confirm = input(
-            _(
-                "Are you sure you want to transfer repository '{repo_name}' to '{new_owner}'? [y/N]: "
-            ).format(repo_name=repo_name, new_owner=args.new_owner)
-        )
-        if confirm.lower() not in ("y", "yes"):
-            output_result(_("Aborted."), result="aborted", fmt=fmt, jq=jq)
-            return
+    if not confirm_action(
+        args,
+        _(
+            "Are you sure you want to transfer repository '{repo_name}' to '{new_owner}'? [y/N]: "
+        ).format(repo_name=repo_name, new_owner=args.new_owner),
+        fmt=fmt,
+        jq=jq,
+    ):
+        return
     team_ids = None
     raw = getattr(args, "team_id", None)
     if raw is not None:

--- a/src/gfo/commands/secret.py
+++ b/src/gfo/commands/secret.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 import os
 
-from gfo.commands import get_adapter, read_file_arg
+from gfo.commands import confirm_action, get_adapter, read_file_arg
 from gfo.exceptions import GfoError
 from gfo.i18n import _
 from gfo.output import output, output_result
@@ -44,6 +44,13 @@ def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
     """gfo secret delete <name> のハンドラ。"""
     adapter = get_adapter()
     scope = getattr(args, "org", None)
+    if not confirm_action(
+        args,
+        _("Are you sure you want to delete secret '{name}'? [y/N]: ").format(name=args.name),
+        fmt=fmt,
+        jq=jq,
+    ):
+        return
     adapter.delete_secret(args.name, scope=scope)
     output_result(
         _("Deleted secret '{name}'.").format(name=args.name),

--- a/src/gfo/commands/ssh_key.py
+++ b/src/gfo/commands/ssh_key.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 
-from gfo.commands import get_adapter
+from gfo.commands import confirm_action, get_adapter
 from gfo.i18n import _
 from gfo.output import output, output_result
 
@@ -33,6 +33,13 @@ def handle_create(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
 def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo ssh-key delete <id> のハンドラ。"""
     adapter = get_adapter()
+    if not confirm_action(
+        args,
+        _("Are you sure you want to delete SSH key '{id}'? [y/N]: ").format(id=args.id),
+        fmt=fmt,
+        jq=jq,
+    ):
+        return
     adapter.delete_ssh_key(key_id=args.id)
     output_result(
         _("Deleted SSH key '{id}'.").format(id=args.id),

--- a/src/gfo/commands/tag.py
+++ b/src/gfo/commands/tag.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 
-from gfo.commands import get_adapter
+from gfo.commands import confirm_action, get_adapter
 from gfo.i18n import _
 from gfo.output import output, output_result
 
@@ -33,6 +33,13 @@ def handle_create(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
 def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo tag delete <name> のハンドラ。"""
     adapter = get_adapter()
+    if not confirm_action(
+        args,
+        _("Are you sure you want to delete tag '{name}'? [y/N]: ").format(name=args.name),
+        fmt=fmt,
+        jq=jq,
+    ):
+        return
     adapter.delete_tag(name=args.name)
     output_result(
         _("Deleted tag '{name}'.").format(name=args.name),

--- a/src/gfo/commands/tag_protect.py
+++ b/src/gfo/commands/tag_protect.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 
-from gfo.commands import get_adapter
+from gfo.commands import confirm_action, get_adapter
 from gfo.i18n import _
 from gfo.output import output, output_result
 
@@ -39,6 +39,13 @@ def handle_edit(args: argparse.Namespace, *, fmt: str, jq: str | None = None) ->
 def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo tag-protect delete <id> のハンドラ。"""
     adapter = get_adapter()
+    if not confirm_action(
+        args,
+        _("Are you sure you want to delete tag protection '{id}'? [y/N]: ").format(id=args.id),
+        fmt=fmt,
+        jq=jq,
+    ):
+        return
     adapter.delete_tag_protection(args.id)
     output_result(
         _("Deleted tag protection '{id}'.").format(id=args.id),

--- a/src/gfo/commands/variable.py
+++ b/src/gfo/commands/variable.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 
-from gfo.commands import get_adapter
+from gfo.commands import confirm_action, get_adapter
 from gfo.i18n import _
 from gfo.output import output, output_result
 
@@ -42,6 +42,13 @@ def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
     """gfo variable delete <name> のハンドラ。"""
     adapter = get_adapter()
     scope = getattr(args, "org", None)
+    if not confirm_action(
+        args,
+        _("Are you sure you want to delete variable '{name}'? [y/N]: ").format(name=args.name),
+        fmt=fmt,
+        jq=jq,
+    ):
+        return
     adapter.delete_variable(args.name, scope=scope)
     output_result(
         _("Deleted variable '{name}'.").format(name=args.name),

--- a/src/gfo/commands/webhook.py
+++ b/src/gfo/commands/webhook.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 
-from gfo.commands import get_adapter
+from gfo.commands import confirm_action, get_adapter
 from gfo.i18n import _
 from gfo.output import output, output_result
 
@@ -26,6 +26,13 @@ def handle_create(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
 def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo webhook delete <id> のハンドラ。"""
     adapter = get_adapter()
+    if not confirm_action(
+        args,
+        _("Are you sure you want to delete webhook '{id}'? [y/N]: ").format(id=args.id),
+        fmt=fmt,
+        jq=jq,
+    ):
+        return
     adapter.delete_webhook(hook_id=args.id)
     output_result(
         _("Deleted webhook '{id}'.").format(id=args.id),

--- a/src/gfo/commands/wiki.py
+++ b/src/gfo/commands/wiki.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 
-from gfo.commands import get_adapter
+from gfo.commands import confirm_action, get_adapter
 from gfo.i18n import _
 from gfo.output import output, output_result
 
@@ -40,6 +40,13 @@ def handle_edit(args: argparse.Namespace, *, fmt: str, jq: str | None = None) ->
 def handle_delete(args: argparse.Namespace, *, fmt: str, jq: str | None = None) -> None:
     """gfo wiki delete <id> のハンドラ。"""
     adapter = get_adapter()
+    if not confirm_action(
+        args,
+        _("Are you sure you want to delete wiki page '{id}'? [y/N]: ").format(id=args.id),
+        fmt=fmt,
+        jq=jq,
+    ):
+        return
     adapter.delete_wiki_page(args.id)
     output_result(
         _("Deleted wiki page '{id}'.").format(id=args.id),

--- a/src/gfo/locale/ja/LC_MESSAGES/gfo.po
+++ b/src/gfo/locale/ja/LC_MESSAGES/gfo.po
@@ -2408,3 +2408,72 @@ msgstr "{service} でパイプラインをトリガーするには --workflow �
 
 msgid "Setup:\n  init             Initialize config (auto-detects from remote URL)\n  auth             Manage authentication tokens\n  completion       Generate shell completion script\n  config           Manage configuration\n\nWorkflow:\n  pr               Pull requests (list, create, merge, review)\n  issue            Issues (list, create, close, comment)\n  issue-template   List issue templates\n  ci               CI pipelines (list, view, trigger, logs)\n  status           Commit statuses (list, create)\n  notification     Notifications (list, read)\n\nRepository:\n  repo             Repositories (list, create, clone, edit, delete)\n  branch           Branches (list, create, delete)\n  tag              Tags (list, create, delete)\n  file             Repository files (get, put, delete)\n  release          Releases (list, create, edit, delete)\n  label            Labels (list, create, edit, clone)\n  milestone        Milestones (list, create, edit, close)\n  wiki             Wiki pages (list, create, edit, delete)\n\nSecurity:\n  collaborator     Collaborators (list, add, remove)\n  deploy-key       Deploy keys (list, view, create, delete)\n  ssh-key          SSH keys (list, view, create, delete)\n  gpg-key          GPG keys (list, view, create, delete)\n  secret           Secrets (list, set, delete)\n  variable         Variables (list, set, get, delete)\n  branch-protect   Branch protection rules (list, set, remove)\n  tag-protect      Tag protection rules (list, create, delete)\n\nOther:\n  user             User commands (whoami)\n  search           Search (repos, issues, prs, commits, code)\n  org              Organizations (list, view, members, repos, create, edit, delete)\n  package          Packages (list, view, delete)\n  browse           Open repository in browser\n  api              Send raw API requests (e.g. gfo api GET /repos/o/r)\n  batch            Batch PR operations (create multiple PRs)\n  schema           Show JSON Schema for commands\n\nGetting started:\n  gfo auth login                  Register authentication token\n  gfo init                        Initialize config (auto-detects from remote URL)\n\nExamples:\n  gfo pr list                     List pull requests\n  gfo issue create -t 'Bug'       Create an issue\n  gfo pr list -R github.com/o/r   List PRs of another repo (no init required)\n  gfo pr list --format json       Output as JSON\n\nSupported forges:\n  GitHub, GitLab, Gitea, Forgejo, Bitbucket,\n  Azure DevOps, Gogs, GitBucket, Backlog\n\nEnvironment variables (checked after 'gfo auth login' tokens):\n  GITHUB_TOKEN      GitHub          GITEA_TOKEN       Gitea/Forgejo/Gogs\n  GITLAB_TOKEN      GitLab          GITBUCKET_TOKEN   GitBucket\n  BITBUCKET_TOKEN   Bitbucket       BACKLOG_API_KEY   Backlog\n  AZURE_DEVOPS_PAT  Azure DevOps    GFO_TOKEN         Fallback (any service)\n\nBehavior variables:\n  GFO_NO_AUTO_JSON  Disable auto JSON output when stdout is not a TTY\n  GFO_RETRY_AFTER_MAX  Max seconds to honor a 429 Retry-After (default 300)\n\nRun 'gfo <command> -h' for details on each command."
 msgstr "セットアップ:\n  init             設定を初期化（remote URL から自動検出）\n  auth             認証トークンを管理\n  completion       シェル補完スクリプトを生成\n  config           設定を管理\n\nワークフロー:\n  pr               プルリクエスト（list, create, merge, review）\n  issue            Issue（list, create, close, comment）\n  issue-template   Issue テンプレートの一覧\n  ci               CI パイプライン（list, view, trigger, logs）\n  status           コミットステータス（list, create）\n  notification     通知（list, read）\n\nリポジトリ:\n  repo             リポジトリ（list, create, clone, edit, delete）\n  branch           ブランチ（list, create, delete）\n  tag              タグ（list, create, delete）\n  file             リポジトリのファイル（get, put, delete）\n  release          リリース（list, create, edit, delete）\n  label            ラベル（list, create, edit, clone）\n  milestone        マイルストーン（list, create, edit, close）\n  wiki             Wiki ページ（list, create, edit, delete）\n\nセキュリティ:\n  collaborator     コラボレーター（list, add, remove）\n  deploy-key       デプロイキー（list, view, create, delete）\n  ssh-key          SSH 鍵（list, view, create, delete）\n  gpg-key          GPG 鍵（list, view, create, delete）\n  secret           シークレット（list, set, delete）\n  variable         変数（list, set, get, delete）\n  branch-protect   ブランチ保護ルール（list, set, remove）\n  tag-protect      タグ保護ルール（list, create, delete）\n\nその他:\n  user             ユーザーコマンド（whoami）\n  search           検索（repos, issues, prs, commits, code）\n  org              組織（list, view, members, repos, create, edit, delete）\n  package          パッケージ（list, view, delete）\n  browse           リポジトリをブラウザで開く\n  api              未加工の API リクエスト（例: gfo api GET /repos/o/r）\n  batch            PR のバッチ操作（複数 PR の一括作成）\n  schema           コマンドの JSON Schema を表示\n\nはじめに:\n  gfo auth login                  認証トークンを登録\n  gfo init                        設定を初期化（remote URL から自動検出）\n\n使用例:\n  gfo pr list                     PR の一覧\n  gfo issue create -t 'Bug'       Issue を作成\n  gfo pr list -R github.com/o/r   別リポジトリの PR を表示（init 不要）\n  gfo pr list --format json       JSON で出力\n\n対応サービス:\n  GitHub, GitLab, Gitea, Forgejo, Bitbucket,\n  Azure DevOps, Gogs, GitBucket, Backlog\n\n環境変数（'gfo auth login' のトークンが優先）:\n  GITHUB_TOKEN      GitHub          GITEA_TOKEN       Gitea/Forgejo/Gogs\n  GITLAB_TOKEN      GitLab          GITBUCKET_TOKEN   GitBucket\n  BITBUCKET_TOKEN   Bitbucket       BACKLOG_API_KEY   Backlog\n  AZURE_DEVOPS_PAT  Azure DevOps    GFO_TOKEN         フォールバック（全サービス）\n\n動作設定の環境変数:\n  GFO_NO_AUTO_JSON  stdout が TTY でないときの自動 JSON 出力を無効化\n  GFO_RETRY_AFTER_MAX  429 の Retry-After を尊重する最大秒数（既定 300）\n\n詳細は 'gfo <command> -h' を参照してください。"
+
+msgid "Confirmation required. Re-run with --yes to skip the prompt in non-interactive mode."
+msgstr "確認が必要な操作です。非対話環境で実行するには --yes を付けて再実行してください。"
+
+msgid "Are you sure you want to delete issue #{number}? [y/N]: "
+msgstr "Issue #{number} を削除しますか？ [y/N]: "
+
+msgid "Are you sure you want to delete time entry '{entry_id}'? [y/N]: "
+msgstr "作業時間エントリ '{entry_id}' を削除しますか？ [y/N]: "
+
+msgid "Are you sure you want to delete comment '{comment_id}'? [y/N]: "
+msgstr "コメント '{comment_id}' を削除しますか？ [y/N]: "
+
+msgid "Are you sure you want to delete release '{tag}'? [y/N]: "
+msgstr "リリース '{tag}' を削除しますか？ [y/N]: "
+
+msgid "Are you sure you want to delete release asset '{asset_id}'? [y/N]: "
+msgstr "リリースアセット '{asset_id}' を削除しますか？ [y/N]: "
+
+msgid "Are you sure you want to delete label '{name}'? [y/N]: "
+msgstr "ラベル '{name}' を削除しますか？ [y/N]: "
+
+msgid "Are you sure you want to delete milestone '{number}'? [y/N]: "
+msgstr "マイルストーン '{number}' を削除しますか？ [y/N]: "
+
+msgid "Are you sure you want to delete branch '{name}'? [y/N]: "
+msgstr "ブランチ '{name}' を削除しますか？ [y/N]: "
+
+msgid "Are you sure you want to delete tag '{name}'? [y/N]: "
+msgstr "タグ '{name}' を削除しますか？ [y/N]: "
+
+msgid "Are you sure you want to delete file '{path}'? [y/N]: "
+msgstr "ファイル '{path}' を削除しますか？ [y/N]: "
+
+msgid "Are you sure you want to delete webhook '{id}'? [y/N]: "
+msgstr "Webhook '{id}' を削除しますか？ [y/N]: "
+
+msgid "Are you sure you want to delete deploy key '{id}'? [y/N]: "
+msgstr "デプロイキー '{id}' を削除しますか？ [y/N]: "
+
+msgid "Are you sure you want to delete SSH key '{id}'? [y/N]: "
+msgstr "SSH 鍵 '{id}' を削除しますか？ [y/N]: "
+
+msgid "Are you sure you want to delete GPG key '{id}'? [y/N]: "
+msgstr "GPG 鍵 '{id}' を削除しますか？ [y/N]: "
+
+msgid "Are you sure you want to remove collaborator '{username}'? [y/N]: "
+msgstr "コラボレーター '{username}' を削除しますか？ [y/N]: "
+
+msgid "Are you sure you want to delete pipeline run '{id}'? [y/N]: "
+msgstr "パイプライン実行 '{id}' を削除しますか？ [y/N]: "
+
+msgid "Are you sure you want to delete wiki page '{id}'? [y/N]: "
+msgstr "Wiki ページ '{id}' を削除しますか？ [y/N]: "
+
+msgid "Are you sure you want to remove branch protection for '{branch}'? [y/N]: "
+msgstr "'{branch}' のブランチ保護を解除しますか？ [y/N]: "
+
+msgid "Are you sure you want to delete tag protection '{id}'? [y/N]: "
+msgstr "タグ保護 '{id}' を削除しますか？ [y/N]: "
+
+msgid "Are you sure you want to delete secret '{name}'? [y/N]: "
+msgstr "シークレット '{name}' を削除しますか？ [y/N]: "
+
+msgid "Are you sure you want to delete variable '{name}'? [y/N]: "
+msgstr "変数 '{name}' を削除しますか？ [y/N]: "
+
+msgid "Are you sure you want to remove push mirror '{name}'? [y/N]: "
+msgstr "プッシュミラー '{name}' を削除しますか？ [y/N]: "

--- a/tests/test_commands/conftest.py
+++ b/tests/test_commands/conftest.py
@@ -40,6 +40,13 @@ def sample_pr():
     )
 
 
+@pytest.fixture
+def interactive_stdin():
+    """confirm_action の TTY 判定を対話扱いに差し替える（プロンプトテスト用）。"""
+    with patch("gfo.commands._stdin_is_interactive", return_value=True):
+        yield
+
+
 def make_args(**kwargs) -> argparse.Namespace:
     """argparse.Namespace を簡単に生成するヘルパー。"""
     return argparse.Namespace(**kwargs)

--- a/tests/test_commands/test_branch.py
+++ b/tests/test_commands/test_branch.py
@@ -78,7 +78,7 @@ class TestHandleCreate:
 class TestHandleDelete:
     def test_calls_delete_branch(self):
         with patch_adapter("gfo.commands.branch") as adapter:
-            args = make_args(name="feature/old")
+            args = make_args(name="feature/old", yes=True)
             branch_cmd.handle_delete(args, fmt="table")
         adapter.delete_branch.assert_called_once_with(name="feature/old")
 
@@ -86,7 +86,7 @@ class TestHandleDelete:
         """404 エラーが伝搬する。"""
         with patch_adapter("gfo.commands.branch") as adapter:
             adapter.delete_branch.side_effect = HttpError(404, "Not found")
-            args = make_args(name="nonexistent")
+            args = make_args(name="nonexistent", yes=True)
             with pytest.raises(HttpError) as exc_info:
                 branch_cmd.handle_delete(args, fmt="table")
             assert exc_info.value.status_code == 404
@@ -95,7 +95,7 @@ class TestHandleDelete:
         """403 保護されたブランチの削除が伝搬する。"""
         with patch_adapter("gfo.commands.branch") as adapter:
             adapter.delete_branch.side_effect = HttpError(403, "Protected branch")
-            args = make_args(name="main")
+            args = make_args(name="main", yes=True)
             with pytest.raises(HttpError) as exc_info:
                 branch_cmd.handle_delete(args, fmt="table")
             assert exc_info.value.status_code == 403
@@ -171,7 +171,7 @@ class TestHandleDeleteSuccessMessage:
     def test_delete_prints_success_message(self, capsys):
         """handle_delete が成功メッセージにブランチ名を含む。"""
         with patch_adapter("gfo.commands.branch"):
-            args = make_args(name="feature/old")
+            args = make_args(name="feature/old", yes=True)
             branch_cmd.handle_delete(args, fmt="table")
         out = capsys.readouterr().out
         assert "feature/old" in out
@@ -179,7 +179,7 @@ class TestHandleDeleteSuccessMessage:
     def test_delete_json_format(self, capsys):
         """fmt="json" で構造化 JSON（result / branch / message）が出力される。"""
         with patch_adapter("gfo.commands.branch"):
-            args = make_args(name="feature/old")
+            args = make_args(name="feature/old", yes=True)
             branch_cmd.handle_delete(args, fmt="json")
         out = capsys.readouterr().out
         data = json.loads(out)

--- a/tests/test_commands/test_branch_protect.py
+++ b/tests/test_commands/test_branch_protect.py
@@ -114,7 +114,7 @@ class TestHandleSet:
 class TestHandleRemove:
     def test_calls_remove(self, capsys):
         with patch_adapter("gfo.commands.branch_protect") as adapter:
-            args = make_args(branch="main")
+            args = make_args(branch="main", yes=True)
             bp_cmd.handle_remove(args, fmt="table")
         adapter.remove_branch_protection.assert_called_once_with("main")
         out = capsys.readouterr().out
@@ -124,7 +124,7 @@ class TestHandleRemove:
     def test_remove_json_format(self, capsys):
         """fmt="json" で構造化 JSON（result / branch / message）が出力される。"""
         with patch_adapter("gfo.commands.branch_protect"):
-            args = make_args(branch="main")
+            args = make_args(branch="main", yes=True)
             bp_cmd.handle_remove(args, fmt="json")
         out = capsys.readouterr().out
         data = json.loads(out)
@@ -135,6 +135,6 @@ class TestHandleRemove:
     def test_error_propagation(self):
         with patch_adapter("gfo.commands.branch_protect") as adapter:
             adapter.remove_branch_protection.side_effect = HttpError(404, "Not found")
-            args = make_args(branch="main")
+            args = make_args(branch="main", yes=True)
             with pytest.raises(HttpError):
                 bp_cmd.handle_remove(args, fmt="table")

--- a/tests/test_commands/test_ci.py
+++ b/tests/test_commands/test_ci.py
@@ -91,13 +91,13 @@ class TestHandleCancel:
 class TestHandleDelete:
     def test_calls_delete_pipeline_run(self):
         with patch_adapter("gfo.commands.ci") as adapter:
-            args = make_args(id="456")
+            args = make_args(id="456", yes=True)
             ci_cmd.handle_delete(args, fmt="table")
         adapter.delete_pipeline_run.assert_called_once_with("456")
 
     def test_prints_message(self, capsys):
         with patch_adapter("gfo.commands.ci"):
-            args = make_args(id="789")
+            args = make_args(id="789", yes=True)
             ci_cmd.handle_delete(args, fmt="table")
         out = capsys.readouterr().out
         assert "789" in out
@@ -105,7 +105,7 @@ class TestHandleDelete:
     def test_error_propagation(self):
         with patch_adapter("gfo.commands.ci") as adapter:
             adapter.delete_pipeline_run.side_effect = GfoError("delete failed")
-            args = make_args(id="123")
+            args = make_args(id="123", yes=True)
             with pytest.raises(GfoError, match="delete failed"):
                 ci_cmd.handle_delete(args, fmt="table")
 

--- a/tests/test_commands/test_collaborator.py
+++ b/tests/test_commands/test_collaborator.py
@@ -108,7 +108,7 @@ class TestHandleAdd:
 class TestHandleRemove:
     def test_calls_remove_collaborator(self):
         with patch_adapter("gfo.commands.collaborator") as adapter:
-            args = make_args(username="charlie")
+            args = make_args(username="charlie", yes=True)
             collab_cmd.handle_remove(args, fmt="table")
         adapter.remove_collaborator.assert_called_once_with(username="charlie")
 
@@ -116,7 +116,7 @@ class TestHandleRemove:
         """HttpError(404) がそのまま伝搬する。"""
         with patch_adapter("gfo.commands.collaborator") as adapter:
             adapter.remove_collaborator.side_effect = HttpError(404, "Not Found")
-            args = make_args(username="nonexistent")
+            args = make_args(username="nonexistent", yes=True)
             with pytest.raises(HttpError) as exc_info:
                 collab_cmd.handle_remove(args, fmt="table")
             assert exc_info.value.status_code == 404
@@ -136,7 +136,7 @@ class TestHandleRemoveSuccessMessage:
     def test_remove_prints_success_message(self, capsys):
         """handle_remove が成功メッセージに username を含む。"""
         with patch_adapter("gfo.commands.collaborator"):
-            args = make_args(username="charlie")
+            args = make_args(username="charlie", yes=True)
             collab_cmd.handle_remove(args, fmt="table")
         out = capsys.readouterr().out
         assert "charlie" in out

--- a/tests/test_commands/test_comment.py
+++ b/tests/test_commands/test_comment.py
@@ -60,13 +60,13 @@ class TestHandlePrComment:
 
     def test_delete_calls_delete_comment(self):
         with patch_adapter("gfo.commands.comment") as adapter:
-            args = make_args(comment_action="delete", comment_id=42)
+            args = make_args(comment_action="delete", comment_id=42, yes=True)
             comment_cmd.handle_pr_comment(args, fmt="table")
         adapter.delete_comment.assert_called_once_with("pr", 42)
 
     def test_delete_prints_success_message(self, capsys):
         with patch_adapter("gfo.commands.comment") as adapter:
-            args = make_args(comment_action="delete", comment_id=42)
+            args = make_args(comment_action="delete", comment_id=42, yes=True)
             comment_cmd.handle_pr_comment(args, fmt="table")
         adapter.delete_comment.assert_called_once_with("pr", 42)
         out = capsys.readouterr().out
@@ -74,7 +74,7 @@ class TestHandlePrComment:
 
     def test_delete_json_format(self, capsys):
         with patch_adapter("gfo.commands.comment") as adapter:
-            args = make_args(comment_action="delete", comment_id=42)
+            args = make_args(comment_action="delete", comment_id=42, yes=True)
             comment_cmd.handle_pr_comment(args, fmt="json")
         adapter.delete_comment.assert_called_once_with("pr", 42)
         data = json.loads(capsys.readouterr().out)
@@ -130,7 +130,7 @@ class TestHandleIssueComment:
 
     def test_delete_calls_delete_comment(self):
         with patch_adapter("gfo.commands.comment") as adapter:
-            args = make_args(comment_action="delete", comment_id=10)
+            args = make_args(comment_action="delete", comment_id=10, yes=True)
             comment_cmd.handle_issue_comment(args, fmt="table")
         adapter.delete_comment.assert_called_once_with("issue", 10)
 

--- a/tests/test_commands/test_confirm.py
+++ b/tests/test_commands/test_confirm.py
@@ -1,0 +1,158 @@
+"""confirm_action ヘルパーと破壊的コマンドの確認ガードのテスト。"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from unittest.mock import patch
+
+import pytest
+
+from gfo.commands import confirm_action
+from gfo.exceptions import ConfigError
+from tests.test_commands.conftest import make_args, patch_adapter
+
+
+class TestConfirmAction:
+    def test_yes_flag_skips_prompt(self):
+        """--yes 指定時は input() を呼ばずに True を返す。"""
+        with patch("builtins.input", side_effect=AssertionError("input must not be called")):
+            assert confirm_action(make_args(yes=True), "sure? ", fmt="table") is True
+
+    def test_missing_yes_attr_treated_as_false(self):
+        """args に yes 属性がない場合も --yes なしとして扱う（非対話では ConfigError）。"""
+        with pytest.raises(ConfigError, match="--yes"):
+            confirm_action(make_args(), "sure? ", fmt="table")
+
+    def test_non_interactive_without_yes_raises(self):
+        """非対話環境（stdin が TTY でない）ではプロンプトを出さず ConfigError。"""
+        with pytest.raises(ConfigError, match="--yes"):
+            confirm_action(make_args(yes=False), "sure? ", fmt="table")
+
+    @pytest.mark.parametrize("answer", ["y", "yes", "Y", "YES", " y "])
+    def test_accepts_yes_answers(self, interactive_stdin, answer):
+        with patch("builtins.input", return_value=answer):
+            assert confirm_action(make_args(yes=False), "sure? ", fmt="table") is True
+
+    @pytest.mark.parametrize("answer", ["", "n", "no", "nope"])
+    def test_rejects_other_answers(self, interactive_stdin, answer, capsys):
+        with patch("builtins.input", return_value=answer):
+            assert confirm_action(make_args(yes=False), "sure? ", fmt="table") is False
+        assert "Aborted" in capsys.readouterr().out
+
+    def test_reject_json_format(self, interactive_stdin, capsys):
+        """fmt="json" で拒否すると result="aborted" の JSON が出力される。"""
+        with patch("builtins.input", return_value="n"):
+            assert confirm_action(make_args(yes=False), "sure? ", fmt="json") is False
+        data = json.loads(capsys.readouterr().out)
+        assert data["result"] == "aborted"
+
+
+# (モジュール, ハンドラ名, args, 呼ばれてはいけないアダプターメソッド)
+_DESTRUCTIVE_CASES = [
+    ("gfo.commands.issue", "handle_delete", {"number": 1}, "delete_issue"),
+    (
+        "gfo.commands.issue",
+        "handle_time",
+        {"time_action": "delete", "number": 1, "entry_id": "42"},
+        "delete_time_entry",
+    ),
+    (
+        "gfo.commands.comment",
+        "handle_pr_comment",
+        {"comment_action": "delete", "comment_id": 42},
+        "delete_comment",
+    ),
+    (
+        "gfo.commands.comment",
+        "handle_issue_comment",
+        {"comment_action": "delete", "comment_id": 42},
+        "delete_comment",
+    ),
+    ("gfo.commands.release", "handle_delete", {"tag": "v1.0.0"}, "delete_release"),
+    (
+        "gfo.commands.release",
+        "handle_asset",
+        {"asset_action": "delete", "tag": "v1.0.0", "asset_id": 7},
+        "delete_release_asset",
+    ),
+    ("gfo.commands.label", "handle_delete", {"name": "bug"}, "delete_label"),
+    ("gfo.commands.milestone", "handle_delete", {"number": 3}, "delete_milestone"),
+    ("gfo.commands.branch", "handle_delete", {"name": "feature/x"}, "delete_branch"),
+    ("gfo.commands.tag", "handle_delete", {"name": "v1"}, "delete_tag"),
+    (
+        "gfo.commands.file",
+        "handle_delete",
+        {"path": "a.txt", "branch": None, "message": "remove"},
+        "delete_file",
+    ),
+    ("gfo.commands.webhook", "handle_delete", {"id": 5}, "delete_webhook"),
+    ("gfo.commands.deploy_key", "handle_delete", {"id": 5}, "delete_deploy_key"),
+    ("gfo.commands.ssh_key", "handle_delete", {"id": 5}, "delete_ssh_key"),
+    ("gfo.commands.gpg_key", "handle_delete", {"id": 5}, "delete_gpg_key"),
+    ("gfo.commands.collaborator", "handle_remove", {"username": "alice"}, "remove_collaborator"),
+    ("gfo.commands.ci", "handle_delete", {"id": 9}, "delete_pipeline_run"),
+    ("gfo.commands.wiki", "handle_delete", {"id": "Home"}, "delete_wiki_page"),
+    (
+        "gfo.commands.branch_protect",
+        "handle_remove",
+        {"branch": "main"},
+        "remove_branch_protection",
+    ),
+    ("gfo.commands.tag_protect", "handle_delete", {"id": 2}, "delete_tag_protection"),
+    ("gfo.commands.secret", "handle_delete", {"name": "TOKEN"}, "delete_secret"),
+    ("gfo.commands.variable", "handle_delete", {"name": "VAR"}, "delete_variable"),
+    (
+        "gfo.commands.repo",
+        "handle_mirror",
+        {"mirror_action": "remove", "mirror_name": "m1"},
+        "delete_push_mirror",
+    ),
+    ("gfo.commands.repo", "handle_delete", {}, "delete_repository"),
+    ("gfo.commands.repo", "handle_archive", {}, "archive_repository"),
+    (
+        "gfo.commands.repo",
+        "handle_transfer",
+        {"new_owner": "new-owner", "team_id": None},
+        "transfer_repository",
+    ),
+    ("gfo.commands.org", "handle_delete", {"name": "my-org"}, "delete_organization"),
+    (
+        "gfo.commands.package",
+        "handle_delete",
+        {"package_type": "npm", "name": "pkg", "version": "1.0.0"},
+        "delete_package",
+    ),
+]
+
+_CASE_IDS = [f"{m.rsplit('.', 1)[-1]}:{h}:{meth}" for m, h, _, meth in _DESTRUCTIVE_CASES]
+
+
+class TestDestructiveCommandsRequireConfirmation:
+    @pytest.mark.parametrize(
+        ("module", "handler", "kwargs", "method"), _DESTRUCTIVE_CASES, ids=_CASE_IDS
+    )
+    def test_non_interactive_without_yes_raises(self, module, handler, kwargs, method):
+        """非対話環境で --yes なしの破壊的操作は ConfigError（アダプター未呼び出し）。"""
+        mod = importlib.import_module(module)
+        with patch_adapter(module) as adapter:
+            with pytest.raises(ConfigError, match="--yes"):
+                getattr(mod, handler)(make_args(**kwargs), fmt="table")
+        getattr(adapter, method).assert_not_called()
+
+    def test_prompt_accept_runs_delete(self, interactive_stdin):
+        """代表例（issue delete）: プロンプトに "y" で削除が実行される。"""
+        mod = importlib.import_module("gfo.commands.issue")
+        with patch_adapter("gfo.commands.issue") as adapter:
+            with patch("builtins.input", return_value="y"):
+                mod.handle_delete(make_args(number=1, yes=False), fmt="table")
+        adapter.delete_issue.assert_called_once_with(1)
+
+    def test_prompt_reject_aborts(self, interactive_stdin, capsys):
+        """代表例（issue delete）: プロンプト拒否で "Aborted." が出力され削除されない。"""
+        mod = importlib.import_module("gfo.commands.issue")
+        with patch_adapter("gfo.commands.issue") as adapter:
+            with patch("builtins.input", return_value="n"):
+                mod.handle_delete(make_args(number=1, yes=False), fmt="table")
+        adapter.delete_issue.assert_not_called()
+        assert "Aborted" in capsys.readouterr().out

--- a/tests/test_commands/test_deploy_key.py
+++ b/tests/test_commands/test_deploy_key.py
@@ -80,14 +80,14 @@ class TestHandleCreate:
 class TestHandleDelete:
     def test_calls_delete_deploy_key(self):
         with patch_adapter("gfo.commands.deploy_key") as adapter:
-            args = make_args(id=1)
+            args = make_args(id=1, yes=True)
             deploy_key_cmd.handle_delete(args, fmt="table")
         adapter.delete_deploy_key.assert_called_once_with(key_id=1)
 
     def test_delete_prints_success_message(self, capsys):
         """handle_delete が成功メッセージに id を含む。"""
         with patch_adapter("gfo.commands.deploy_key"):
-            args = make_args(id=99)
+            args = make_args(id=99, yes=True)
             deploy_key_cmd.handle_delete(args, fmt="table")
         out = capsys.readouterr().out
         assert "99" in out
@@ -95,7 +95,7 @@ class TestHandleDelete:
     def test_json_format(self, capsys):
         """fmt="json" のとき構造化 JSON が出力される。"""
         with patch_adapter("gfo.commands.deploy_key"):
-            args = make_args(id=99)
+            args = make_args(id=99, yes=True)
             deploy_key_cmd.handle_delete(args, fmt="json")
         out = capsys.readouterr().out
         data = json.loads(out)

--- a/tests/test_commands/test_file_cmd.py
+++ b/tests/test_commands/test_file_cmd.py
@@ -124,7 +124,7 @@ class TestHandleDelete:
     def test_calls_delete_file(self):
         with patch_adapter("gfo.commands.file") as adapter:
             adapter.get_file_content.return_value = ("content", "deadbeef")
-            args = make_args(path="old.txt", message="Remove file", branch=None)
+            args = make_args(path="old.txt", message="Remove file", branch=None, yes=True)
             file_cmd.handle_delete(args, fmt="table")
         adapter.delete_file.assert_called_once_with(
             "old.txt", sha="deadbeef", message="Remove file", branch=None
@@ -134,7 +134,7 @@ class TestHandleDelete:
         """handle_delete で NotFoundError が伝搬する。"""
         with patch_adapter("gfo.commands.file") as adapter:
             adapter.get_file_content.side_effect = NotFoundError()
-            args = make_args(path="missing.txt", message="Delete", branch=None)
+            args = make_args(path="missing.txt", message="Delete", branch=None, yes=True)
             with pytest.raises(NotFoundError):
                 file_cmd.handle_delete(args, fmt="table")
 
@@ -143,7 +143,7 @@ class TestHandleDelete:
         with patch_adapter("gfo.commands.file") as adapter:
             adapter.get_file_content.return_value = ("content", "sha123")
             adapter.delete_file.side_effect = HttpError(403, "Forbidden")
-            args = make_args(path="protected.txt", message="Delete", branch=None)
+            args = make_args(path="protected.txt", message="Delete", branch=None, yes=True)
             with pytest.raises(HttpError) as exc_info:
                 file_cmd.handle_delete(args, fmt="table")
             assert exc_info.value.status_code == 403
@@ -214,7 +214,7 @@ class TestHandleDeleteSuccessMessage:
         """handle_delete が成功メッセージに path を含む。"""
         with patch_adapter("gfo.commands.file") as adapter:
             adapter.get_file_content.return_value = ("content", "deadbeef")
-            args = make_args(path="old.txt", message="Remove file", branch=None)
+            args = make_args(path="old.txt", message="Remove file", branch=None, yes=True)
             file_cmd.handle_delete(args, fmt="table")
         out = capsys.readouterr().out
         assert "old.txt" in out
@@ -223,7 +223,7 @@ class TestHandleDeleteSuccessMessage:
         """fmt="json" で構造化 JSON（result / path / message）が出力される。"""
         with patch_adapter("gfo.commands.file") as adapter:
             adapter.get_file_content.return_value = ("content", "deadbeef")
-            args = make_args(path="old.txt", message="Remove file", branch=None)
+            args = make_args(path="old.txt", message="Remove file", branch=None, yes=True)
             file_cmd.handle_delete(args, fmt="json")
         out = capsys.readouterr().out
         data = json.loads(out)

--- a/tests/test_commands/test_gpg_key.py
+++ b/tests/test_commands/test_gpg_key.py
@@ -103,7 +103,7 @@ class TestHandleCreate:
 class TestHandleDelete:
     def test_calls_delete_gpg_key(self, capsys):
         with patch_adapter("gfo.commands.gpg_key") as adapter:
-            args = make_args(id=1)
+            args = make_args(id=1, yes=True)
             gpg_key_cmd.handle_delete(args, fmt="table")
         adapter.delete_gpg_key.assert_called_once_with(key_id=1)
         out = capsys.readouterr().out
@@ -113,7 +113,7 @@ class TestHandleDelete:
     def test_json_format(self, capsys):
         """fmt="json" のとき構造化 JSON が出力される。"""
         with patch_adapter("gfo.commands.gpg_key"):
-            args = make_args(id=1)
+            args = make_args(id=1, yes=True)
             gpg_key_cmd.handle_delete(args, fmt="json")
         out = capsys.readouterr().out
         data = json.loads(out)
@@ -123,13 +123,13 @@ class TestHandleDelete:
 
     def test_calls_delete_gpg_key_string_id(self):
         with patch_adapter("gfo.commands.gpg_key") as adapter:
-            args = make_args(id="abc-123")
+            args = make_args(id="abc-123", yes=True)
             gpg_key_cmd.handle_delete(args, fmt="table")
         adapter.delete_gpg_key.assert_called_once_with(key_id="abc-123")
 
     def test_error_propagation(self):
         with patch_adapter("gfo.commands.gpg_key") as adapter:
             adapter.delete_gpg_key.side_effect = HttpError(404, "Not found")
-            args = make_args(id=1)
+            args = make_args(id=1, yes=True)
             with pytest.raises(HttpError):
                 gpg_key_cmd.handle_delete(args, fmt="table")

--- a/tests/test_commands/test_issue.py
+++ b/tests/test_commands/test_issue.py
@@ -522,14 +522,14 @@ class TestHandleDelete:
         self.adapter = _make_adapter(self.issue)
 
     def test_calls_delete_issue(self):
-        args = make_args(number=5)
+        args = make_args(number=5, yes=True)
         with _patch_all(self.config, self.adapter):
             issue_cmd.handle_delete(args, fmt="table")
 
         self.adapter.delete_issue.assert_called_once_with(5)
 
     def test_prints_confirmation(self, capsys):
-        args = make_args(number=5)
+        args = make_args(number=5, yes=True)
         with _patch_all(self.config, self.adapter):
             issue_cmd.handle_delete(args, fmt="table")
 
@@ -722,7 +722,7 @@ class TestHandleTime:
 
     def test_delete_time_entry(self, capsys):
         with patch_adapter("gfo.commands.issue") as adapter:
-            args = make_args(time_action="delete", number=1, entry_id="42")
+            args = make_args(time_action="delete", number=1, entry_id="42", yes=True)
             issue_cmd.handle_time(args, fmt="table")
         adapter.delete_time_entry.assert_called_once_with(1, "42")
 

--- a/tests/test_commands/test_label.py
+++ b/tests/test_commands/test_label.py
@@ -227,14 +227,14 @@ class TestHandleDelete:
         self.adapter = _make_adapter(self.label)
 
     def test_delete_calls_adapter(self, sample_config):
-        args = make_args(name="bug")
+        args = make_args(name="bug", yes=True)
         with _patch_all(sample_config, self.adapter):
             label_cmd.handle_delete(args, fmt="table")
 
         self.adapter.delete_label.assert_called_once_with(name="bug")
 
     def test_delete_prints_message(self, sample_config, capsys):
-        args = make_args(name="bug")
+        args = make_args(name="bug", yes=True)
         with _patch_all(sample_config, self.adapter):
             label_cmd.handle_delete(args, fmt="table")
 
@@ -243,7 +243,7 @@ class TestHandleDelete:
         assert "Deleted" in out
 
     def test_delete_json_format(self, sample_config, capsys):
-        args = make_args(name="bug")
+        args = make_args(name="bug", yes=True)
         with _patch_all(sample_config, self.adapter):
             label_cmd.handle_delete(args, fmt="json")
 
@@ -259,7 +259,7 @@ class TestHandleDelete:
                 label_cmd.handle_delete(args, fmt="table")
 
     def test_name_stripped_before_call(self, sample_config):
-        args = make_args(name="  bug  ")
+        args = make_args(name="  bug  ", yes=True)
         with _patch_all(sample_config, self.adapter):
             label_cmd.handle_delete(args, fmt="table")
 

--- a/tests/test_commands/test_milestone.py
+++ b/tests/test_commands/test_milestone.py
@@ -210,14 +210,14 @@ class TestHandleDelete:
         self.adapter = _make_adapter(self.milestone)
 
     def test_delete_calls_adapter(self, sample_config):
-        args = make_args(number=3)
+        args = make_args(number=3, yes=True)
         with _patch_all(sample_config, self.adapter):
             milestone_cmd.handle_delete(args, fmt="table")
 
         self.adapter.delete_milestone.assert_called_once_with(number=3)
 
     def test_delete_prints_message(self, sample_config, capsys):
-        args = make_args(number=5)
+        args = make_args(number=5, yes=True)
         with _patch_all(sample_config, self.adapter):
             milestone_cmd.handle_delete(args, fmt="table")
 
@@ -226,7 +226,7 @@ class TestHandleDelete:
         assert "Deleted" in out
 
     def test_delete_json_format(self, sample_config, capsys):
-        args = make_args(number=5)
+        args = make_args(number=5, yes=True)
         with _patch_all(sample_config, self.adapter):
             milestone_cmd.handle_delete(args, fmt="json")
 

--- a/tests/test_commands/test_org.py
+++ b/tests/test_commands/test_org.py
@@ -246,14 +246,14 @@ class TestHandleDelete:
         out = capsys.readouterr().out
         assert "my-org" in out
 
-    def test_confirmation_prompt_accepted(self, capsys):
+    def test_confirmation_prompt_accepted(self, capsys, interactive_stdin):
         with patch_adapter("gfo.commands.org") as adapter:
             args = make_args(name="my-org", yes=False)
             with patch("builtins.input", return_value="y"):
                 org_cmd.handle_delete(args, fmt="table")
         adapter.delete_organization.assert_called_once_with("my-org")
 
-    def test_confirmation_prompt_rejected(self, capsys):
+    def test_confirmation_prompt_rejected(self, capsys, interactive_stdin):
         with patch_adapter("gfo.commands.org") as adapter:
             args = make_args(name="my-org", yes=False)
             with patch("builtins.input", return_value="n"):

--- a/tests/test_commands/test_package.py
+++ b/tests/test_commands/test_package.py
@@ -81,7 +81,7 @@ class TestHandleDelete:
             package_cmd.handle_delete(args, fmt="table")
         adapter.delete_package.assert_called_once_with("npm", "test-pkg", "1.0.0")
 
-    def test_delete_confirm_yes(self, capsys):
+    def test_delete_confirm_yes(self, capsys, interactive_stdin):
         """builtins.input を "y" にパッチ → delete_package() が呼び出される。"""
         from unittest.mock import patch
 
@@ -93,7 +93,7 @@ class TestHandleDelete:
         out = capsys.readouterr().out
         assert "Deleted" in out
 
-    def test_delete_confirm_no(self, capsys):
+    def test_delete_confirm_no(self, capsys, interactive_stdin):
         """builtins.input を "n" にパッチ → "Aborted." 出力、delete_package 未呼び出し。"""
         from unittest.mock import patch
 
@@ -105,7 +105,7 @@ class TestHandleDelete:
         out = capsys.readouterr().out
         assert "Aborted" in out
 
-    def test_delete_confirm_empty(self, capsys):
+    def test_delete_confirm_empty(self, capsys, interactive_stdin):
         """builtins.input を "" にパッチ → Aborted (y/yes 以外は拒否)。"""
         from unittest.mock import patch
 

--- a/tests/test_commands/test_release.py
+++ b/tests/test_commands/test_release.py
@@ -445,14 +445,14 @@ class TestHandleDelete:
         self.adapter = _make_adapter(self.release)
 
     def test_delete_calls_adapter(self, sample_config):
-        args = make_args(tag="v1.0.0")
+        args = make_args(tag="v1.0.0", yes=True)
         with _patch_all(sample_config, self.adapter):
             release_cmd.handle_delete(args, fmt="table")
 
         self.adapter.delete_release.assert_called_once_with(tag="v1.0.0")
 
     def test_delete_prints_message(self, sample_config, capsys):
-        args = make_args(tag="v1.0.0")
+        args = make_args(tag="v1.0.0", yes=True)
         with _patch_all(sample_config, self.adapter):
             release_cmd.handle_delete(args, fmt="table")
 
@@ -462,7 +462,7 @@ class TestHandleDelete:
 
     def test_delete_json_format(self, sample_config, capsys):
         """fmt="json" で構造化 JSON（result / tag / message）が出力される。"""
-        args = make_args(tag="v1.0.0")
+        args = make_args(tag="v1.0.0", yes=True)
         with _patch_all(sample_config, self.adapter):
             release_cmd.handle_delete(args, fmt="json")
 
@@ -816,7 +816,7 @@ class TestHandleAsset:
         )
 
     def test_asset_delete(self, sample_config, capsys):
-        args = make_args(asset_action="delete", tag="v1.0.0", asset_id="1")
+        args = make_args(asset_action="delete", tag="v1.0.0", asset_id="1", yes=True)
         with _patch_all(sample_config, self.adapter):
             release_cmd.handle_asset(args, fmt="table")
 
@@ -824,7 +824,7 @@ class TestHandleAsset:
 
     def test_asset_delete_json_format(self, sample_config, capsys):
         """fmt="json" で構造化 JSON（result / asset_id / message）が出力される。"""
-        args = make_args(asset_action="delete", tag="v1.0.0", asset_id="1")
+        args = make_args(asset_action="delete", tag="v1.0.0", asset_id="1", yes=True)
         with _patch_all(sample_config, self.adapter):
             release_cmd.handle_asset(args, fmt="json")
 

--- a/tests/test_commands/test_repo.py
+++ b/tests/test_commands/test_repo.py
@@ -865,7 +865,7 @@ class TestHandleDelete:
         out = capsys.readouterr().out
         assert "test-owner/test-repo" in out
 
-    def test_delete_confirmation_yes(self, sample_config, mock_adapter, capsys):
+    def test_delete_confirmation_yes(self, sample_config, mock_adapter, capsys, interactive_stdin):
         args = make_args(yes=False)
         mock_adapter.owner = "test-owner"
         mock_adapter.repo = "test-repo"
@@ -874,7 +874,7 @@ class TestHandleDelete:
 
         mock_adapter.delete_repository.assert_called_once()
 
-    def test_delete_confirmation_no(self, sample_config, mock_adapter, capsys):
+    def test_delete_confirmation_no(self, sample_config, mock_adapter, capsys, interactive_stdin):
         args = make_args(yes=False)
         mock_adapter.owner = "test-owner"
         mock_adapter.repo = "test-repo"
@@ -909,7 +909,9 @@ class TestHandleDelete:
         assert data["repository"] == "my-org/my-repo"
         assert data["message"]
 
-    def test_delete_aborted_json_format(self, sample_config, mock_adapter, capsys):
+    def test_delete_aborted_json_format(
+        self, sample_config, mock_adapter, capsys, interactive_stdin
+    ):
         """fmt="json" で確認を拒否すると result="aborted" の JSON が出力される。"""
         args = make_args(yes=False)
         mock_adapter.owner = "my-org"
@@ -1120,7 +1122,7 @@ class TestHandleArchive:
         out = capsys.readouterr().out
         assert "Archived" in out
 
-    def test_archive_confirmation_no(self, sample_config, capsys):
+    def test_archive_confirmation_no(self, sample_config, capsys, interactive_stdin):
         adapter = MagicMock()
         adapter.owner = "test-owner"
         adapter.repo = "test-repo"
@@ -1135,7 +1137,7 @@ class TestHandleArchive:
         out = capsys.readouterr().out
         assert "Aborted" in out
 
-    def test_archive_confirmation_yes(self, sample_config, capsys):
+    def test_archive_confirmation_yes(self, sample_config, capsys, interactive_stdin):
         adapter = MagicMock()
         adapter.owner = "test-owner"
         adapter.repo = "test-repo"
@@ -1412,7 +1414,9 @@ class TestHandleTransfer:
             repo_cmd.handle_transfer(args, fmt="table")
         mock_adapter.transfer_repository.assert_called_once_with("new-owner", team_ids=None)
 
-    def test_transfer_confirmation_yes(self, sample_config, mock_adapter, capsys):
+    def test_transfer_confirmation_yes(
+        self, sample_config, mock_adapter, capsys, interactive_stdin
+    ):
         """ "y" → transfer_repository() 呼び出し。"""
         mock_adapter.owner = "test-owner"
         mock_adapter.repo = "test-repo"
@@ -1421,7 +1425,7 @@ class TestHandleTransfer:
             repo_cmd.handle_transfer(args, fmt="table")
         mock_adapter.transfer_repository.assert_called_once_with("new-owner", team_ids=None)
 
-    def test_transfer_confirmation_no(self, sample_config, mock_adapter, capsys):
+    def test_transfer_confirmation_no(self, sample_config, mock_adapter, capsys, interactive_stdin):
         """ "n" → "Aborted." 出力、未呼び出し。"""
         mock_adapter.owner = "test-owner"
         mock_adapter.repo = "test-repo"

--- a/tests/test_commands/test_secret.py
+++ b/tests/test_commands/test_secret.py
@@ -111,14 +111,14 @@ class TestHandleSet:
 class TestHandleDelete:
     def test_calls_delete(self):
         with patch_adapter("gfo.commands.secret") as adapter:
-            args = make_args(name="MY_SECRET")
+            args = make_args(name="MY_SECRET", yes=True)
             secret_cmd.handle_delete(args, fmt="table")
         adapter.delete_secret.assert_called_once_with("MY_SECRET", scope=None)
 
     def test_json_format(self, capsys):
         """fmt="json" のとき構造化 JSON が出力される。"""
         with patch_adapter("gfo.commands.secret"):
-            args = make_args(name="MY_SECRET")
+            args = make_args(name="MY_SECRET", yes=True)
             secret_cmd.handle_delete(args, fmt="json")
         out = capsys.readouterr().out
         data = json.loads(out)
@@ -129,7 +129,7 @@ class TestHandleDelete:
     def test_error_propagation(self):
         with patch_adapter("gfo.commands.secret") as adapter:
             adapter.delete_secret.side_effect = HttpError(404, "Not found")
-            args = make_args(name="MY_SECRET")
+            args = make_args(name="MY_SECRET", yes=True)
             with pytest.raises(HttpError):
                 secret_cmd.handle_delete(args, fmt="table")
 
@@ -153,6 +153,6 @@ class TestOrgScope:
 
     def test_delete_org_secret(self):
         with patch_adapter("gfo.commands.secret") as adapter:
-            args = make_args(name="ORG_SECRET", org="my-org")
+            args = make_args(name="ORG_SECRET", org="my-org", yes=True)
             secret_cmd.handle_delete(args, fmt="table")
         adapter.delete_secret.assert_called_once_with("ORG_SECRET", scope="my-org")

--- a/tests/test_commands/test_ssh_key.py
+++ b/tests/test_commands/test_ssh_key.py
@@ -95,7 +95,7 @@ class TestHandleCreate:
 class TestHandleDelete:
     def test_calls_delete_ssh_key(self, capsys):
         with patch_adapter("gfo.commands.ssh_key") as adapter:
-            args = make_args(id=1)
+            args = make_args(id=1, yes=True)
             ssh_key_cmd.handle_delete(args, fmt="table")
         adapter.delete_ssh_key.assert_called_once_with(key_id=1)
         out = capsys.readouterr().out
@@ -105,7 +105,7 @@ class TestHandleDelete:
     def test_json_format(self, capsys):
         """fmt="json" のとき構造化 JSON が出力される。"""
         with patch_adapter("gfo.commands.ssh_key"):
-            args = make_args(id=1)
+            args = make_args(id=1, yes=True)
             ssh_key_cmd.handle_delete(args, fmt="json")
         out = capsys.readouterr().out
         data = json.loads(out)
@@ -115,13 +115,13 @@ class TestHandleDelete:
 
     def test_calls_delete_ssh_key_string_id(self):
         with patch_adapter("gfo.commands.ssh_key") as adapter:
-            args = make_args(id="abc-123")
+            args = make_args(id="abc-123", yes=True)
             ssh_key_cmd.handle_delete(args, fmt="table")
         adapter.delete_ssh_key.assert_called_once_with(key_id="abc-123")
 
     def test_error_propagation(self):
         with patch_adapter("gfo.commands.ssh_key") as adapter:
             adapter.delete_ssh_key.side_effect = HttpError(404, "Not found")
-            args = make_args(id=1)
+            args = make_args(id=1, yes=True)
             with pytest.raises(HttpError):
                 ssh_key_cmd.handle_delete(args, fmt="table")

--- a/tests/test_commands/test_tag.py
+++ b/tests/test_commands/test_tag.py
@@ -78,7 +78,7 @@ class TestHandleCreate:
 class TestHandleDelete:
     def test_calls_delete_tag(self):
         with patch_adapter("gfo.commands.tag") as adapter:
-            args = make_args(name="v1.0.0")
+            args = make_args(name="v1.0.0", yes=True)
             tag_cmd.handle_delete(args, fmt="table")
         adapter.delete_tag.assert_called_once_with(name="v1.0.0")
 
@@ -86,7 +86,7 @@ class TestHandleDelete:
         """404 エラーが伝搬する。"""
         with patch_adapter("gfo.commands.tag") as adapter:
             adapter.delete_tag.side_effect = HttpError(404, "Not found")
-            args = make_args(name="nonexistent")
+            args = make_args(name="nonexistent", yes=True)
             with pytest.raises(HttpError) as exc_info:
                 tag_cmd.handle_delete(args, fmt="table")
             assert exc_info.value.status_code == 404
@@ -170,7 +170,7 @@ class TestHandleDeleteSuccessMessage:
     def test_delete_prints_success_message(self, capsys):
         """handle_delete が成功メッセージにタグ名を含む。"""
         with patch_adapter("gfo.commands.tag"):
-            args = make_args(name="v1.0.0")
+            args = make_args(name="v1.0.0", yes=True)
             tag_cmd.handle_delete(args, fmt="table")
         out = capsys.readouterr().out
         assert "v1.0.0" in out
@@ -178,7 +178,7 @@ class TestHandleDeleteSuccessMessage:
     def test_delete_json_format(self, capsys):
         """fmt="json" で構造化 JSON（result / tag / message）が出力される。"""
         with patch_adapter("gfo.commands.tag"):
-            args = make_args(name="v1.0.0")
+            args = make_args(name="v1.0.0", yes=True)
             tag_cmd.handle_delete(args, fmt="json")
         out = capsys.readouterr().out
         data = json.loads(out)

--- a/tests/test_commands/test_tag_protect.py
+++ b/tests/test_commands/test_tag_protect.py
@@ -127,7 +127,7 @@ class TestHandleEdit:
 class TestHandleDelete:
     def test_calls_delete(self, capsys):
         with patch_adapter("gfo.commands.tag_protect") as adapter:
-            args = make_args(id=1)
+            args = make_args(id=1, yes=True)
             tp_cmd.handle_delete(args, fmt="table")
         adapter.delete_tag_protection.assert_called_once_with(1)
         out = capsys.readouterr().out
@@ -136,14 +136,14 @@ class TestHandleDelete:
 
     def test_string_id(self):
         with patch_adapter("gfo.commands.tag_protect") as adapter:
-            args = make_args(id="v*")
+            args = make_args(id="v*", yes=True)
             tp_cmd.handle_delete(args, fmt="table")
         adapter.delete_tag_protection.assert_called_once_with("v*")
 
     def test_delete_json_format(self, capsys):
         """fmt="json" で構造化 JSON（result / id / message）が出力される。"""
         with patch_adapter("gfo.commands.tag_protect"):
-            args = make_args(id=1)
+            args = make_args(id=1, yes=True)
             tp_cmd.handle_delete(args, fmt="json")
         out = capsys.readouterr().out
         data = json.loads(out)
@@ -154,6 +154,6 @@ class TestHandleDelete:
     def test_error_propagation(self):
         with patch_adapter("gfo.commands.tag_protect") as adapter:
             adapter.delete_tag_protection.side_effect = HttpError(404, "Not found")
-            args = make_args(id=1)
+            args = make_args(id=1, yes=True)
             with pytest.raises(HttpError):
                 tp_cmd.handle_delete(args, fmt="table")

--- a/tests/test_commands/test_variable.py
+++ b/tests/test_commands/test_variable.py
@@ -101,14 +101,14 @@ class TestHandleGet:
 class TestHandleDelete:
     def test_calls_delete(self):
         with patch_adapter("gfo.commands.variable") as adapter:
-            args = make_args(name="MY_VAR")
+            args = make_args(name="MY_VAR", yes=True)
             variable_cmd.handle_delete(args, fmt="table")
         adapter.delete_variable.assert_called_once_with("MY_VAR", scope=None)
 
     def test_json_format(self, capsys):
         """fmt="json" のとき構造化 JSON が出力される。"""
         with patch_adapter("gfo.commands.variable"):
-            args = make_args(name="MY_VAR")
+            args = make_args(name="MY_VAR", yes=True)
             variable_cmd.handle_delete(args, fmt="json")
         out = capsys.readouterr().out
         data = json.loads(out)
@@ -119,7 +119,7 @@ class TestHandleDelete:
     def test_error_propagation(self):
         with patch_adapter("gfo.commands.variable") as adapter:
             adapter.delete_variable.side_effect = GfoError("not found")
-            args = make_args(name="MY_VAR")
+            args = make_args(name="MY_VAR", yes=True)
             with pytest.raises(GfoError, match="not found"):
                 variable_cmd.handle_delete(args, fmt="table")
 
@@ -141,7 +141,7 @@ class TestOrgScope:
 
     def test_delete_org_variable(self):
         with patch_adapter("gfo.commands.variable") as adapter:
-            args = make_args(name="ORG_VAR", org="my-org")
+            args = make_args(name="ORG_VAR", org="my-org", yes=True)
             variable_cmd.handle_delete(args, fmt="table")
         adapter.delete_variable.assert_called_once_with("ORG_VAR", scope="my-org")
 

--- a/tests/test_commands/test_webhook.py
+++ b/tests/test_commands/test_webhook.py
@@ -41,14 +41,14 @@ class TestHandleCreate:
 class TestHandleDelete:
     def test_calls_delete_webhook(self):
         with patch_adapter("gfo.commands.webhook") as adapter:
-            args = make_args(id=1)
+            args = make_args(id=1, yes=True)
             webhook_cmd.handle_delete(args, fmt="table")
         adapter.delete_webhook.assert_called_once_with(hook_id=1)
 
     def test_json_format(self, capsys):
         """fmt="json" のとき構造化 JSON が出力される。"""
         with patch_adapter("gfo.commands.webhook"):
-            args = make_args(id=42)
+            args = make_args(id=42, yes=True)
             webhook_cmd.handle_delete(args, fmt="json")
         out = capsys.readouterr().out
         data = json.loads(out)
@@ -168,7 +168,7 @@ class TestHandleDeleteSuccessMessage:
     def test_delete_prints_success_message(self, capsys):
         """handle_delete が成功メッセージに id を含む。"""
         with patch_adapter("gfo.commands.webhook"):
-            args = make_args(id=42)
+            args = make_args(id=42, yes=True)
             webhook_cmd.handle_delete(args, fmt="table")
         out = capsys.readouterr().out
         assert "42" in out

--- a/tests/test_commands/test_wiki.py
+++ b/tests/test_commands/test_wiki.py
@@ -113,14 +113,14 @@ class TestHandleEdit:
 class TestHandleDelete:
     def test_calls_delete_wiki_page(self):
         with patch_adapter("gfo.commands.wiki") as adapter:
-            args = make_args(id="1")
+            args = make_args(id="1", yes=True)
             wiki_cmd.handle_delete(args, fmt="table")
         adapter.delete_wiki_page.assert_called_once_with("1")
 
     def test_delete_json_format(self, capsys):
         """fmt="json" で構造化 JSON（result / id / message）が出力される。"""
         with patch_adapter("gfo.commands.wiki"):
-            args = make_args(id="1")
+            args = make_args(id="1", yes=True)
             wiki_cmd.handle_delete(args, fmt="json")
         out = capsys.readouterr().out
         data = json.loads(out)
@@ -131,7 +131,7 @@ class TestHandleDelete:
     def test_error_propagation(self):
         with patch_adapter("gfo.commands.wiki") as adapter:
             adapter.delete_wiki_page.side_effect = HttpError(403, "Forbidden")
-            args = make_args(id="1")
+            args = make_args(id="1", yes=True)
             with pytest.raises(HttpError):
                 wiki_cmd.handle_delete(args, fmt="table")
 


### PR DESCRIPTION
Closes #56

## 概要

delete / remove 系の全サブコマンドに確認プロンプトと `--yes` / `-y` フラグを追加し、既存の `repo delete` / `repo archive` / `repo transfer` / `org delete` / `package delete` と挙動を統一します。

## 変更内容

- **共通ヘルパー `confirm_action()`**（`src/gfo/commands/__init__.py`）
  - `--yes` 指定時は確認をスキップ
  - 対話環境ではプロンプト表示、y/yes 以外の回答で `Aborted.`（JSON では `{"result": "aborted"}`）
  - **非対話環境（stdin 非 TTY）ではプロンプトを出さず `ConfigError`**。パイプ・CI・AI agent からの誤操作を防ぐため、`--yes` による明示同意を要求する
- **新たに確認対象になったコマンド（23）**: issue delete / issue time delete / pr・issue comment delete / release delete / release asset delete / label delete / milestone delete / branch delete / tag delete / file delete / webhook delete / deploy-key delete / ssh-key delete / gpg-key delete / collaborator remove / ci delete / wiki delete / branch-protect remove / tag-protect delete / secret delete / variable delete / repo mirror remove
- 既存 5 コマンドのインライン `input()` 実装をヘルパーに置換（重複 5 箇所を集約）
- i18n: プロンプト msgid 22 件 + 非対話エラー 1 件の ja 訳を `.po` に追加
- テスト: `test_confirm.py` 新設（ヘルパー単体テスト + 全 28 破壊的ハンドラの非対話ガードをパラメトライズで網羅）。既存の delete 系テスト 71 件に `yes=True` を付与、既存プロンプトテスト 12 件は新設の `interactive_stdin` fixture で対応
- docs: `commands.md` / `commands.ja.md` の usage 23 行に `[--yes]` を追記し、グローバルオプション直後に共通注記を追加

## 挙動変更（注意）

- 対話端末では上記 23 コマンドがデフォルトで確認プロンプトを表示するようになります
- 非対話実行（`echo y |` などのパイプ経由を含む）では、破壊的操作に `--yes` が必須になります（exit code 6 の `config_error`）

## テスト

- `uv run pytest`: 4021 passed（i18n lint 含む）
- ruff / mypy / bandit: green
- hermetic smoke: 非 TTY で `gfo issue delete 999` → `{"error": "config_error", "message": "Confirmation required. ...", "exit_code": 6}`、`--help` に `--yes, -y` 表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)