### PR TITLE
fix(pr): --remote 指定を pr checkout / pr create の git 操作に反映する

### DIFF
--- a/src/gfo/commands/pr.py
+++ b/src/gfo/commands/pr.py
@@ -6,6 +6,7 @@ import argparse
 import json
 
 import gfo.git_util
+from gfo._context import cli_remote
 from gfo.commands import get_adapter, open_in_browser, read_file_arg
 from gfo.exceptions import ConfigError
 from gfo.i18n import _
@@ -39,7 +40,8 @@ def handle_create(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
         args.body = read_file_arg(args.body_file)
     adapter = get_adapter()
     head = args.head or gfo.git_util.get_current_branch()
-    base = args.base or gfo.git_util.get_default_branch()
+    # --remote 指定時はそのリモートの HEAD から base を推定する
+    base = args.base or gfo.git_util.get_default_branch(remote=cli_remote.get())
     title = (args.title or gfo.git_util.get_last_commit_subject() or "").strip()
     if not title:
         raise ConfigError(_("Could not determine PR title. Use --title option."))
@@ -214,7 +216,8 @@ def handle_checkout(args: argparse.Namespace, *, fmt: str, jq: str | None = None
     adapter = get_adapter()
     pr = adapter.get_pull_request(args.number)
     refspec = adapter.get_pr_checkout_refspec(args.number, pr=pr)
-    gfo.git_util.git_fetch("origin", refspec)
+    # --remote 指定時はそのリモートから fetch する（アダプターの参照先と揃える）
+    gfo.git_util.git_fetch(cli_remote.get() or "origin", refspec)
     gfo.git_util.git_checkout_branch(pr.source_branch)
 
 

--- a/tests/test_commands/test_pr.py
+++ b/tests/test_commands/test_pr.py
@@ -164,6 +164,26 @@ class TestHandleCreate:
         call_kwargs = mock_adapter.create_pull_request.call_args.kwargs
         assert call_kwargs["base"] == "develop"
 
+    def test_infers_base_from_cli_remote(self, sample_config, mock_adapter, capsys):
+        """--remote 指定時は base 推定にそのリモートを使う。"""
+        from gfo._context import cli_remote
+
+        args = make_args(head="feature/x", base=None, title="My PR", body="", draft=False)
+        token = cli_remote.set("upstream")
+        try:
+            with (
+                _patch_all(sample_config, mock_adapter),
+                patch(
+                    "gfo.commands.pr.gfo.git_util.get_default_branch", return_value="develop"
+                ) as mock_gdb,
+            ):
+                pr_cmd.handle_create(args, fmt="table")
+        finally:
+            cli_remote.reset(token)
+
+        mock_gdb.assert_called_once_with(remote="upstream")
+        assert mock_adapter.create_pull_request.call_args.kwargs["base"] == "develop"
+
     def test_infers_title_from_last_commit(self, sample_config, mock_adapter, capsys):
         args = make_args(head="feature/x", base="main", title=None, body="", draft=False)
         with (
@@ -572,6 +592,25 @@ class TestHandleCheckout:
         mock_adapter.get_pull_request.assert_called_once_with(1)
         mock_adapter.get_pr_checkout_refspec.assert_called_once()
         mock_fetch.assert_called_once_with("origin", "refs/pull/1/head")
+        mock_checkout.assert_called_once_with("feature/test")
+
+    def test_checkout_fetches_from_cli_remote(self, sample_config, mock_adapter):
+        """--remote 指定時はそのリモートから fetch する。"""
+        from gfo._context import cli_remote
+
+        args = make_args(number=1)
+        token = cli_remote.set("upstream")
+        try:
+            with (
+                _patch_all(sample_config, mock_adapter),
+                patch("gfo.commands.pr.gfo.git_util.git_fetch") as mock_fetch,
+                patch("gfo.commands.pr.gfo.git_util.git_checkout_branch") as mock_checkout,
+            ):
+                pr_cmd.handle_checkout(args, fmt="table")
+        finally:
+            cli_remote.reset(token)
+
+        mock_fetch.assert_called_once_with("upstream", "refs/pull/1/head")
         mock_checkout.assert_called_once_with("feature/test")
 
     def test_checkout_pr_not_found_raises(self, sample_config, mock_adapter):


### PR DESCRIPTION
Closes #59

## 概要

グローバルオプション `--remote REMOTE` はサービス検出（アダプターの参照先）には反映される一方、ローカル git 操作には反映されていませんでした。issue #59 で指摘された 2 箇所を修正します。

## 変更内容

- **`pr checkout`**: `git fetch` が `"origin"` 固定だったのを、`cli_remote.get() or "origin"` に変更。`--remote upstream` 指定時はアダプターが参照する upstream から fetch します
- **`pr create`**: `--base` 省略時の default base 推定を `get_default_branch(remote=cli_remote.get())` に変更。`--remote` 指定時はそのリモートの symbolic HEAD から推定します。未指定時（`remote=None`）は従来の origin → 最初のリモート → `"main"` フォールバックがそのまま機能します

## テスト

- 新規 2 件: `test_checkout_fetches_from_cli_remote` / `test_infers_base_from_cli_remote`（既存テストと同じ ContextVar set/reset パターン）
- `uv run pytest`: 4033 passed、ruff / mypy green

🤖 Generated with [Claude Code](https://claude.com/claude-code)