### PR TITLE
ci: job 表示名を統一しランナー説明コメントを整理する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,10 @@
 # test leg と並列に走り (~10s < test ~25s) クリティカルパスには乗らない。
 # mypy は version_info 分岐等で版差が出うるため test 両 leg に残す。
 #
-# Runner: gfo は public リポジトリで GitHub Actions が無料のため、全ジョブを GitHub-hosted の
-# ubuntu-latest で回す (self-hosted は使わない)。
-#
 # Python バージョン: 対応下限 (min) と最新 (max) の 2 つを matrix で並列検証する。
 # job 名にバージョン番号を入れず min/max ラベルにするのは、版を上げても check 名 (= Ruleset の
-# 必須ステータスチェック名) が変わらないようにするため。さらに matrix を束ねる安定名 "ci" の
-# aggregate gate job を置き、Ruleset の必須チェックは "ci" 一本で固定する (版更新で再設定不要)。
+# 必須ステータスチェック名) が変わらないようにするため。さらに matrix を束ねる安定名 "verify" の
+# aggregate gate job を置き、Ruleset の必須チェックは "verify" 一本で固定する (版更新で再設定不要)。
 #
 # 統合テストは実サービス (GitHub/GitLab 等) へアクセスするため CI では実行しない。
 # pytest 設定 (pyproject.toml の addopts) で tests/integration を除外済み。
@@ -43,7 +40,7 @@ jobs:
   # version 非依存の品質チェックを 1 回だけ実行する (mise 既定の python = 3.13)。
   # test matrix と並列に走るためクリティカルパスには乗らない。
   quality:
-    name: quality
+    name: Quality
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -91,7 +88,7 @@ jobs:
         run: uv run bandit -r src/gfo -c pyproject.toml -q
 
   test:
-    name: test (${{ matrix.label }})
+    name: Test (${{ matrix.label }})
     runs-on: ubuntu-latest
     # ハング時の保険。通常 1 分前後で終わる。
     timeout-minutes: 15
@@ -159,10 +156,10 @@ jobs:
           PYTEST_COV_ARGS: ${{ matrix.cov }}
         run: uv run pytest -n 4 $PYTEST_COV_ARGS -q
 
-  # matrix を束ねる安定名の必須チェック。Ruleset は "ci" だけを Require すればよく、
+  # matrix を束ねる安定名の必須チェック。Ruleset は "verify" だけを Require すればよく、
   # テスト対象バージョンを増減しても再設定不要。
-  ci:
-    name: ci
+  verify:
+    name: Verify
     needs: [quality, test]
     if: ${{ always() }}
     runs-on: ubuntu-latest

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,5 +1,5 @@
 # PR が追加/更新する依存に既知の脆弱性 (GitHub Advisory DB) があればマージ前にブロックする。
-# Dependabot (事後通知) に対し、これは PR 時点の事前ゲート。public リポジトリで無償、
+# Dependabot (事後通知) に対し、これは PR 時点の事前ゲート。
 # Dependency graph (uv.lock を含む) の差分を見るため pull_request でのみ意味を持つ。
 #
 # 権限は contents: read のみ (依存グラフ参照に必要)。PR への自動コメントは行わない
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   dependency-review:
-    name: dependency-review
+    name: Dependency review
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
   # ソースをチェックアウトして sdist / wheel をビルドし、artifact として publish job へ渡す。
   # OIDC 権限は持たない (contents: read のみ)。
   build:
-    name: build
+    name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -90,7 +90,7 @@ jobs:
   # build 成果物を PyPI へ公開する。OIDC トークン発行のため id-token: write を付与し、
   # checkout は行わない (ソース取得経路と分離)。
   publish:
-    name: publish
+    name: Publish
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@
 #   GitHub-hosted ubuntu-latest / action は 40桁 commit SHA で pin / persist-credentials: false /
 #   permissions は job ごとに最小付与。SHA pin の自己検証は ci.yml の quality job が全 workflow
 #   ファイルを対象に行うため (PR 時に強制)、ここでは重複させない。
-name: release
+name: Release
 
 on:
   push:


### PR DESCRIPTION
## 概要

- CI 系ワークフローの job 表示名 (`name:`) を統一する。
- `public リポジトリだから無料で使える` / `self-hosted は使わない` といった、job 表示名とは無関係な補足コメントを削除する。

## 変更内容

### ci.yml
- `jobs.quality.name`: `quality` → `Quality`
- `jobs.test.name`: `test (${{ matrix.label }})` → `Test (${{ matrix.label }})`
- aggregate gate job の id を `ci` → `verify` にリネーム、`name`: `ci` → `Verify`
- Runner (public だから無料 / self-hosted は使わない) の説明コメントを削除
- コメント中の `"ci"` 表記を `"verify"` に追従

### dependency-review.yml
- `jobs.dependency-review.name`: `dependency-review` → `Dependency review`
- 冒頭コメントの「public リポジトリで無償」を削除

### release.yml
- `jobs.build.name`: `build` → `Build`
- `jobs.publish.name`: `publish` → `Publish`

## 注意事項

- GitHub Rules（branch protection）による必須ステータスチェックは free プランでは実効しないため（CLAUDE.md 記載）、本 PR による設定変更は不要。ただし将来 Rules を有効化する場合、必須チェック名は旧 `ci` ではなく新しい `Verify` を指定する必要がある。

## Test plan

- [x] `uv run python -c "import yaml; yaml.safe_load(open(f))"` で3ファイルとも構文チェック済み
- [ ] CI green を確認