### PR TITLE
feat(schema): 孫サブコマンドの JSON Schema 取得に対応する

### DIFF
--- a/src/gfo/commands/schema.py
+++ b/src/gfo/commands/schema.py
@@ -52,6 +52,7 @@ from gfo.adapter.base import (
     WikiRevision,
     Workflow,
 )
+from gfo.commands.batch import BatchPrResult
 from gfo.exceptions import ConfigError
 from gfo.i18n import _
 from gfo.output import apply_jq_filter
@@ -269,6 +270,53 @@ _SPECIAL_OUTPUT: dict[tuple[str, str | None], dict[str, Any]] = {
     },
 }
 
+# 孫サブコマンド（例: release asset delete）の出力スキーマ。
+# キーは (command, subcommand, action)。
+_GRANDCHILD_OUTPUT_MAP: dict[tuple[str, str, str], type | None] = {
+    ("pr", "reviewers", "list"): list[str],
+    ("pr", "reviewers", "add"): None,
+    ("pr", "reviewers", "remove"): None,
+    ("pr", "review", "list"): list[Review],
+    ("pr", "review", "create"): Review,
+    ("pr", "review", "dismiss"): None,
+    ("pr", "comment", "list"): list[Comment],
+    ("pr", "comment", "create"): Comment,
+    ("pr", "comment", "edit"): Comment,
+    ("pr", "comment", "delete"): None,
+    ("issue", "comment", "list"): list[Comment],
+    ("issue", "comment", "create"): Comment,
+    ("issue", "comment", "edit"): Comment,
+    ("issue", "comment", "delete"): None,
+    ("issue", "reaction", "list"): list[Reaction],
+    ("issue", "reaction", "add"): Reaction,
+    ("issue", "reaction", "remove"): None,
+    ("issue", "depends", "list"): list[Issue],
+    ("issue", "depends", "add"): None,
+    ("issue", "depends", "remove"): None,
+    ("issue", "time", "list"): list[TimeEntry],
+    ("issue", "time", "add"): TimeEntry,
+    ("issue", "time", "delete"): None,
+    ("repo", "topics", "list"): list[str],
+    ("repo", "topics", "add"): list[str],
+    ("repo", "topics", "remove"): list[str],
+    ("repo", "topics", "set"): list[str],
+    ("repo", "mirror", "list"): list[PushMirror],
+    ("repo", "mirror", "add"): PushMirror,
+    ("repo", "mirror", "remove"): None,
+    ("repo", "mirror", "sync"): None,
+    ("release", "asset", "list"): list[ReleaseAsset],
+    ("release", "asset", "upload"): ReleaseAsset,
+    ("release", "asset", "download"): None,
+    ("release", "asset", "edit"): ReleaseAsset,
+    ("release", "asset", "delete"): None,
+    ("ci", "workflow", "list"): list[Workflow],
+    ("ci", "workflow", "enable"): None,
+    ("ci", "workflow", "disable"): None,
+    ("ci", "artifact", "list"): list[Artifact],
+    ("ci", "artifact", "download"): None,
+    ("batch", "pr", "create"): list[BatchPrResult],
+}
+
 
 def _python_type_to_json_schema(tp: Any) -> dict[str, Any]:
     """Python 型アノテーションを JSON Schema に変換する。"""
@@ -441,12 +489,56 @@ def _get_subcommand_parser(
     )
 
 
