### PR TITLE
docs: Azure DevOps issue create の --type 省略時デフォルトを明記する

### DIFF
--- a/docs/commands.ja.md
+++ b/docs/commands.ja.md
@@ -625,7 +625,7 @@ gfo issue create --title TITLE [--body BODY] [--body-file FILE] [--assignee USER
 | `--assignee` / `-a` | — | 担当者 |
 | `--label` / `-l` | — | ラベル |
 | `--milestone` / `-m` | — | マイルストーン名 |
-| `--type` | — | Issue タイプ（Azure DevOps: `Task`, `Bug` など） |
+| `--type` | — | Issue タイプ（Azure DevOps: `Task`, `Bug` など。省略時 Azure DevOps では `Task` になる） |
 | `--priority` | — | 優先度（Backlog など数値で指定するサービス向け） |
 | `--due-date` | — | 期限（YYYY-MM-DD 形式、対応サービスのみ） |
 | `--template` | — | Issue テンプレート名 |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -611,7 +611,7 @@ gfo issue create --title TITLE [--body BODY] [--body-file FILE] [--assignee USER
 | `--assignee` / `-a` | — | Assignee |
 | `--label` / `-l` | — | Label |
 | `--milestone` / `-m` | — | Milestone name |
-| `--type` | — | Issue type (Azure DevOps: `Task`, `Bug`, etc.) |
+| `--type` | — | Issue type (Azure DevOps: `Task`, `Bug`, etc.; defaults to `Task` on Azure DevOps when omitted) |
 | `--priority` | — | Priority (for services that use numeric priority, e.g., Backlog) |
 | `--due-date` | — | Due date (YYYY-MM-DD format, for services that support it) |
 | `--template` | — | Issue template name |


### PR DESCRIPTION
## Summary
- `.claude/rules/06-azure-devops.md` には「デフォルト Work Item Type: Task」と記載があるが、ユーザー向け `docs/commands.md`（英）/`commands.ja.md`（日）には省略時デフォルトが未記載だった
- GitHub/GitLab 感覚で `--type` を省略すると Azure DevOps では意図せず `Task` タイプで作成される旨を明記

## Test plan
- [x] ドキュメントのみの変更のため CI が green であることを確認

Closes #105