### PR TITLE
docs: 共有CLAUDE.md規約をvendorし重複記述を整理

### DIFF
--- a/.claude/vendor/product-repo.md
+++ b/.claude/vendor/product-repo.md
@@ -1,0 +1,80 @@
+<!-- GENERATED FILE — do not edit directly.
+     Source: claude-md/*.md, composed by scripts/build-bundles.mjs.
+     Edit the source files under claude-md/ and re-run this script instead. -->
+
+## Decision-making and clarifying questions
+
+Rank implementation options by: "if this were built from scratch today,
+what would we pick?" and "will this hold up in 5-10 years?"
+
+Do not justify a choice by the existing implementation's shape, diff size,
+scope framing ("technically out of scope"), "minimal change" wording, or
+implementation effort as a tiebreaker. If removing one of these phrases
+from a draft recommendation would change the ranking, the ranking is
+non-compliant — rewrite it using the lens above.
+
+When a decision needs to be surfaced to the user, structure it as:
+background (why it matters) -> options (2-4) -> tradeoffs (framed by
+user-visible behavior, ops cost, and long-term debt, not internal function
+or file names) -> a recommendation (one option, 1-2 lines of reasoning).
+Mark the recommended option first (e.g. in `AskUserQuestion`).
+
+## Autonomy and task tracking
+
+Run `/tdd` -> `/pre-commit-code-review` -> commit -> push -> open a PR ->
+`/pre-merge-code-review` -> wait for CI -> merge once green, all without
+per-step confirmation. Commit granularity, PR granularity, and whether to
+file an issue are all within your judgment.
+
+Run `/pre-merge-code-review` right after opening the PR rather than
+waiting for CI — CI runs in the background regardless, so reviewing in
+parallel uses that wait time instead of stacking review time after it.
+`/pre-merge-code-review` is the last check before an autonomous merge with
+no human PR review gate; internally it skips only its correctness
+re-check on a single-commit branch (already covered by the per-commit
+review), and its security check always runs regardless of commit count.
+If a new commit lands after that review and before merge (e.g. a
+CI-failure fix-up), re-run `/pre-merge-code-review` against the updated
+diff before merging — never merge a diff that differs from what was last
+reviewed.
+
+Confirm first: history rewrite or force-push of published commits,
+external-service actions (deploys, third-party API calls with side
+effects), and security-sensitive or non-trivial schema/architecture
+decisions — work through these in dialogue, one item at a time.
+
+When you find something worth fixing outside the current task, fix it
+inline or file an issue and report afterward, rather than stopping to ask
+— provided the finding has code-level evidence and isn't a hunch.
+
+Once a blanket rule is confirmed ("for all X, do Y"), keep applying it
+mechanically even as scope expands; raise a candidate exception as a
+separate question instead of narrowing the rule unilaterally.
+
+Track the backlog in GitHub Issues via the `gh` CLI, not ad-hoc notes, TODO
+comments, or handoff documents.
+
+Before starting a large addition, change, or fix, and after repeated
+failed attempts at the same problem or when a failure's root cause can't
+be pinned down, run `/second-opinion` — an independent read from a model
+outside the main session. Run it unconditionally, no confirmation needed;
+report the result afterward. Whether to act on the feedback is your
+judgment call.
+
+## Engineering conventions
+
+Use Conventional Commits.
+
+Write a test that reproduces a bug before fixing it. For concurrency/
+race-condition fixes, use a real concurrency-forcing test harness — a
+sequential test that passes on both the old and new code is not a valid
+regression pin.
+
+Propose updating the handoff doc and switching to a fresh session when
+either: context is getting full and you've reached a clean stopping point,
+or the next task is large, complex, or largely unrelated to the current
+context and would go better starting from a clear context. Include: the
+absolute worktree path, branch name and last commit, completed/skipped
+tasks (with reasons for any skipped), and the next task quoted from the
+original spec rather than summarized.
+

--- a/.claude/vendor/universal.md
+++ b/.claude/vendor/universal.md
@@ -1,0 +1,54 @@
+<!-- GENERATED FILE — do not edit directly.
+     Source: claude-md/*.md, composed by scripts/build-bundles.mjs.
+     Edit the source files under claude-md/ and re-run this script instead. -->
+
+## Git and gh operations
+
+- Do not use `git add -A` or `git add .` — they can sweep in unrelated or
+  unintended files. Stage explicitly by path instead.
+- Do not use `gh pr merge --auto` — it merges without you having read the
+  actual CI result. Run `gh pr checks`, read the output, then merge.
+- Do not pipe `gh pr checks --watch` into another command — piping can
+  swallow the real exit status. Run it directly and read the output.
+- `gh` `--body`/`--comment` arguments containing backticks: pass them via a
+  quoted heredoc (`"$(cat <<'EOF' ... EOF)"`) instead of an inline string.
+- Repos with a `.github/workflows/` directory: use an SSH remote
+  (`git@github.com:...`) instead of HTTPS.
+
+## Collaboration norms
+
+Write in English: CLAUDE.md, everything under `.claude/*`, memory files,
+and prompts to (sub)agents.
+
+Write in Japanese, using natural, polite phrasing (です・ます): replies to
+the user, commit messages, and issue/PR titles, bodies, and comments — even
+when the surrounding tool output, diffs, and logs are in English.
+
+Do not name other projects or organizations in code, commits, issues, or
+PRs. Describe cross-project context generically instead.
+
+Write issue/PR comments as decision content only. Omit dates, timing
+narration, and meta-commentary — git/GitHub metadata already carries that.
+
+Before writing a code comment, ask: would this make sense to someone with
+no memory of this conversation? State only durable facts about the code —
+never this session's plan, an instruction, "per your request," a prior
+draft, an ad hoc label invented while working, or how the code changed.
+If a comment leans on this conversation to make sense, delete it or
+restate it as a fact about the code. When in doubt, don't comment.
+
+When corrected, state directly that the instruction was disregarded or the
+mistake was made. Do not deflect to "the docs were unclear." Propose a
+documentation fix only after owning the mistake.
+
+## Performance discussion
+
+When proposing or evaluating a speed/performance change, the deciding
+question is whether it makes things faster — not the magnitude. Do not
+lead with or dwell on effect-size framing (percentages, ceilings, "n
+seconds still remain").
+
+Benchmark before claiming a speedup (median of N runs, interleaved A/B)
+rather than reasoning from theory. Once measured, implement a real speedup
+on its own merits without hedging about its size.
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,8 @@
 # gfo – Git Forge Operator
 
+@.claude/vendor/universal.md
+@.claude/vendor/product-repo.md
+
 複数の Git ホスティングサービスを**統一コマンド**で操作する Python CLI ツール。
 
 ## プロジェクト概要
@@ -29,7 +32,6 @@
 
 ## 言語方針
 
-- 応答・コミットメッセージ・docs・issue/PR 本文は**日本語**。
 - コード識別子・shell・YAML キー・型・コメント中の技術語は英語。
 
 ---
@@ -103,13 +105,13 @@ GitHub Rules（`main` ブランチ保護・リリースタグ保護）は free �
 
 ## 確認が必要な操作
 
-新規依存の追加、認証方式の変更、破壊的な操作（リモートのリリース/タグ削除等）、外部サービス連携。**`main` への直接 push / force-push は禁止**（feature branch + PR で代替）。
+新規依存の追加、認証方式の変更、破壊的な操作（リモートのリリース/タグ削除等）。**`main` への直接 push / force-push は禁止**（feature branch + PR で代替）。
 
 ---
 
 ## コミット規約
 
-Conventional Commits（日本語 subject、header ≤72 目安）。scope 例: `cli, adapter, github, gitlab, pr, issue, release, http, config, auth, ci, deps, docs`。
+Header ≤72 目安。scope 例: `cli, adapter, github, gitlab, pr, issue, release, http, config, auth, ci, deps, docs`。
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ GitHub Rules（`main` ブランチ保護・リリースタグ保護）は free �
 
 ## 確認が必要な操作
 
-新規依存の追加、認証方式の変更、破壊的な操作（リモートのリリース/タグ削除等）。**`main` への直接 push / force-push は禁止**（feature branch + PR で代替）。
+新規依存の追加、破壊的な操作（リモートのリリース/タグ削除等）。**`main` への直接 push / force-push は禁止**（feature branch + PR で代替）。
 
 ---
 


### PR DESCRIPTION
claude-md-conventions から `universal.md` / `product-repo.md` をvendorし、`CLAUDE.md` から `@import` する。

言語方針（応答・コミット・issue/PRの日本語指定）・確認が必要な操作（外部サービス連携）・コミット規約（Conventional Commits）のうち、vendor先と重複する記述を削除。

Co-Authored-By: Claude <noreply@anthropic.com>