-def _build_output_schema(key: tuple[str, str | None]) -> Any:
-    """コマンドキーから出力スキーマを生成する。"""
-    if key in _SPECIAL_OUTPUT:
-        return _SPECIAL_OUTPUT[key]
+def _get_nested_subparsers_action(
+    parser: argparse.ArgumentParser,
+) -> argparse._SubParsersAction[argparse.ArgumentParser] | None:
+    """パーサー直下の _SubParsersAction を返す（孫サブコマンドが無ければ None）。
 
-    output_type = _OUTPUT_MAP.get(key)
+    NOTE: argparse の非公開 API を使用: parser._actions, _SubParsersAction。
+    """
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            return action
+    return None
+
+
+def _get_grandchild_parser(
+    subparser_map: dict[str, argparse.ArgumentParser],
+    command: str,
+    subcommand: str,
+    action: str,
+) -> argparse.ArgumentParser:
+    """孫サブコマンドパーサーを取得する。"""
+    parser = _get_subcommand_parser(subparser_map, command, subcommand)
+    sub_action = _get_nested_subparsers_action(parser)
+    if sub_action is not None and action in sub_action.choices:
+        result: argparse.ArgumentParser = sub_action.choices[action]
+        return result
+    raise ConfigError(
+        _("Unknown command: {command} {subcommand} {action}").format(
+            command=command, subcommand=subcommand, action=action
+        )
+    )
+
+
+def _get_choice_description(parent_parser: argparse.ArgumentParser, choice: str) -> str:
+    """親パーサー直下の _SubParsersAction から choice の help テキストを取得する。
+
+    NOTE: action._choices_actions は argparse 非公開 API。
+    """
+    action = _get_nested_subparsers_action(parent_parser)
+    if action is None or choice not in action.choices:
+        return ""
+    desc = action.choices[choice].description or ""
+    if not desc:
+        for ca in action._choices_actions:
+            if ca.dest == choice and ca.help:
+                return ca.help
+    return desc
+
+
+def _output_type_to_schema(output_type: Any) -> Any:
+    """Python 型（dataclass / list[dataclass] 等）を出力 JSON Schema に変換する。"""
     if output_type is None:
         return None
 
@@ -463,6 +555,18 @@ def _build_output_schema(key: tuple[str, str | None]) -> Any:
         return _dataclass_to_json_schema(output_type)
 
     return None
