### PR TITLE
fix(i18n): test_language_empty_string_fallback を実環境ロケールから隔離

### DIFF
--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -63,8 +63,13 @@ def test_windows_locale_fallback():
 
 def test_language_empty_string_fallback():
     """LANGUAGE="" 空文字列の場合は OS ロケールにフォールバックする。"""
+    # LC_ALL/LC_MESSAGES/LANG が実環境に残っていると locale.getlocale() 経路に
+    # 到達する前にそちらへ分岐してしまうため、LANGUAGE 以外の locale 系変数も剥がす
+    _LOCALE_VARS = ("LC_ALL", "LC_MESSAGES", "LANG")
+    env = {k: v for k, v in os.environ.items() if k not in _LOCALE_VARS}
+    env["LANGUAGE"] = ""
     with (
-        mock.patch.dict(os.environ, {"LANGUAGE": ""}, clear=False),
+        mock.patch.dict(os.environ, env, clear=True),
         mock.patch("locale.getlocale", return_value=("ja_JP", "UTF-8")),
     ):
         mod = importlib.reload(gfo.i18n)


### PR DESCRIPTION
## 概要

`test_language_empty_string_fallback` は `LANGUAGE=""` のみをモックし、実環境の
`LC_ALL`/`LC_MESSAGES`/`LANG` を残したまま実行していた。これらが設定された環境
（例: `LANG=en_US.UTF-8`）では、`_get_languages()` がテストの意図した
`locale.getlocale()` 経路に到達する前に実環境の値で分岐してしまい、テストが
環境依存で失敗する状態だった。

同ファイル内の `test_windows_locale_fallback` / `test_locale_getlocale_exception`
と同様に、locale 系環境変数を剥がしてから実行するよう修正した。

## Test plan

- [x] `uv run pytest tests/test_i18n.py -v` が `LANG=en_US.UTF-8` の環境でも全件 PASS
- [x] `uv run pytest`（フルスイート）4058 passed
- [x] `uv run ruff check .` / `ruff format --check .` / `mypy src/gfo` / `bandit -r src/gfo`