### PR TITLE
chore(deps): github-actions の Dependabot 更新にも cooldown を追加する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,6 +49,8 @@ updates:
       time: "06:00"
       timezone: Asia/Tokyo
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: chore
       include: scope


### PR DESCRIPTION
## Summary
- zizmor (`uvx zizmor .github/dependabot.yml`) で `dependabot-cooldown` (medium) を検出
- `uv` エコシステムには `cooldown: default-days: 7` があったが `github-actions` エコシステムに抜けていたため追加し、供給網対策 (リリース直後の新版隔離) を両方に揃える

## Test plan
- [x] `uvx zizmor .github/dependabot.yml` で findings 0 件を確認
- [ ] CI green を確認