+
+
+def _build_output_schema(key: tuple[str, str | None]) -> Any:
+    """コマンドキーから出力スキーマを生成する。"""
+    if key in _SPECIAL_OUTPUT:
+        return _SPECIAL_OUTPUT[key]
+    return _output_type_to_schema(_OUTPUT_MAP.get(key))
+
+
+def _build_grandchild_output_schema(key: tuple[str, str, str]) -> Any:
+    """孫サブコマンドキーから出力スキーマを生成する。"""
+    return _output_type_to_schema(_GRANDCHILD_OUTPUT_MAP.get(key))
 
 
 def _build_command_schema(
@@ -485,6 +589,22 @@ def _build_command_schema(
         "output": _build_output_schema(key),
     }
     return result
+
+
+def _build_grandchild_command_schema(
+    command: str,
+    subcommand: str,
+    action: str,
+    subparser_map: dict[str, argparse.ArgumentParser],
+) -> dict[str, Any]:
+    """孫サブコマンド（例: release asset delete）のスキーマを構築する。"""
+    parser = _get_grandchild_parser(subparser_map, command, subcommand, action)
+    key = (command, subcommand, action)
+    return {
+        "command": f"{command} {subcommand} {action}",
+        "input": _parser_to_input_schema(parser),
+        "output": _build_grandchild_output_schema(key),
+    }
 
 
 def _print_json(json_str: str, jq: str | None) -> None:
@@ -519,47 +639,55 @@ def handle_schema(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
             # description はサブパーサーの help から取得
             if subcommand is not None:
                 try:
-                    p = _get_subcommand_parser(subparser_map, command, subcommand)
-                    desc = p.description or ""
-                    # p.description が空の場合、add_parser() の help= を参照する
-                    # NOTE: _choices_actions は argparse 非公開 API
-                    if not desc:
-                        cmd_parser = subparser_map[command]
-                        for act in cmd_parser._actions:
-                            if isinstance(act, argparse._SubParsersAction):
-                                for ca in act._choices_actions:
-                                    if ca.dest == subcommand and ca.help:
-                                        desc = ca.help
-                                        break
-                                break
-                except (ConfigError, KeyError):
+                    desc = _get_choice_description(subparser_map[command], subcommand)
+                except KeyError:
                     logger.warning("Failed to get parser for %s %s", command, subcommand)
                     desc = ""
             else:
-                desc = subparser_map.get(command, argparse.ArgumentParser()).description or ""
-                # description が空の場合、add_parser() の help= を参照する
-                # NOTE: _choices_actions は argparse 非公開 API
-                if not desc:
-                    for act in main_parser._actions:
-                        if isinstance(act, argparse._SubParsersAction):
-                            for ca in act._choices_actions:
-                                if ca.dest == command and ca.help:
-                                    desc = ca.help
-                                    break
-                            break
+                desc = _get_choice_description(main_parser, command)
             result.append({"command": cmd_label, "description": desc})
+
+            # 孫サブコマンド（例: release asset delete）があれば併せて列挙する
+            if subcommand is not None:
+                try:
+                    parser = _get_subcommand_parser(subparser_map, command, subcommand)
+                except (ConfigError, KeyError):
+                    continue
+                grandchild_action = _get_nested_subparsers_action(parser)
+                if grandchild_action is not None:
+                    for action_name in grandchild_action.choices:
+                        result.append(
+                            {
+                                "command": f"{cmd_label} {action_name}",
+                                "description": _get_choice_description(parser, action_name),
+                            }
+                        )
         json_str = json.dumps(result, indent=2, ensure_ascii=False)
         _print_json(json_str, jq)
         return
 
-    if len(target) > 2:
+    if len(target) > 3:
         raise ConfigError(_("Too many arguments: {args}").format(args=" ".join(target)))
 
     command = target[0]
     subcommand = target[1] if len(target) > 1 else None
+    action = target[2] if len(target) > 2 else None
 
-    if subcommand is not None:
-        # 単一コマンドスキーマ
+    if action is not None:
+        # 孫サブコマンドスキーマ（例: release asset delete）
+        subcommand = target[1]
+        key2 = (command, subcommand)
+        if key2 not in _DISPATCH:
+            raise ConfigError(
+                _("Unknown command: {command} {subcommand}").format(
+                    command=command, subcommand=subcommand
+                )
+            )
+        schema = _build_grandchild_command_schema(command, subcommand, action, subparser_map)
+        json_str = json.dumps(schema, indent=2, ensure_ascii=False)
+        _print_json(json_str, jq)
+    elif subcommand is not None:
+        # 単一コマンドスキーマ、または孫サブコマンドを持つグループ
         key = (command, subcommand)
         if key not in _DISPATCH:
             raise ConfigError(
@@ -567,8 +695,18 @@ def handle_schema(args: argparse.Namespace, *, fmt: str, jq: str | None = None) 
                     command=command, subcommand=subcommand
                 )
             )
-        schema = _build_command_schema(key, subparser_map)
-        json_str = json.dumps(schema, indent=2, ensure_ascii=False)
+        parser = _get_subcommand_parser(subparser_map, command, subcommand)
+        grandchild_action = _get_nested_subparsers_action(parser)
+        if grandchild_action is not None:
+            # 孫グループ — action 別スキーマの一覧
+            schemas = [
+                _build_grandchild_command_schema(command, subcommand, act, subparser_map)
+                for act in grandchild_action.choices
+            ]
+            json_str = json.dumps(schemas, indent=2, ensure_ascii=False)
+        else:
+            schema = _build_command_schema(key, subparser_map)
+            json_str = json.dumps(schema, indent=2, ensure_ascii=False)
         _print_json(json_str, jq)
     else:
         # コマンドグループ — 該当 command 配下の全サブコマンド

--- a/src/gfo/locale/ja/LC_MESSAGES/gfo.po
+++ b/src/gfo/locale/ja/LC_MESSAGES/gfo.po
@@ -2376,6 +2376,9 @@ msgstr "未知のコマンド: {command}"
 msgid "Unknown command: {command} {subcommand}"
 msgstr "未知のコマンド: {command} {subcommand}"
 
+msgid "Unknown command: {command} {subcommand} {action}"
+msgstr "未知のコマンド: {command} {subcommand} {action}"
+
 msgid "Unknown subcommand: {command} {subcommand}"
 msgstr "未知のサブコマンド: {command} {subcommand}"
 

--- a/tests/test_commands/test_schema.py
+++ b/tests/test_commands/test_schema.py
@@ -268,9 +268,20 @@ class TestHandleSchema:
         assert missing == set(), f"_OUTPUT_MAP に不足: {missing}"
 
     def test_too_many_arguments(self):
-        """target に 3 個以上渡すと ConfigError。"""
+        """孫サブコマンドを持たないコマンドに 3 個目を渡すと ConfigError。"""
         args = make_args(
             command="schema", subcommand=None, list_commands=False, target=["pr", "list", "extra"]
+        )
+        with pytest.raises(ConfigError):
+            handle_schema(args, fmt="json")
+
+    def test_too_many_arguments_four_elements(self):
+        """target に 4 個以上渡すと ConfigError。"""
+        args = make_args(
+            command="schema",
+            subcommand=None,
+            list_commands=False,
+            target=["release", "asset", "delete", "extra"],
         )
         with pytest.raises(ConfigError):
             handle_schema(args, fmt="json")
@@ -376,3 +387,134 @@ class TestSchemaAlwaysEnglish:
         for item in out:
             desc = item.get("description", "")
             assert "[翻訳]" not in desc, f"{item['command']} の description に翻訳が混入: {desc}"
+
+
+# ---- 孫サブコマンド（#58） ----
+
+
+def _discover_grandchild_triples():
+    """create_parser() から (command, subcommand, action) の全組を動的に発見する。"""
+    import argparse as _ap
+
+    from gfo.cli import create_parser
+
+    _, subparser_map = create_parser()
+    triples = []
+    for command, cmd_parser in subparser_map.items():
+        for cmd_action in cmd_parser._actions:
+            if not isinstance(cmd_action, _ap._SubParsersAction):
+                continue
+            for subcommand, sub_parser in cmd_action.choices.items():
+                for sub_action in sub_parser._actions:
+                    if not isinstance(sub_action, _ap._SubParsersAction):
+                        continue
+                    for action in sub_action.choices:
+                        triples.append((command, subcommand, action))
+    return triples
+
+
+class TestGrandchildSchema:
+    """孫サブコマンド（release asset delete 等）の schema 取得（#58）。"""
+
+    def test_grandchild_single_command(self, capsys):
+        args = make_args(
+            command="schema",
+            subcommand=None,
+            list_commands=False,
+            target=["release", "asset", "delete"],
+        )
+        handle_schema(args, fmt="json")
+        out = json.loads(capsys.readouterr().out)
+        assert out["command"] == "release asset delete"
+        assert "asset_id" in out["input"]["properties"]
+        assert out["output"] is None
+
+    def test_grandchild_output_dataclass(self, capsys):
+        """release asset upload は単一オブジェクトを返す。"""
+        args = make_args(
+            command="schema",
+            subcommand=None,
+            list_commands=False,
+            target=["release", "asset", "upload"],
+        )
+        handle_schema(args, fmt="json")
+        out = json.loads(capsys.readouterr().out)
+        assert out["output"]["type"] == "object"
+        assert "download_url" in out["output"]["properties"]
+
+    def test_grandchild_list_str_output(self, capsys):
+        """repo topics add は list[str] を返す。"""
+        args = make_args(
+            command="schema",
+            subcommand=None,
+            list_commands=False,
+            target=["repo", "topics", "add"],
+        )
+        handle_schema(args, fmt="json")
+        out = json.loads(capsys.readouterr().out)
+        assert out["output"] == {"type": "array", "items": {"type": "string"}}
+
+    def test_grandchild_group_returns_array(self, capsys):
+        """2 要素指定が孫グループの場合は action 別スキーマの配列を返す。"""
+        args = make_args(
+            command="schema", subcommand=None, list_commands=False, target=["release", "asset"]
+        )
+        handle_schema(args, fmt="json")
+        out = json.loads(capsys.readouterr().out)
+        assert isinstance(out, list)
+        commands = [item["command"] for item in out]
+        assert commands == [
+            "release asset list",
+            "release asset upload",
+            "release asset download",
+            "release asset edit",
+            "release asset delete",
+        ]
+
+    def test_grandchild_unknown_action(self):
+        args = make_args(
+            command="schema",
+            subcommand=None,
+            list_commands=False,
+            target=["release", "asset", "nonexistent"],
+        )
+        with pytest.raises(ConfigError):
+            handle_schema(args, fmt="json")
+
+    def test_grandchild_on_non_grandchild_subcommand(self):
+        """孫を持たないコマンドに 3 要素目を渡すと ConfigError。"""
+        args = make_args(
+            command="schema", subcommand=None, list_commands=False, target=["pr", "list", "extra"]
+        )
+        with pytest.raises(ConfigError):
+            handle_schema(args, fmt="json")
+
+    def test_grandchild_unknown_command_subcommand(self):
+        args = make_args(
+            command="schema",
+            subcommand=None,
+            list_commands=False,
+            target=["nonexistent", "asset", "delete"],
+        )
+        with pytest.raises(ConfigError):
+            handle_schema(args, fmt="json")
+
+    def test_list_commands_includes_grandchildren(self, capsys):
+        """schema --list に孫サブコマンドも含まれる。"""
+        args = make_args(command="schema", subcommand=None, list_commands=True, target=[])
+        handle_schema(args, fmt="json")
+        out = json.loads(capsys.readouterr().out)
+        commands = [item["command"] for item in out]
+        assert "release asset delete" in commands
+        assert "issue time add" in commands
+        assert "batch pr create" in commands
+
+    def test_grandchild_output_map_covers_all_actions(self):
+        """_GRANDCHILD_OUTPUT_MAP が実際の argparse 構造の全 (command, subcommand, action) をカバーしている。"""
+        from gfo.commands.schema import _GRANDCHILD_OUTPUT_MAP
+
+        triples = set(_discover_grandchild_triples())
+        missing = triples - set(_GRANDCHILD_OUTPUT_MAP.keys())
+        assert missing == set(), f"_GRANDCHILD_OUTPUT_MAP に不足: {missing}"
+        extra = set(_GRANDCHILD_OUTPUT_MAP.keys()) - triples
+        assert extra == set(), f"_GRANDCHILD_OUTPUT_MAP に存在しない孫コマンド: {extra}"


### PR DESCRIPTION
## Summary
- `gfo schema` の `target` を最大3要素まで受け付け、`gfo schema release asset delete` のような孫サブコマンド単体の schema（input/output）を返すようにした
- 2要素指定 (`gfo schema release asset`) が孫グループに該当する場合は action 別 schema の配列を返す（従来は `properties: {}` のプレースホルダのみで実引数が見えなかった）
- 孫グループの検出は argparse の実パーサー構造（`_SubParsersAction` の有無）を動的に見て判定するため、ハードコードされたグループ一覧に依存しない
- `_GRANDCHILD_OUTPUT_MAP`（13グループ・42アクション）を追加し、各アクションの実際のハンドラ実装を確認したうえで出力型を明示。カバレッジは動的発見と突き合わせるテストで保証
- `gfo schema --list` にも孫サブコマンド（例: `release asset delete`）を列挙するようにした
- 新規エラーメッセージ `Unknown command: {command} {subcommand} {action}` を `_()` + ja 訳で追加

Closes #58

## Test plan
- [x] `uv run pytest` 全件パス（4043 passed）
- [x] `uv run ruff check .` / `uv run ruff format --check .`
- [x] `uv run mypy src/gfo`
- [x] `uv run bandit -r src/gfo -c pyproject.toml`
- [x] `gfo schema release asset delete` / `gfo schema release asset` / `gfo schema --list` を手動実行し出力を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)