### PR TITLE
fix(cli)!: 短縮フラグの衝突を解消し「1短縮フラグ=1意味」に統一する

### DIFF
--- a/docs/commands.ja.md
+++ b/docs/commands.ja.md
@@ -223,7 +223,7 @@ gfo pr list [--state {open,closed,merged,all}] [--limit N] [--author USER] [--la
 | `--search` / `-S` | — | タイトル/説明でフィルタ |
 | `--base` / `-B` | — | ベースブランチでフィルタ |
 | `--head` / `-H` | — | ヘッドブランチでフィルタ |
-| `--draft` / `-d` / `--no-draft` | — | ドラフト状態でフィルタ |
+| `--draft` / `--no-draft` | — | ドラフト状態でフィルタ |
 | `--milestone` / `-m` | — | マイルストーンでフィルタ |
 
 ```bash
@@ -246,8 +246,8 @@ gfo pr create [--title TITLE] [--body BODY] [--body-file FILE] [--base BRANCH] [
 | `--body-file` / `-F` | ファイルから本文を読み込む |
 | `--base` / `-B` | マージ先ブランチ（省略時はデフォルトブランチ） |
 | `--head` / `-H` | マージ元ブランチ（省略時は現在のブランチ） |
-| `--draft` / `-d` | ドラフト PR として作成 |
-| `--reviewer` / `-r` | レビュアーのユーザー名（繰り返し可） |
+| `--draft` | ドラフト PR として作成 |
+| `--reviewer` | レビュアーのユーザー名（繰り返し可） |
 | `--assignee` / `-a` | 担当者のユーザー名（繰り返し可） |
 | `--label` / `-l` | ラベル名（繰り返し可） |
 | `--milestone` / `-m` | マイルストーン名 |
@@ -285,8 +285,8 @@ gfo pr merge NUMBER [--merge | --squash | --rebase] [--delete-branch] [--subject
 | `--merge` / `-m` | マージコミットを作成（デフォルト） |
 | `--squash` / `-s` | スカッシュしてマージ |
 | `--rebase` / `-r` | リベースしてマージ |
-| `--delete-branch` / `-d` | マージ後にブランチを削除 |
-| `--subject` / `-t` | マージコミットのタイトル |
+| `--delete-branch` | マージ後にブランチを削除 |
+| `--subject` | マージコミットのタイトル |
 | `--body` / `-b` | マージコミットの本文 |
 | `--auto` | 自動マージを有効化（条件を満たしたら自動でマージ） |
 | `--disable-auto` | 自動マージを無効化 |
@@ -398,7 +398,7 @@ gfo pr edit NUMBER [--title TITLE] [--body BODY] [--base BRANCH] [--add-label LA
 | `--add-assignee` | 担当者を追加（繰り返し可） |
 | `--remove-assignee` | 担当者を削除（繰り返し可） |
 | `--milestone` / `-m` | マイルストーン名 |
-| `--draft` / `-d` / `--ready` | ドラフトと公開状態を切り替え |
+| `--draft` / `--ready` | ドラフトと公開状態を切り替え |
 
 ```bash
 gfo pr edit 42 --title "Updated title"
@@ -765,7 +765,7 @@ gfo issue develop NUMBER [--name BRANCH] [--base BRANCH]
 
 | オプション | 説明 |
 |---|---|
-| `--name` / `-n` | ブランチ名（デフォルト: `issue-{number}-{slug}`） |
+| `--name` | ブランチ名（デフォルト: `issue-{number}-{slug}`） |
 | `--base` / `-B` | ベースブランチ（デフォルト: デフォルトブランチ） |
 
 ```bash
@@ -1179,7 +1179,7 @@ gfo repo migrate CLONE_URL --name NAME [--private | --public | --internal] [--de
 | オプション | 必須 | 説明 |
 |---|---|---|
 | `CLONE_URL` | **必須** | インポート元リポジトリの clone URL |
-| `--name` / `-n` | **必須** | 作成するリポジトリ名（組織リポジトリは `org/repo` 形式） |
+| `--name` | **必須** | 作成するリポジトリ名（組織リポジトリは `org/repo` 形式） |
 | `--private` | — | 非公開リポジトリとして作成 |
 | `--public` | — | 公開リポジトリとして作成（デフォルト） |
 | `--internal` | — | internal リポジトリとして作成（組織のみ） |
@@ -1259,7 +1259,7 @@ gfo repo sync [--branch BRANCH]
 
 | オプション | 説明 |
 |---|---|
-| `--branch` / `-b` | 同期するブランチ（省略時はデフォルトブランチ） |
+| `--branch` | 同期するブランチ（省略時はデフォルトブランチ） |
 
 ```bash
 gfo repo sync
@@ -1299,7 +1299,7 @@ gfo release list [--limit N] [--draft | --no-draft] [--prerelease | --no-prerele
 | オプション | 説明 |
 |---|---|
 | `--limit N` | 最大取得件数（デフォルト: 30） |
-| `--draft` / `-d` / `--no-draft` | ドラフトのみ / ドラフト除外 |
+| `--draft` / `--no-draft` | ドラフトのみ / ドラフト除外 |
 | `--prerelease` / `-p` / `--no-prerelease` | プレリリースのみ / プレリリース除外 |
 
 ```bash
@@ -1319,7 +1319,7 @@ gfo release create TAG [--title TITLE] [--notes NOTES] [--notes-file FILE] [--dr
 | `--title` / `-t` | リリースタイトル |
 | `--notes` / `-n` | リリースノート |
 | `--notes-file` / `-F` | ファイルからリリースノートを読み込み |
-| `--draft` / `-d` | ドラフトとして作成 |
+| `--draft` | ドラフトとして作成 |
 | `--prerelease` / `-p` | プレリリースとしてマーク |
 | `--target` | ターゲットブランチまたはコミット SHA |
 | `--generate-notes` | リリースノートを自動生成（GitHub/GitLab） |
@@ -1373,7 +1373,7 @@ gfo release edit TAG [--title TITLE] [--notes NOTES] [--notes-file FILE] [--draf
 | `--title` / `-t` | リリースタイトル |
 | `--notes` / `-n` | リリースノート |
 | `--notes-file` / `-F` | ファイルからリリースノートを読み込み |
-| `--draft` / `-d` / `--no-draft` | ドラフト状態の切り替え |
+| `--draft` / `--no-draft` | ドラフト状態の切り替え |
 | `--prerelease` / `-p` / `--no-prerelease` | プレリリース状態の切り替え |
 | `--tag` | 新しいタグ名（GitHub, Gitea, Forgejo） |
 | `--target` | ターゲットブランチまたはコミット SHA（GitHub, Gitea, Forgejo） |
@@ -1445,7 +1445,7 @@ gfo label edit NAME [--name NEW_NAME] [--color COLOR] [--description DESC]
 
 | オプション | 説明 |
 |---|---|
-| `--name` / `-n` | 新しいラベル名 |
+| `--name` | 新しいラベル名 |
 | `--color` / `-c` | 色（`RRGGBB` 形式、`#` なし） |
 | `--description` / `-d` | 説明 |
 
@@ -1956,8 +1956,8 @@ gfo ci watch ID [--interval N] [--timeout N]
 
 | オプション | デフォルト | 説明 |
 |---|---|---|
-| `--interval` / `-i` | `5` | ポーリング間隔（秒） |
-| `--timeout` / `-t` | `1800` | タイムアウト秒数（0 で無制限） |
+| `--interval` | `5` | ポーリング間隔（秒） |
+| `--timeout` | `1800` | タイムアウト秒数（0 で無制限） |
 
 ```bash
 gfo ci watch 12345678
@@ -2616,8 +2616,8 @@ gfo api <METHOD> <PATH> [--data JSON] [--header HEADER]
 |---|---|
 | `METHOD` | HTTP メソッド（GET, POST, PUT, PATCH, DELETE） |
 | `PATH` | API パス（例: `/repos/owner/repo`） |
-| `--data` / `-d` | リクエストボディ（JSON 文字列） |
-| `--header` / `-H` | HTTP ヘッダー（複数指定可、形式: `Key: Value`） |
+| `--data` | リクエストボディ（JSON 文字列） |
+| `--header` | HTTP ヘッダー（複数指定可、形式: `Key: Value`） |
 
 **例:**
 
@@ -2683,7 +2683,7 @@ gfo gpg-key delete 12345
 
 > **対応サービス**: GitHub, GitLab, Bitbucket, Azure DevOps, Gitea, Forgejo
 >
-> **注意**: GitHub / Gitea は `--workflow` / `-w` が必須です。
+> **注意**: GitHub / Gitea は `--workflow` が必須です。
 
 ```
 gfo ci trigger --ref REF [--workflow WORKFLOW] [--input KEY=VALUE ...]
@@ -2692,7 +2692,7 @@ gfo ci trigger --ref REF [--workflow WORKFLOW] [--input KEY=VALUE ...]
 | オプション | 必須 | 説明 |
 |---|---|---|
 | `--ref` | **必須** | 対象ブランチまたはタグ |
-| `--workflow` / `-w` | GitHub/Gitea で必須 | ワークフロー名またはファイル名 |
+| `--workflow` | GitHub/Gitea で必須 | ワークフロー名またはファイル名 |
 | `--input` / `-i` | — | 入力パラメータ（`KEY=VALUE` 形式、複数指定可） |
 
 ```bash
@@ -2934,7 +2934,7 @@ gfo batch pr create --repos SPECS --title TITLE --head BRANCH [options]
 | `--body` / `-b` | PR 本文 | `""` |
 | `--head` / `-H` | ソースブランチ | （必須） |
 | `--base` / `-B` | ターゲットブランチ | `main` |
-| `--draft` / `-d` | ドラフト PR として作成 | — |
+| `--draft` | ドラフト PR として作成 | — |
 | `--dry-run` | PR を作成せず検証のみ実行 | — |
 
 リポジトリ指定は `gfo issue migrate` の SERVICE_SPEC と同じ形式。

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -209,7 +209,7 @@ gfo pr list [--state {open,closed,merged,all}] [--limit N] [--author USER] [--la
 | `--search` / `-S` | — | Filter by title/description |
 | `--base` / `-B` | — | Filter by base branch |
 | `--head` / `-H` | — | Filter by head branch |
-| `--draft` / `-d` / `--no-draft` | — | Filter by draft status |
+| `--draft` / `--no-draft` | — | Filter by draft status |
 | `--milestone` / `-m` | — | Filter by milestone |
 
 ```bash
@@ -232,8 +232,8 @@ gfo pr create [--title TITLE] [--body BODY] [--body-file FILE] [--base BRANCH] [
 | `--body-file` / `-F` | Read body from file |
 | `--base` / `-B` | Target branch (default branch if omitted) |
 | `--head` / `-H` | Source branch (current branch if omitted) |
-| `--draft` / `-d` | Create as draft PR |
-| `--reviewer` / `-r` | Reviewer username (repeatable) |
+| `--draft` | Create as draft PR |
+| `--reviewer` | Reviewer username (repeatable) |
 | `--assignee` / `-a` | Assignee username (repeatable) |
 | `--label` / `-l` | Label name (repeatable) |
 | `--milestone` / `-m` | Milestone name |
@@ -271,8 +271,8 @@ gfo pr merge NUMBER [--merge | --squash | --rebase] [--delete-branch] [--subject
 | `--merge` / `-m` | Create a merge commit (default) |
 | `--squash` / `-s` | Squash and merge |
 | `--rebase` / `-r` | Rebase and merge |
-| `--delete-branch` / `-d` | Delete branch after merge |
-| `--subject` / `-t` | Merge commit title |
+| `--delete-branch` | Delete branch after merge |
+| `--subject` | Merge commit title |
 | `--body` / `-b` | Merge commit body |
 | `--auto` | Enable auto-merge (merges automatically when conditions are met) |
 | `--disable-auto` | Disable auto-merge |
@@ -384,7 +384,7 @@ gfo pr edit NUMBER [--title TITLE] [--body BODY] [--base BRANCH] [--add-label LA
 | `--add-assignee` | Add assignee (repeatable) |
 | `--remove-assignee` | Remove assignee (repeatable) |
 | `--milestone` / `-m` | Milestone name |
-| `--draft` / `-d` / `--ready` | Switch between draft and ready state |
+| `--draft` / `--ready` | Switch between draft and ready state |
 
 ```bash
 gfo pr edit 42 --title "Updated title"
@@ -751,7 +751,7 @@ gfo issue develop NUMBER [--name BRANCH] [--base BRANCH]
 
 | Option | Description |
 |---|---|
-| `--name` / `-n` | Branch name (default: `issue-{number}-{slug}`) |
+| `--name` | Branch name (default: `issue-{number}-{slug}`) |
 | `--base` / `-B` | Base branch (default: default branch) |
 
 ```bash
@@ -1165,7 +1165,7 @@ gfo repo migrate CLONE_URL --name NAME [--private | --public | --internal] [--de
 | Option | Required | Description |
 |---|---|---|
 | `CLONE_URL` | **Required** | Clone URL of the source repository |
-| `--name` / `-n` | **Required** | Name of the repository to create (`org/repo` format for organization repositories) |
+| `--name` | **Required** | Name of the repository to create (`org/repo` format for organization repositories) |
 | `--private` | — | Create as a private repository |
 | `--public` | — | Create as a public repository (default) |
 | `--internal` | — | Create as an internal repository (organization only) |
@@ -1245,7 +1245,7 @@ gfo repo sync [--branch BRANCH]
 
 | Option | Description |
 |---|---|
-| `--branch` / `-b` | Branch to sync (default branch if omitted) |
+| `--branch` | Branch to sync (default branch if omitted) |
 
 ```bash
 gfo repo sync
@@ -1285,7 +1285,7 @@ gfo release list [--limit N] [--draft | --no-draft] [--prerelease | --no-prerele
 | Option | Description |
 |---|---|
 | `--limit N` | Maximum number of results (default: 30) |
-| `--draft` / `-d` / `--no-draft` | Filter draft only / exclude drafts |
+| `--draft` / `--no-draft` | Filter draft only / exclude drafts |
 | `--prerelease` / `-p` / `--no-prerelease` | Filter prerelease only / exclude prereleases |
 
 ```bash
@@ -1305,7 +1305,7 @@ gfo release create TAG [--title TITLE] [--notes NOTES] [--notes-file FILE] [--dr
 | `--title` / `-t` | Release title |
 | `--notes` / `-n` | Release notes |
 | `--notes-file` / `-F` | Read release notes from file |
-| `--draft` / `-d` | Create as draft |
+| `--draft` | Create as draft |
 | `--prerelease` / `-p` | Mark as prerelease |
 | `--target` | Target branch or commit SHA |
 | `--generate-notes` | Auto-generate release notes (GitHub/GitLab) |
@@ -1359,7 +1359,7 @@ gfo release edit TAG [--title TITLE] [--notes NOTES] [--notes-file FILE] [--draf
 | `--title` / `-t` | Release title |
 | `--notes` / `-n` | Release notes |
 | `--notes-file` / `-F` | Read release notes from file |
-| `--draft` / `-d` / `--no-draft` | Toggle draft status |
+| `--draft` / `--no-draft` | Toggle draft status |
 | `--prerelease` / `-p` / `--no-prerelease` | Toggle prerelease status |
 | `--tag` | New tag name (GitHub, Gitea, Forgejo) |
 | `--target` | Target branch or commit SHA (GitHub, Gitea, Forgejo) |
@@ -1431,7 +1431,7 @@ gfo label edit NAME [--name NEW_NAME] [--color COLOR] [--description DESC]
 
 | Option | Description |
 |---|---|
-| `--name` / `-n` | New name for the label |
+| `--name` | New name for the label |
 | `--color` / `-c` | Color (`RRGGBB` format, without `#`) |
 | `--description` / `-d` | Description |
 
@@ -1942,8 +1942,8 @@ gfo ci watch ID [--interval N] [--timeout N]
 
 | Option | Default | Description |
 |---|---|---|
-| `--interval` / `-i` | `5` | Poll interval in seconds |
-| `--timeout` / `-t` | `1800` | Timeout in seconds (0 for unlimited) |
+| `--interval` | `5` | Poll interval in seconds |
+| `--timeout` | `1800` | Timeout in seconds (0 for unlimited) |
 
 ```bash
 gfo ci watch 12345678
@@ -2602,8 +2602,8 @@ gfo api <METHOD> <PATH> [--data JSON] [--header HEADER]
 |---|---|
 | `METHOD` | HTTP method (GET, POST, PUT, PATCH, DELETE) |
 | `PATH` | API path (e.g., `/repos/owner/repo`) |
-| `--data` / `-d` | Request body as JSON string |
-| `--header` / `-H` | HTTP header (can be repeated, format: `Key: Value`) |
+| `--data` | Request body as JSON string |
+| `--header` | HTTP header (can be repeated, format: `Key: Value`) |
 
 **Examples:**
 
@@ -2669,7 +2669,7 @@ Manually trigger a pipeline / workflow.
 
 > **Supported services**: GitHub, GitLab, Bitbucket, Azure DevOps, Gitea, Forgejo
 >
-> **Note**: `--workflow` / `-w` is required for GitHub / Gitea.
+> **Note**: `--workflow` is required for GitHub / Gitea.
 
 ```
 gfo ci trigger --ref REF [--workflow WORKFLOW] [--input KEY=VALUE ...]
@@ -2678,7 +2678,7 @@ gfo ci trigger --ref REF [--workflow WORKFLOW] [--input KEY=VALUE ...]
 | Option | Required | Description |
 |---|---|---|
 | `--ref` | **Required** | Target branch or tag |
-| `--workflow` / `-w` | Required for GitHub/Gitea | Workflow name or filename |
+| `--workflow` | Required for GitHub/Gitea | Workflow name or filename |
 | `--input` / `-i` | — | Input parameters (`KEY=VALUE` format, can be specified multiple times) |
 
 ```bash
@@ -2920,7 +2920,7 @@ gfo batch pr create --repos SPECS --title TITLE --head BRANCH [options]
 | `--body` / `-b` | PR body | `""` |
 | `--head` / `-H` | Source branch | (required) |
 | `--base` / `-B` | Target branch | `main` |
-| `--draft` / `-d` | Create as draft PR | — |
+| `--draft` | Create as draft PR | — |
 | `--dry-run` | Validate only, do not create PRs | — |
 
 Repository specification uses the same SERVICE_SPEC format as `gfo issue migrate`.

--- a/src/gfo/cli.py
+++ b/src/gfo/cli.py
@@ -328,7 +328,6 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     _pr_list_draft = pr_list.add_mutually_exclusive_group()
     _pr_list_draft.add_argument(
         "--draft",
-        "-d",
         dest="draft",
         action="store_true",
         default=None,
@@ -345,10 +344,8 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     pr_create.add_argument("--body-file", "-F", help=_("Read body from file"))
     pr_create.add_argument("--base", "-B", help=_("Base branch"))
     pr_create.add_argument("--head", "-H", help=_("Head branch"))
-    pr_create.add_argument("--draft", "-d", action="store_true", help=_("Create as draft"))
-    pr_create.add_argument(
-        "--reviewer", "-r", action="append", help=_("Reviewer username (repeatable)")
-    )
+    pr_create.add_argument("--draft", action="store_true", help=_("Create as draft"))
+    pr_create.add_argument("--reviewer", action="append", help=_("Reviewer username (repeatable)"))
     pr_create.add_argument(
         "--assignee", "-a", action="append", help=_("Assignee username (repeatable)")
     )
@@ -374,12 +371,11 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     _merge_method.add_argument("--rebase", "-r", action="store_true", help=_("Rebase and merge"))
     pr_merge.add_argument(
         "--delete-branch",
-        "-d",
         dest="delete_branch",
         action="store_true",
         help=_("Delete branch after merge"),
     )
-    pr_merge.add_argument("--subject", "-t", help=_("Merge commit title"))
+    pr_merge.add_argument("--subject", help=_("Merge commit title"))
     pr_merge.add_argument("--body", "-b", help=_("Merge commit body"))
     pr_merge.add_argument("--auto", action="store_true", help=_("Enable auto-merge"))
     pr_merge.add_argument(
@@ -727,7 +723,7 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     # gfo repo migrate
     repo_migrate = repo_sub.add_parser("migrate", help=_("Migrate repository from URL"))
     repo_migrate.add_argument("clone_url", help=_("Clone URL of source repository"))
-    repo_migrate.add_argument("--name", "-n", required=True, help=_("Repository name or org/name"))
+    repo_migrate.add_argument("--name", required=True, help=_("Repository name or org/name"))
     _repo_migrate_visibility = repo_migrate.add_mutually_exclusive_group()
     _repo_migrate_visibility.add_argument(
         "--private", dest="visibility", action="store_const", const="private"
@@ -777,7 +773,6 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     _release_list_draft = release_list.add_mutually_exclusive_group()
     _release_list_draft.add_argument(
         "--draft",
-        "-d",
         dest="draft",
         action="store_true",
         default=None,
@@ -812,7 +807,7 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
         dest="notes_file",
         help=_("Read release notes from file"),
     )
-    release_create.add_argument("--draft", "-d", action="store_true", help=_("Create as draft"))
+    release_create.add_argument("--draft", action="store_true", help=_("Create as draft"))
     release_create.add_argument(
         "--prerelease", "-p", action="store_true", help=_("Mark as prerelease")
     )
@@ -844,9 +839,7 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
         dest="notes_file",
         help=_("Read release notes from file"),
     )
-    release_edit.add_argument(
-        "--draft", "-d", action="store_true", default=None, help=_("Mark as draft")
-    )
+    release_edit.add_argument("--draft", action="store_true", default=None, help=_("Mark as draft"))
     release_edit.add_argument(
         "--no-draft", dest="draft", action="store_false", help=_("Unmark as draft")
     )
@@ -899,7 +892,7 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     label_delete.add_argument("name", help=_("Label name"))
     label_edit = label_sub.add_parser("edit", help=_("Edit label"))
     label_edit.add_argument("current_name", metavar="NAME", help=_("Label name"))
-    label_edit.add_argument("--name", "-n", help=_("New name"))
+    label_edit.add_argument("--name", help=_("New name"))
     label_edit.add_argument("--color", "-c", help=_("Color (hex)"))
     label_edit.add_argument("--description", "-d", help=_("Description"))
 
@@ -946,7 +939,7 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     pr_edit.add_argument("--milestone", "-m", help=_("Milestone"))
     _pr_edit_draft = pr_edit.add_mutually_exclusive_group()
     _pr_edit_draft.add_argument(
-        "--draft", "-d", dest="draft", action="store_true", default=None, help=_("Convert to draft")
+        "--draft", dest="draft", action="store_true", default=None, help=_("Convert to draft")
     )
     _pr_edit_draft.add_argument(
         "--ready", dest="draft", action="store_false", help=_("Mark as ready for review")
@@ -996,7 +989,7 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
 
     # gfo repo sync（fork を上流と同期）
     repo_sync = repo_sub.add_parser("sync", help=_("Sync fork with upstream"))
-    repo_sync.add_argument("--branch", "-b", help=_("Branch to sync"))
+    repo_sync.add_argument("--branch", help=_("Branch to sync"))
 
     # gfo branch → サブサブコマンド
     branch_parser = subparser_map["branch"] = subparsers.add_parser(
@@ -1038,7 +1031,7 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     tag_create = tag_sub.add_parser("create", help=_("Create tag"))
     tag_create.add_argument("name", help=_("Tag name"))
     tag_create.add_argument("--ref", required=True, help=_("Source ref"))
-    tag_create.add_argument("--message", "-m", default="", help=_("Tag message"))
+    tag_create.add_argument("--message", default="", help=_("Tag message"))
     tag_delete = tag_sub.add_parser("delete", help=_("Delete tag"))
     tag_delete.add_argument("--yes", "-y", action="store_true", help=_("Skip confirmation prompt"))
     tag_delete.add_argument("name", help=_("Tag name"))
@@ -1199,7 +1192,7 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     ci_delete.add_argument("id", help=_("Pipeline ID"))
     ci_trigger = ci_sub.add_parser("trigger", help=_("Trigger pipeline"))
     ci_trigger.add_argument("--ref", required=True, help=_("Git ref"))
-    ci_trigger.add_argument("--workflow", "-w", help=_("Workflow name or file"))
+    ci_trigger.add_argument("--workflow", help=_("Workflow name or file"))
     ci_trigger.add_argument("--input", "-i", action="append", help=_("Input parameter (key=value)"))
     ci_retry = ci_sub.add_parser("retry", help=_("Retry pipeline"))
     ci_retry.add_argument("id", help=_("Pipeline ID"))
@@ -1209,10 +1202,10 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     ci_watch = ci_sub.add_parser("watch", help=_("Watch pipeline status"))
     ci_watch.add_argument("id", help=_("Pipeline ID"))
     ci_watch.add_argument(
-        "--interval", "-i", type=_positive_int, default=5, help=_("Poll interval in seconds")
+        "--interval", type=_positive_int, default=5, help=_("Poll interval in seconds")
     )
     ci_watch.add_argument(
-        "--timeout", "-t", type=int, default=1800, help=_("Timeout in seconds (0 for unlimited)")
+        "--timeout", type=int, default=1800, help=_("Timeout in seconds (0 for unlimited)")
     )
     ci_download = ci_sub.add_parser("download", help=_("Download pipeline logs to file"))
     ci_download.add_argument("id", help=_("Pipeline ID"))
@@ -1752,8 +1745,8 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
         help=_("HTTP method"),
     )
     api_parser.add_argument("path", help=_("API path"))
-    api_parser.add_argument("--data", "-d", help=_("Request body (JSON)"))
-    api_parser.add_argument("--header", "-H", action="append", help=_("Request header"))
+    api_parser.add_argument("--data", help=_("Request body (JSON)"))
+    api_parser.add_argument("--header", action="append", help=_("Request header"))
 
     # gfo batch → サブコマンド
     batch_parser = subparser_map["batch"] = subparsers.add_parser(
@@ -1774,7 +1767,7 @@ def create_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.Argumen
     batch_pr_create.add_argument("--body", "-b", default="", help=_("Body"))
     batch_pr_create.add_argument("--head", "-H", required=True, help=_("Head branch"))
     batch_pr_create.add_argument("--base", "-B", default="main", help=_("Base branch"))
-    batch_pr_create.add_argument("--draft", "-d", action="store_true", help=_("Create as draft"))
+    batch_pr_create.add_argument("--draft", action="store_true", help=_("Create as draft"))
     batch_pr_create.add_argument(
         "--dry-run", dest="dry_run", action="store_true", help=_("Dry run")
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1714,3 +1714,84 @@ def test_hoist_main_format_after_subcommand():
     handler.assert_called_once()
     _, kwargs = handler.call_args
     assert kwargs["fmt"] == "json"
+
+
+# ── 短縮フラグの一意性ガードテスト（#70） ──
+
+# pr merge の --merge/-m --squash/-s --rebase/-r は mutually exclusive group
+# （gh CLI 互換）のため、この 1 コマンドに限りグローバルな「1 短縮フラグ = 1 意味」の
+# 対象から除外する。
+_SHORT_FLAG_PATH_EXCEPTIONS = {
+    ("pr", "merge"): {"-m", "-s", "-r"},
+}
+
+# "ファイルから読む" という一貫した意味を持つとみなし、対象から除外する短縮フラグ。
+_SHORT_FLAG_GLOBAL_EXCEPTIONS = {"-F"}
+
+
+def _walk_short_flags(parser, path):
+    """パーサーを再帰的に走査し、(コマンドパス, 短縮フラグ集合, 意味) の一覧を返す。
+
+    NOTE: argparse の非公開 API を使用: parser._actions, _SubParsersAction。
+    """
+    entries = []
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            for name, sub_parser in action.choices.items():
+                entries.extend(_walk_short_flags(sub_parser, path + (name,)))
+            continue
+        short_flags = tuple(
+            o for o in action.option_strings if len(o) == 2 and o[0] == "-" and o[1] != "-"
+        )
+        if not short_flags:
+            continue
+        long_opts = tuple(o for o in action.option_strings if o.startswith("--"))
+        meaning = long_opts[0] if long_opts else action.dest
+        entries.append((path, short_flags, meaning))
+    return entries
+
+
+def test_short_flags_have_unique_meaning():
+    """短縮フラグは全体で1つの意味（long option）にのみ対応する（#70）。
+
+    衝突していた短縮フラグ（-t/-n/-d/-b/-m/-w/-H/-i/-r）を長い形のみに整理した。
+    再発防止のため、パーサー全体を走査して意味の対応が一意であることを検証する。
+    """
+    import collections
+
+    main_parser, _ = create_parser()
+    entries = _walk_short_flags(main_parser, ())
+
+    meanings = collections.defaultdict(set)
+    for path, short_flags, meaning in entries:
+        allowed_here = _SHORT_FLAG_PATH_EXCEPTIONS.get(path, set())
+        for flag in short_flags:
+            if flag == "-h" or flag in _SHORT_FLAG_GLOBAL_EXCEPTIONS or flag in allowed_here:
+                continue
+            meanings[flag].add(meaning)
+
+    conflicts = {flag: sorted(m) for flag, m in meanings.items() if len(m) > 1}
+    assert conflicts == {}, f"短縮フラグが複数の意味を持つ: {conflicts}"
+
+
+def test_pr_merge_method_flags_are_the_documented_exception():
+    """pr merge の --merge/-m --squash/-s --rebase/-r は例外として維持されている。"""
+    _, subparser_map = create_parser()
+    pr_parser = subparser_map["pr"]
+    merge_parser = None
+    for action in pr_parser._actions:
+        if isinstance(action, argparse._SubParsersAction) and "merge" in action.choices:
+            merge_parser = action.choices["merge"]
+            break
+    assert merge_parser is not None
+
+    short_to_long = {}
+    for action in merge_parser._actions:
+        short = [o for o in action.option_strings if len(o) == 2 and o[0] == "-" and o[1] != "-"]
+        long_opts = [o for o in action.option_strings if o.startswith("--")]
+        for s in short:
+            short_to_long[s] = long_opts[0]
+
+    assert short_to_long["-m"] == "--merge"
+    assert short_to_long["-s"] == "--squash"
+    assert short_to_long["-r"] == "--rebase"


### PR DESCRIPTION
## Summary

短縮フラグが複数の異なる意味に割り当てられていた箇所を、実際の argparse 構造を再帰的に走査するスクリプトで全量監査し、「1 短縮フラグ = 1 意味」の原則に統一した。issue 本文が挙げていた `-t` / `-n` の衝突だけでなく、issue のコメントで指摘された `-d` / `-b` / `-m` / `-w` / `-s` / `-H` の衝突、さらに手動監査では見落とされていた `-i`（`--input` vs `--interval`）・`-r`（`--reviewer` vs `--rebase`）の衝突も検出・修正した。

### BREAKING CHANGE

以下の短縮フラグを削除した（**長い形は全コマンドで引き続き利用可能**）:

| フラグ | 削除箇所 | 代替 |
|---|---|---|
| `-t` | `pr merge`, `ci watch` | `--subject`, `--timeout` |
| `-n` | `repo migrate`, `label edit` | `--name` |
| `-d` | `pr list/create/edit --draft`, `release list/create/edit --draft`, `batch pr create --draft`, `api --data`, `pr merge --delete-branch` | `--draft`, `--data`, `--delete-branch` |
| `-b` | `repo sync` | `--branch` |
| `-m` | `tag create` | `--message` |
| `-w` | `ci trigger` | `--workflow` |
| `-H` | `api` | `--header` |
| `-i` | `ci watch` | `--interval` |
| `-r` | `pr create` | `--reviewer` |

`pr merge` の `--merge/-m --squash/-s --rebase/-r`（mutually exclusive group、gh CLI 互換）は使い勝手を優先しこの 1 コマンドに限り例外として維持し、ガードテストで明示的に allowlist している。`-F`（`--body-file`/`--notes-file`）も「ファイルから読む」という一貫した意味とみなし対象外。

### 再発防止

`tests/test_cli.py` に `create_parser()` を再帰走査するガードテストを追加。短縮フラグの意味がグローバルに一意であることを CI で検証し、新規コマンド追加時の衝突混入を防ぐ。

### その他

- `docs/commands.md` / `docs/commands.ja.md` のオプション一覧テーブルから削除済み短縮フラグの記載を除去（`gfo issue develop --name` の `-n` 表記は実装に存在しない記載ミスだったため合わせて修正）
- CHANGELOG は本リポジトリの慣例（`.claude/rules` 参照）どおりリリース準備コミットでまとめて追記するため、本 PR では更新していません。リリース時に本 PR の Breaking Changes セクションを参照してください。

Closes #70

## Test plan
- [x] `uv run pytest` 全件パス（4057 passed、新規ガードテストが実際の argparse 構造との不一致をゼロ件で検証）
- [x] `uv run ruff check .` / `uv run ruff format --check .`
- [x] `uv run mypy src/gfo`
- [x] `uv run bandit -r src/gfo -c pyproject.toml`
- [x] `gfo pr merge --help` / `gfo ci watch --help` / `gfo pr create --help` を手動実行し short flag が意図通りであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)