### PR TITLE
ci: /test スキルを uv run 経由に統一する

### DIFF
--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -7,8 +7,8 @@ allowed-tools: Bash, Read, Glob, Grep
 ## Context
 
 - Python パス: !`which python`
-- pytest バージョン: !`python -m pytest --version 2>&1 | head -1`
-- テスト総数: !`python -m pytest --collect-only -q 2>/dev/null | tail -1`
+- pytest バージョン: !`uv run pytest --version 2>&1 | head -1`
+- テスト総数: !`uv run pytest --collect-only -q 2>/dev/null | tail -1`
 - ワーキングツリー状態: !`git status --short`
 
 ## Arguments
@@ -29,12 +29,12 @@ allowed-tools: Bash, Read, Glob, Grep
 ### 実行手順
 
 1. **引数の解析**: `$ARGUMENTS` を確認する
-   - 引数なし → `python -m pytest --ignore=tests/integration --cov=gfo --cov-report=term-missing -n auto`
+   - 引数なし → `uv run pytest --ignore=tests/integration --cov=gfo --cov-report=term-missing -n auto`
    - ファイルやキーワード指定あり → そのまま pytest に渡す（`--cov=gfo --cov-report=term-missing -n auto` は維持）
 
 2. **テスト実行**: 以下のコマンドで実行する
    ```
-   python -m pytest {target} --cov=gfo --cov-report=term-missing -n auto
+   uv run pytest {target} --cov=gfo --cov-report=term-missing -n auto
    ```
    - `{target}` は引数から構築する
    - `tests/integration/` は常に除外する（引数で明示的に指定された場合を除く）


### PR DESCRIPTION
## Summary
- `.claude/skills/test/SKILL.md` が CLAUDE.md の「uv run 経由でツールを実行する（python -m は使わない）」規約に反して `python -m pytest` を使用していた
- `uv run pytest` に統一し、規約との矛盾を解消

## Test plan
- [x] `uv run pytest --version` / `uv run pytest --collect-only -q` がこの環境で動作することを確認済み

Closes #99