### PR TITLE
ci: zizmor --pedantic の指摘を解消する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,9 @@ jobs:
       # dev は dependency-groups で定義されており uv sync が既定でインストールする。
       # --python で matrix のバージョンに .venv を作る (mise の既定 python を上書き)。
       - name: Install dependencies (frozen, python ${{ matrix.python-version }})
-        run: uv sync --locked --python ${{ matrix.python-version }}
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
+        run: uv sync --locked --python "$PYTHON_VERSION"
 
       # mypy は version_info 分岐等で版差が出うるため min/max 両 leg で実行する。
       - name: Type check (mypy)
@@ -154,7 +156,8 @@ jobs:
       - name: Unit tests (pytest)
         env:
           COVERAGE_CORE: ${{ matrix.label == 'max' && 'sysmon' || '' }}
-        run: uv run pytest -n 4 ${{ matrix.cov }} -q
+          PYTEST_COV_ARGS: ${{ matrix.cov }}
+        run: uv run pytest -n 4 $PYTEST_COV_ARGS -q
 
   # matrix を束ねる安定名の必須チェック。Ruleset は "ci" だけを Require すればよく、
   # テスト対象バージョンを増減しても再設定不要。
@@ -168,12 +171,15 @@ jobs:
       contents: read
     steps:
       - name: Gate on quality and test results
+        env:
+          QUALITY_RESULT: ${{ needs.quality.result }}
+          TEST_RESULT: ${{ needs.test.result }}
         run: |
-          if [ "${{ needs.quality.result }}" != "success" ]; then
-            echo "::error::quality job did not succeed (result=${{ needs.quality.result }})"
+          if [ "$QUALITY_RESULT" != "success" ]; then
+            echo "::error::quality job did not succeed (result=$QUALITY_RESULT)"
             exit 1
           fi
-          if [ "${{ needs.test.result }}" != "success" ]; then
-            echo "::error::test matrix did not succeed (result=${{ needs.test.result }})"
+          if [ "$TEST_RESULT" != "success" ]; then
+            echo "::error::test matrix did not succeed (result=$TEST_RESULT)"
             exit 1
           fi

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,11 @@ on:
 permissions:
   contents: read
 
+# 同一 ref への連続 push では古い run をキャンセルし、無駄な実行を避ける。
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (python)

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,8 +13,14 @@ on:
 permissions:
   contents: read
 
+# 同一 ref への連続 push では古い run をキャンセルし、無駄な実行を避ける。
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dependency-review:
+    name: dependency-review
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
       name: pypi
       url: https://pypi.org/project/gfo/
     permissions:
-      id-token: write
+      id-token: write # PyPI Trusted Publishing (OIDC) でトークンを発行するため
     steps:
       - name: Download dist artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
## Summary
- `uvx zizmor --pedantic .github/` で検出された 10 件 (1 informational, 9 low、いずれも code smell レベル) を修正
  - template-injection: `ci.yml` の `run:` block 内で `${{ matrix.python-version }}` / `${{ matrix.cov }}` / `${{ needs.*.result }}` を直接展開せず `env:` 経由の shell 変数に変更
  - concurrency-limits: `codeql.yml` / `dependency-review.yml` に `concurrency` (同一 ref の古い run キャンセル) を追加
  - anonymous-definition: `dependency-review.yml` の job に `name:` を追加
  - undocumented-permissions: `release.yml` の `id-token: write` に説明コメントを追加
- 通常 persona (`uvx zizmor .github/`) では元々 0 件だったので挙動変更ではなく hardening のみ

## Test plan
- [x] `uvx zizmor --pedantic .github/` で findings 0 件を確認
- [x] YAML 構文チェック (`yaml.safe_load`)
- [x] SHA-pin 自己検証 (`grep` で全 `uses:` が 40桁 SHA pin) を確認
- [ ] CI green を確認