### PR TITLE
fix(exceptions): 401 と 403 でメッセージ・ヒントを分岐する

### DIFF
--- a/src/gfo/exceptions.py
+++ b/src/gfo/exceptions.py
@@ -102,18 +102,28 @@ class HttpError(GfoError):
 
 
 class AuthenticationError(HttpError):
-    """401/403 認証エラー。"""
+    """401/403 認証エラー。
+
+    401（トークン自体が無効）と 403（トークンは有効だがスコープ/権限不足）は
+    原因が異なるため、status_code に応じてメッセージを分岐する。
+    """
 
     error_code = "auth_failed"
     exit_code = ExitCode.AUTH
 
     def __init__(self, status_code: int, url: str = ""):
-        super().__init__(
-            status_code,
-            _("Authentication failed. Check your token with 'gfo auth status'."),
-            url,
-        )
-        self.hint = _("Check your token with 'gfo auth status'.")
+        if status_code == 403:
+            message = _(
+                "Permission denied. Your token may be valid but lack the required "
+                "scope for this operation. See 'Token Creation Instructions by "
+                "Service' in docs/authentication.md."
+            )
+            hint = message
+        else:
+            message = _("Authentication failed. Check your token with 'gfo auth status'.")
+            hint = _("Check your token with 'gfo auth status'.")
+        super().__init__(status_code, message, url)
+        self.hint = hint
 
 
 class NotFoundError(HttpError):

--- a/src/gfo/locale/ja/LC_MESSAGES/gfo.po
+++ b/src/gfo/locale/ja/LC_MESSAGES/gfo.po
@@ -139,6 +139,9 @@ msgstr "HTTP {status_code}: {message}"
 msgid "Authentication failed. Check your token with 'gfo auth status'."
 msgstr "認証に失敗しました。'gfo auth status' でトークンを確認してください。"
 
+msgid "Permission denied. Your token may be valid but lack the required scope for this operation. See 'Token Creation Instructions by Service' in docs/authentication.md."
+msgstr "権限がありません。トークン自体は有効でも、この操作に必要なスコープが不足している可能性があります。docs/authentication.md の「Token Creation Instructions by Service」を確認してください。"
+
 msgid "Resource not found."
 msgstr "リソースが見つかりません。"
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -95,6 +95,9 @@ class TestAuthenticationError:
         assert err.status_code == 403
         assert isinstance(err, HttpError)
         assert isinstance(err, GfoError)
+        assert "Permission denied" in str(err)
+        assert "scope" in str(err)
+        assert err.hint == str(err).removeprefix("HTTP 403: ")
 
 
 class TestNotFoundError:


### PR DESCRIPTION
## Summary
- `AuthenticationError` は 401（トークン自体が無効）と 403（トークンは有効だがスコープ/権限不足）を同一の「トークンを確認しろ」というメッセージにマップしており、実際の原因が権限不足であっても誤誘導していた
- 403 の場合はメッセージ・ヒントを「スコープ不足の可能性があり、docs/authentication.md の Token Creation Instructions by Service を確認する」旨に分岐
- 401 の既存メッセージ・ヒントは変更なし
- 新規メッセージの ja 訳を gfo.po に追加、既存テストの 403 アサーションを更新

## Test plan
- [x] `uv run pytest`（4057 件通過）
- [x] `uv run ruff check .` / `uv run ruff format --check .` / `uv run mypy src/gfo`

Closes #103