### PR TITLE
ci: mise セットアップを prata0x/actions/setup-mise に切り替える

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           fi
 
       - name: Setup mise (python + uv)
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        uses: prata0x/actions/setup-mise@8798a439844c9fd4545fc00fc3611e8b13d58ac1 # v1.0.0
 
       - name: Cache uv packages
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -120,7 +120,7 @@ jobs:
       # mise-action は python/uv の toolchain バイナリはキャッシュするが、uv の
       # パッケージキャッシュ (~/.cache/uv) はキャッシュしないため、下の cache step で補う。
       - name: Setup mise (python + uv)
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        uses: prata0x/actions/setup-mise@8798a439844c9fd4545fc00fc3611e8b13d58ac1 # v1.0.0
 
       # uv のパッケージキャッシュ (~/.cache/uv = 展開済み wheel) を復元/保存し、毎ジョブの
       # wheel ダウンロードを省く。キーは uv.lock のハッシュ + OS + python 版で構成し、

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
 
       # mise.toml の python / uv を供給する (ローカル開発 / ci.yml と同一 toolchain)。
       - name: Setup mise (python + uv)
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        uses: prata0x/actions/setup-mise@8798a439844c9fd4545fc00fc3611e8b13d58ac1 # v1.0.0
 
       # hatchling のカスタムフック (.po → .mo) を含め sdist + wheel をビルドする。
       # uv build は隔離環境で build-backend を実行するため事前の sync は不要。


### PR DESCRIPTION
## Summary
- `jdx/mise-action` の直接利用を、mise 本体のバージョン固定を一元管理する自前の composite action `prata0x/actions/setup-mise@v1.0.0` に切り替え (ci.yml x2, release.yml x1)
- 動作は変更なし（同じ mise 2026.7.0 を内部で SHA pin して呼び出すラッパー）

## Test plan
- [ ] CI green を確認