### PR TITLE
fix(exceptions): NotSupportedError に汎用的な既定ヒントを持たせる

### DIFF
--- a/src/gfo/cli.py
+++ b/src/gfo/cli.py
@@ -2141,8 +2141,8 @@ def main(argv: list[str] | None = None) -> int:
                 print(format_error_json(err), file=sys.stderr)
             else:
                 print(str(err), file=sys.stderr)
-                if isinstance(err, NotSupportedError) and err.web_url:
-                    print(err.web_url)
+                if isinstance(err, NotSupportedError) and err.hint:
+                    print(err.hint)
             return err.exit_code
         except KeyboardInterrupt:
             # Ctrl+C による中断: トレースバックを抑制して標準的な終了コード 130 を返す

--- a/src/gfo/exceptions.py
+++ b/src/gfo/exceptions.py
@@ -196,8 +196,11 @@ class NotSupportedError(GfoError):
                 service=service, operation=operation
             )
         )
-        if web_url:
-            self.hint = web_url
+        # web_url が渡されなかった場合でも、対象リポジトリの Web UI への
+        # 汎用的な導線だけは提示する（個別の URL までは特定できないため）。
+        self.hint = web_url or _(
+            "Run 'gfo repo view --web' to open the repository in your browser."
+        )
 
 
 class PartialFailureError(GfoError):

--- a/src/gfo/locale/ja/LC_MESSAGES/gfo.po
+++ b/src/gfo/locale/ja/LC_MESSAGES/gfo.po
@@ -154,6 +154,9 @@ msgstr "サーバーエラーです。しばらくしてから再試行してく
 msgid "{service} does not support {operation}. Use the web interface instead."
 msgstr "{service} は {operation} に対応していません。Web インターフェースを使用してください。"
 
+msgid "Run 'gfo repo view --web' to open the repository in your browser."
+msgstr "'gfo repo view --web' を実行してリポジトリをブラウザで開いてください。"
+
 msgid "{failed} of {total} operations failed."
 msgstr "{total} 件中 {failed} 件の操作が失敗しました。"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1213,6 +1213,23 @@ def test_main_not_supported_error_text_format_still_prints_web_url(capsys):
     assert "github" in captured.err
 
 
+def test_main_not_supported_error_text_format_prints_default_hint_without_web_url(capsys):
+    """--format table で web_url 未指定でも、汎用的なヒントが stdout に出力される。"""
+
+    def raise_nse(args, *, fmt, jq=None):
+        raise NotSupportedError("gitlab", "milestones")
+
+    with (
+        patch.dict(_DISPATCH, {("pr", "list"): raise_nse}),
+        patch("gfo.cli.get_configured_output_format", return_value="table"),
+    ):
+        result = main(["pr", "list"])
+    assert result == 5
+    captured = capsys.readouterr()
+    assert "gfo repo view --web" in captured.out
+    assert "gitlab" in captured.err
+
+
 # ── _ensure_utf8_stdio のテスト ──
 
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -280,9 +280,9 @@ class TestHint:
         err = NotSupportedError("Gitea", "op", web_url="https://example.com")
         assert err.hint == "https://example.com"
 
-    def test_not_supported_error_hint_none_without_web_url(self):
+    def test_not_supported_error_hint_defaults_to_generic_guidance(self):
         err = NotSupportedError("Gitea", "op")
-        assert err.hint is None
+        assert err.hint == "Run 'gfo repo view --web' to open the repository in your browser."
 
     def test_rate_limit_error_hint_with_retry_after(self):
         err = RateLimitError(retry_after=60)


### PR DESCRIPTION
## Summary
- `NotSupportedError` は `web_url` を渡された場合のみ `hint` を設定していたが、`adapter/base.py` 内の 159 件の呼び出しは 0 件しか `web_url=` を渡しておらず、非対応操作のヒントが常に空振りしていた
- 159 箇所を個別に精査して実 URL を付与するのは規模が大きい変更のため、まずは `web_url` 未指定時のフォールバックとして「`gfo repo view --web` で対象リポジトリをブラウザで開く」旨の汎用ヒントを既定値として設定
- `cli.py` 側も `web_url` の有無ではなく `hint` の有無で判定するよう変更し、このフォールバックが非 JSON 出力でも実際に表示されるようにした（従来は JSON 出力でしか `hint` が見えなかった）

## Test plan
- [x] `uv run pytest`（4058 件通過、新規テスト2件追加）
- [x] `uv run ruff check .` / `uv run ruff format --check .` / `uv run mypy src/gfo` / `uv run bandit -r src/gfo -c pyproject.toml`

Closes #102