### PR TITLE
docs: CLAUDE.md の pytest カバレッジ記載を実態に合わせる

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,8 @@ mise install
 uv sync            # dependency-groups の dev も既定でインストールされる
 
 # 以降は uv run 経由でツールを実行する（`python -m ...` は使わない）
-uv run pytest                       # 単体テスト（カバレッジ付き・統合テストは自動除外）
+uv run pytest                       # 単体テスト（カバレッジ無し・統合テストは自動除外）
+uv run pytest --cov=gfo --cov-report=term-missing -n auto   # カバレッジ計測が必要な場合は明示的に付与
 uv run pytest tests/test_commands/test_pr.py -v   # 特定テスト
 uv run ruff check .                 # lint
 uv run ruff format .                # format


### PR DESCRIPTION
## Summary
- CLAUDE.md:56 の「カバレッジ付き」という記載が pyproject.toml の addopts（--cov 系を含まない）や test スキルの実態と矛盾していた
- 「カバレッジ無し」に修正し、カバレッジ計測が必要な場合の明示コマンドを追記

## Test plan
- [x] ドキュメントのみの変更のため CI が green であることを確認

Closes #98